### PR TITLE
Fix: Prevent submission when pressing Cancel in coin split or combine dialog

### DIFF
--- a/src/pages/Token.tsx
+++ b/src/pages/Token.tsx
@@ -367,7 +367,11 @@ export default function Token() {
                 )}
               />
               <DialogFooter className='gap-2'>
-                <Button variant='outline' onClick={() => setCombineOpen(false)}>
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() => setCombineOpen(false)}
+                >
                   Cancel
                 </Button>
                 <Button type='submit'>Combine</Button>
@@ -423,7 +427,11 @@ export default function Token() {
                 )}
               />
               <DialogFooter className='gap-2'>
-                <Button variant='outline' onClick={() => setSplitOpen(false)}>
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() => setSplitOpen(false)}
+                >
                   Cancel
                 </Button>
                 <Button type='submit'>Split</Button>


### PR DESCRIPTION
Currently, pressing `Cancel` in the coin split or combine dialog still triggers the form submission due to being placed within a form.

This change adds `type='button'` to the `Cancel` buttons to make them actually cancel the action.