### PR TITLE
Fix offer logic

### DIFF
--- a/crates/sage-wallet/src/wallet/nfts.rs
+++ b/crates/sage-wallet/src/wallet/nfts.rs
@@ -31,7 +31,7 @@ impl Wallet {
             return Err(WalletError::MissingDid(did_id));
         };
 
-        let total_amount = fee as u128 + 1;
+        let total_amount = fee as u128 + mints.len() as u128;
         let coins = self.select_p2_coins(total_amount).await?;
         let selected: u128 = coins.iter().map(|coin| coin.amount as u128).sum();
 

--- a/crates/sage-wallet/src/wallet/offer.rs
+++ b/crates/sage-wallet/src/wallet/offer.rs
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn test_xch_for_nft() -> anyhow::Result<()> {
+    async fn test_offer_xch_for_nft() -> anyhow::Result<()> {
         let mut alice = TestWallet::new(1030).await?;
         let mut bob = alice.next(2).await?;
 
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn test_nft_for_xch() -> anyhow::Result<()> {
+    async fn test_offer_nft_for_xch() -> anyhow::Result<()> {
         let mut alice = TestWallet::new(2).await?;
         let mut bob = alice.next(1030).await?;
 
@@ -236,6 +236,203 @@ mod tests {
         assert_eq!(alice.wallet.db.balance().await?, 1000);
         assert_ne!(
             bob.wallet.db.spendable_nft(nft.info.launcher_id).await?,
+            None
+        );
+
+        Ok(())
+    }
+
+    #[test(tokio::test)]
+    async fn test_offer_nft_same_royalties_for_xch() -> anyhow::Result<()> {
+        let mut alice = TestWallet::new(3).await?;
+        let mut bob = alice.next(1030).await?;
+
+        let (coin_spends, did) = alice.wallet.create_did(0, false, true).await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let (coin_spends, mut nfts, _did) = alice
+            .wallet
+            .bulk_mint_nfts(
+                0,
+                did.info.launcher_id,
+                vec![
+                    WalletNftMint {
+                        metadata: NftMetadata::default(),
+                        royalty_puzzle_hash: Some(Bytes32::default()),
+                        royalty_ten_thousandths: 300,
+                    },
+                    WalletNftMint {
+                        metadata: NftMetadata::default(),
+                        royalty_puzzle_hash: Some(Bytes32::default()),
+                        royalty_ten_thousandths: 300,
+                    },
+                ],
+                false,
+                true,
+            )
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let nft_id_first = nfts.remove(0);
+        let nft_id_second = nfts.remove(0);
+
+        // Create offer
+        let offer = alice
+            .wallet
+            .make_offer(
+                MakerSide {
+                    xch: 0,
+                    cats: IndexMap::new(),
+                    nfts: vec![
+                        nft_id_first.info.launcher_id,
+                        nft_id_second.info.launcher_id,
+                    ],
+                    fee: 0,
+                },
+                TakerSide {
+                    xch: 1000,
+                    cats: IndexMap::new(),
+                    nfts: IndexMap::new(),
+                },
+                None,
+                false,
+                true,
+            )
+            .await?;
+        let offer = alice
+            .wallet
+            .sign_make_offer(offer, &alice.agg_sig, alice.master_sk.clone())
+            .await?;
+
+        // Take offer
+        let offer = bob.wallet.take_offer(offer, 0, false, true).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_take_offer(offer, &bob.agg_sig, bob.master_sk.clone())
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+
+        // We need to wait for both wallets to sync in this case
+        alice.wait_for_coins().await;
+        bob.wait_for_coins().await;
+
+        // Check balances
+        assert_eq!(alice.wallet.db.balance().await?, 1000);
+        assert_ne!(
+            bob.wallet
+                .db
+                .spendable_nft(nft_id_first.info.launcher_id)
+                .await?,
+            None
+        );
+        assert_ne!(
+            bob.wallet
+                .db
+                .spendable_nft(nft_id_second.info.launcher_id)
+                .await?,
+            None
+        );
+
+        Ok(())
+    }
+
+    #[test(tokio::test)]
+    async fn test_offer_nft_same_royalties_for_cat() -> anyhow::Result<()> {
+        let mut alice = TestWallet::new(3).await?;
+        let mut bob = alice.next(1030).await?;
+
+        let (coin_spends, did) = alice.wallet.create_did(0, false, true).await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let (coin_spends, mut nfts, _did) = alice
+            .wallet
+            .bulk_mint_nfts(
+                0,
+                did.info.launcher_id,
+                vec![
+                    WalletNftMint {
+                        metadata: NftMetadata::default(),
+                        royalty_puzzle_hash: Some(Bytes32::default()),
+                        royalty_ten_thousandths: 300,
+                    },
+                    WalletNftMint {
+                        metadata: NftMetadata::default(),
+                        royalty_puzzle_hash: Some(Bytes32::default()),
+                        royalty_ten_thousandths: 300,
+                    },
+                ],
+                false,
+                true,
+            )
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let nft_id_first = nfts.remove(0);
+        let nft_id_second = nfts.remove(0);
+
+        // Issue CAT
+        let (coin_spends, asset_id) = bob.wallet.issue_cat(1030, 0, None, false, true).await?;
+        bob.transact(coin_spends).await?;
+        bob.wait_for_coins().await;
+
+        // Create offer
+        let offer = alice
+            .wallet
+            .make_offer(
+                MakerSide {
+                    xch: 0,
+                    cats: IndexMap::new(),
+                    nfts: vec![
+                        nft_id_first.info.launcher_id,
+                        nft_id_second.info.launcher_id,
+                    ],
+                    fee: 0,
+                },
+                TakerSide {
+                    xch: 0,
+                    cats: indexmap! { asset_id => 1000 },
+                    nfts: IndexMap::new(),
+                },
+                None,
+                false,
+                true,
+            )
+            .await?;
+        let offer = alice
+            .wallet
+            .sign_make_offer(offer, &alice.agg_sig, alice.master_sk.clone())
+            .await?;
+
+        // Take offer
+        let offer = bob.wallet.take_offer(offer, 0, false, true).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_take_offer(offer, &bob.agg_sig, bob.master_sk.clone())
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+
+        // We need to wait for both wallets to sync in this case
+        alice.wait_for_puzzles().await;
+        bob.wait_for_coins().await;
+
+        // Check balances
+        assert_eq!(alice.wallet.db.cat_balance(asset_id).await?, 1000);
+        assert_ne!(
+            bob.wallet
+                .db
+                .spendable_nft(nft_id_first.info.launcher_id)
+                .await?,
+            None
+        );
+        assert_ne!(
+            bob.wallet
+                .db
+                .spendable_nft(nft_id_second.info.launcher_id)
+                .await?,
             None
         );
 

--- a/crates/sage-wallet/src/wallet/offer/lock_assets.rs
+++ b/crates/sage-wallet/src/wallet/offer/lock_assets.rs
@@ -98,32 +98,72 @@ impl Wallet {
                     None,
                 );
 
-                let royalty_coin = Coin::new(
+                let mut parent_royalty_coin = Coin::new(
                     primary_xch_coin.coin_id(),
                     SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
                     royalty_amount,
                 );
+                let mut remaining_royalties =
+                    royalties.xch.clone().into_iter().rev().collect::<Vec<_>>();
 
-                let coin_spend = SettlementLayer.construct_coin_spend(
-                    ctx,
-                    royalty_coin,
-                    SettlementPaymentsSolution {
-                        notarized_payments: royalties
-                            .xch
-                            .iter()
-                            .map(|royalty| NotarizedPayment {
-                                nonce: royalty.nft_id,
-                                payments: vec![Payment::with_memos(
-                                    royalty.p2_puzzle_hash,
-                                    royalty.amount,
-                                    vec![royalty.p2_puzzle_hash.into()],
-                                )],
-                            })
-                            .collect(),
-                    },
-                )?;
+                while !remaining_royalties.is_empty() {
+                    let mut outputs = Vec::new();
+                    let mut notarized_payments = Vec::new();
 
-                ctx.insert(coin_spend);
+                    for (i, royalty) in remaining_royalties.clone().into_iter().enumerate().rev() {
+                        let royalty_coin = Coin::new(
+                            parent_royalty_coin.coin_id(),
+                            royalty.p2_puzzle_hash,
+                            royalty.amount,
+                        );
+
+                        if outputs.contains(&royalty_coin) {
+                            continue;
+                        }
+
+                        remaining_royalties.remove(i);
+
+                        notarized_payments.push(NotarizedPayment {
+                            nonce: royalty.nft_id,
+                            payments: vec![Payment::with_memos(
+                                royalty.p2_puzzle_hash,
+                                royalty.amount,
+                                vec![royalty.p2_puzzle_hash.into()],
+                            )],
+                        });
+
+                        outputs.push(royalty_coin);
+                    }
+
+                    // TODO: This is a hack to make the puzzle non-conflicting, maybe there's a better amount or method
+                    let non_conflicting_amount =
+                        outputs.iter().map(|output| output.amount).sum::<u64>() + 1;
+
+                    if !remaining_royalties.is_empty() {
+                        notarized_payments.push(NotarizedPayment {
+                            // TODO: Make nonce nil as an optimization
+                            nonce: Bytes32::default(),
+                            payments: vec![Payment::new(
+                                SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
+                                non_conflicting_amount,
+                            )],
+                        });
+                    }
+
+                    let coin_spend = SettlementLayer.construct_coin_spend(
+                        ctx,
+                        parent_royalty_coin,
+                        SettlementPaymentsSolution { notarized_payments },
+                    )?;
+
+                    ctx.insert(coin_spend);
+
+                    parent_royalty_coin = Coin::new(
+                        parent_royalty_coin.coin_id(),
+                        SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
+                        non_conflicting_amount,
+                    );
+                }
             }
 
             let total_amount = coins.xch.iter().map(|coin| coin.amount).sum::<u64>();
@@ -182,27 +222,68 @@ impl Wallet {
                     Some(settlement_hint),
                 );
 
-                let royalty_cat = primary_cat
+                let mut cat_spends = Vec::new();
+                let mut parent_royalty_cat = primary_cat
                     .wrapped_child(SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(), royalty_amount);
+                let mut remaining_royalties = royalties.cats[&asset_id]
+                    .clone()
+                    .into_iter()
+                    .rev()
+                    .collect::<Vec<_>>();
 
-                let inner_spend = SettlementLayer.construct_spend(
-                    ctx,
-                    SettlementPaymentsSolution {
-                        notarized_payments: royalties.cats[&asset_id]
-                            .iter()
-                            .map(|royalty| NotarizedPayment {
-                                nonce: royalty.nft_id,
-                                payments: vec![Payment::with_memos(
-                                    royalty.p2_puzzle_hash,
-                                    royalty.amount,
-                                    vec![royalty.p2_puzzle_hash.into()],
-                                )],
-                            })
-                            .collect(),
-                    },
-                )?;
+                while !remaining_royalties.is_empty() {
+                    let mut outputs = Vec::new();
+                    let mut notarized_payments = Vec::new();
 
-                Cat::spend_all(ctx, &[CatSpend::new(royalty_cat, inner_spend)])?;
+                    for (i, royalty) in remaining_royalties.clone().into_iter().enumerate().rev() {
+                        let royalty_cat = parent_royalty_cat
+                            .wrapped_child(royalty.p2_puzzle_hash, royalty.amount);
+
+                        if outputs.contains(&royalty_cat.coin) {
+                            continue;
+                        }
+
+                        remaining_royalties.remove(i);
+
+                        notarized_payments.push(NotarizedPayment {
+                            nonce: royalty.nft_id,
+                            payments: vec![Payment::with_memos(
+                                royalty.p2_puzzle_hash,
+                                royalty.amount,
+                                vec![royalty.p2_puzzle_hash.into()],
+                            )],
+                        });
+
+                        outputs.push(royalty_cat.coin);
+                    }
+
+                    // TODO: This is a hack to make the puzzle non-conflicting, maybe there's a better amount or method
+                    let non_conflicting_amount =
+                        outputs.iter().map(|output| output.amount).sum::<u64>() + 1;
+
+                    if !remaining_royalties.is_empty() {
+                        notarized_payments.push(NotarizedPayment {
+                            // TODO: Make nonce nil as an optimization
+                            nonce: Bytes32::default(),
+                            payments: vec![Payment::new(
+                                SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
+                                non_conflicting_amount,
+                            )],
+                        });
+                    }
+
+                    let inner_spend = SettlementLayer
+                        .construct_spend(ctx, SettlementPaymentsSolution { notarized_payments })?;
+
+                    cat_spends.push(CatSpend::new(parent_royalty_cat, inner_spend));
+
+                    parent_royalty_cat = parent_royalty_cat.wrapped_child(
+                        SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
+                        non_conflicting_amount,
+                    );
+                }
+
+                Cat::spend_all(ctx, &cat_spends)?;
             }
 
             self.spend_cat_coins(

--- a/crates/sage-wallet/src/wallet/offer/lock_assets.rs
+++ b/crates/sage-wallet/src/wallet/offer/lock_assets.rs
@@ -307,7 +307,16 @@ impl Wallet {
                 .remove(&nft.coin.coin_id())
                 .unwrap_or_default();
 
-            let nft = nft.lock_settlement(ctx, &p2, trade_prices.clone(), conditions)?;
+            let nft = nft.lock_settlement(
+                ctx,
+                &p2,
+                if nft.info.royalty_ten_thousandths > 0 {
+                    trade_prices.clone()
+                } else {
+                    Vec::new()
+                },
+                conditions,
+            )?;
 
             locked.nfts.insert(nft.info.launcher_id, nft);
         }

--- a/crates/sage-wallet/src/wallet/offer/lock_assets.rs
+++ b/crates/sage-wallet/src/wallet/offer/lock_assets.rs
@@ -135,9 +135,10 @@ impl Wallet {
                         outputs.push(royalty_coin);
                     }
 
-                    // TODO: This is a hack to make the puzzle non-conflicting, maybe there's a better amount or method
-                    let non_conflicting_amount =
-                        outputs.iter().map(|output| output.amount).sum::<u64>() + 1;
+                    let remaining_amount = remaining_royalties
+                        .iter()
+                        .map(|royalty| royalty.amount)
+                        .sum::<u64>();
 
                     if !remaining_royalties.is_empty() {
                         notarized_payments.push(NotarizedPayment {
@@ -145,7 +146,7 @@ impl Wallet {
                             nonce: Bytes32::default(),
                             payments: vec![Payment::new(
                                 SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
-                                non_conflicting_amount,
+                                remaining_amount,
                             )],
                         });
                     }
@@ -161,7 +162,7 @@ impl Wallet {
                     parent_royalty_coin = Coin::new(
                         parent_royalty_coin.coin_id(),
                         SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
-                        non_conflicting_amount,
+                        remaining_amount,
                     );
                 }
             }
@@ -257,9 +258,10 @@ impl Wallet {
                         outputs.push(royalty_cat.coin);
                     }
 
-                    // TODO: This is a hack to make the puzzle non-conflicting, maybe there's a better amount or method
-                    let non_conflicting_amount =
-                        outputs.iter().map(|output| output.amount).sum::<u64>() + 1;
+                    let remaining_amount = remaining_royalties
+                        .iter()
+                        .map(|royalty| royalty.amount)
+                        .sum::<u64>();
 
                     if !remaining_royalties.is_empty() {
                         notarized_payments.push(NotarizedPayment {
@@ -267,7 +269,7 @@ impl Wallet {
                             nonce: Bytes32::default(),
                             payments: vec![Payment::new(
                                 SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
-                                non_conflicting_amount,
+                                remaining_amount,
                             )],
                         });
                     }
@@ -277,10 +279,8 @@ impl Wallet {
 
                     cat_spends.push(CatSpend::new(parent_royalty_cat, inner_spend));
 
-                    parent_royalty_cat = parent_royalty_cat.wrapped_child(
-                        SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(),
-                        non_conflicting_amount,
-                    );
+                    parent_royalty_cat = parent_royalty_cat
+                        .wrapped_child(SETTLEMENT_PAYMENTS_PUZZLE_HASH.into(), remaining_amount);
                 }
 
                 Cat::spend_all(ctx, &cat_spends)?;

--- a/crates/sage-wallet/src/wallet/offer/make_offer.rs
+++ b/crates/sage-wallet/src/wallet/offer/make_offer.rs
@@ -146,7 +146,14 @@ impl Wallet {
             cats: taker.cats,
         };
 
-        let trade_prices = calculate_trade_prices(&taker_amounts, maker.nfts.len())?;
+        let trade_prices = calculate_trade_prices(
+            &taker_amounts,
+            maker_coins
+                .nfts
+                .values()
+                .filter(|nft| nft.info.royalty_ten_thousandths > 0)
+                .count(),
+        )?;
 
         let (assertions, builder) = builder.finish();
         let mut extra_conditions = Conditions::new()

--- a/crates/sage-wallet/src/wallet/offer/make_offer.rs
+++ b/crates/sage-wallet/src/wallet/offer/make_offer.rs
@@ -155,10 +155,24 @@ impl Wallet {
                 .count(),
         )?;
 
+        let taker_royalties = calculate_royalties(
+            &taker_amounts,
+            &maker_coins
+                .nfts
+                .values()
+                .map(|nft| NftRoyaltyInfo {
+                    launcher_id: nft.info.launcher_id,
+                    royalty_puzzle_hash: nft.info.royalty_puzzle_hash,
+                    royalty_ten_thousandths: nft.info.royalty_ten_thousandths,
+                })
+                .collect::<Vec<_>>(),
+        )?;
+
         let (assertions, builder) = builder.finish();
         let mut extra_conditions = Conditions::new()
             .extend(assertions)
-            .extend(maker_royalties.assertions());
+            .extend(maker_royalties.assertions())
+            .extend(taker_royalties.assertions());
 
         if let Some(expires_at) = expires_at {
             extra_conditions = extra_conditions.assert_before_seconds_absolute(expires_at);

--- a/crates/sage-wallet/src/wallet/offer/make_offer.rs
+++ b/crates/sage-wallet/src/wallet/offer/make_offer.rs
@@ -155,24 +155,10 @@ impl Wallet {
                 .count(),
         )?;
 
-        let taker_royalties = calculate_royalties(
-            &taker_amounts,
-            &maker_coins
-                .nfts
-                .values()
-                .map(|nft| NftRoyaltyInfo {
-                    launcher_id: nft.info.launcher_id,
-                    royalty_puzzle_hash: nft.info.royalty_puzzle_hash,
-                    royalty_ten_thousandths: nft.info.royalty_ten_thousandths,
-                })
-                .collect::<Vec<_>>(),
-        )?;
-
         let (assertions, builder) = builder.finish();
         let mut extra_conditions = Conditions::new()
             .extend(assertions)
-            .extend(maker_royalties.assertions())
-            .extend(taker_royalties.assertions());
+            .extend(maker_royalties.assertions());
 
         if let Some(expires_at) = expires_at {
             extra_conditions = extra_conditions.assert_before_seconds_absolute(expires_at);

--- a/crates/sage-wallet/src/wallet/offer/royalties.rs
+++ b/crates/sage-wallet/src/wallet/offer/royalties.rs
@@ -132,6 +132,11 @@ pub fn calculate_royalties(
     amounts: &OfferAmounts,
     nfts: &[NftRoyaltyInfo],
 ) -> Result<Royalties, WalletError> {
+    let royalty_nfts = nfts
+        .iter()
+        .filter(|nft| nft.royalty_ten_thousandths > 0)
+        .count();
+
     let mut royalties = Royalties::default();
 
     if nfts.is_empty() {
@@ -139,10 +144,14 @@ pub fn calculate_royalties(
     }
 
     if amounts.xch > 0 {
-        let trade_price = calculate_nft_trace_price(amounts.xch, nfts.len())
+        let trade_price = calculate_nft_trace_price(amounts.xch, royalty_nfts)
             .ok_or(WalletError::InvalidTradePrice)?;
 
         for nft in nfts {
+            if nft.royalty_ten_thousandths == 0 {
+                continue;
+            }
+
             let amount = calculate_nft_royalty(trade_price, nft.royalty_ten_thousandths)
                 .ok_or(WalletError::InvalidRoyaltyAmount)?;
 
@@ -159,10 +168,14 @@ pub fn calculate_royalties(
     }
 
     for (&asset_id, &amount) in &amounts.cats {
-        let trade_price =
-            calculate_nft_trace_price(amount, nfts.len()).ok_or(WalletError::InvalidTradePrice)?;
+        let trade_price = calculate_nft_trace_price(amount, royalty_nfts)
+            .ok_or(WalletError::InvalidTradePrice)?;
 
         for nft in nfts {
+            if nft.royalty_ten_thousandths == 0 {
+                continue;
+            }
+
             let amount = calculate_nft_royalty(trade_price, nft.royalty_ten_thousandths)
                 .ok_or(WalletError::InvalidRoyaltyAmount)?;
 

--- a/crates/sage-wallet/src/wallet/offer/take_offer.rs
+++ b/crates/sage-wallet/src/wallet/offer/take_offer.rs
@@ -62,7 +62,14 @@ impl Wallet {
             unlock_assets(&mut ctx, locked_coins, taker_coins.nonce(), p2_puzzle_hash)?;
 
         // Calculate trade prices for the maker side.
-        let trade_prices = calculate_trade_prices(&maker_amounts, requested_payments.nfts.len())?;
+        let trade_prices = calculate_trade_prices(
+            &maker_amounts,
+            requested_payments
+                .nfts
+                .values()
+                .filter(|(nft, _)| nft.royalty_ten_thousandths > 0)
+                .count(),
+        )?;
 
         let extra_conditions = Conditions::new()
             .extend(assertions)

--- a/crates/sage-wallet/src/wallet/offer/take_offer.rs
+++ b/crates/sage-wallet/src/wallet/offer/take_offer.rs
@@ -32,19 +32,6 @@ impl Wallet {
         let requested_payments = parse_offer_payments(&mut ctx, &mut builder)?;
         let taker_amounts = requested_payments.amounts();
 
-        let maker_royalties = calculate_royalties(
-            &maker_amounts,
-            &requested_payments
-                .nfts
-                .values()
-                .map(|(nft, _)| NftRoyaltyInfo {
-                    launcher_id: nft.launcher_id,
-                    royalty_puzzle_hash: nft.royalty_puzzle_hash,
-                    royalty_ten_thousandths: nft.royalty_ten_thousandths,
-                })
-                .collect::<Vec<_>>(),
-        )?;
-
         let taker_royalties = calculate_royalties(
             &taker_amounts,
             &locked_coins
@@ -86,8 +73,7 @@ impl Wallet {
 
         let extra_conditions = Conditions::new()
             .extend(assertions)
-            .extend(taker_royalties.assertions())
-            .extend(maker_royalties.assertions());
+            .extend(taker_royalties.assertions());
 
         // Spend the assets.
         let payment_coins = self

--- a/crates/sage-wallet/src/wallet/offer/take_offer.rs
+++ b/crates/sage-wallet/src/wallet/offer/take_offer.rs
@@ -32,6 +32,19 @@ impl Wallet {
         let requested_payments = parse_offer_payments(&mut ctx, &mut builder)?;
         let taker_amounts = requested_payments.amounts();
 
+        let maker_royalties = calculate_royalties(
+            &maker_amounts,
+            &requested_payments
+                .nfts
+                .values()
+                .map(|(nft, _)| NftRoyaltyInfo {
+                    launcher_id: nft.launcher_id,
+                    royalty_puzzle_hash: nft.royalty_puzzle_hash,
+                    royalty_ten_thousandths: nft.royalty_ten_thousandths,
+                })
+                .collect::<Vec<_>>(),
+        )?;
+
         let taker_royalties = calculate_royalties(
             &taker_amounts,
             &locked_coins
@@ -73,7 +86,8 @@ impl Wallet {
 
         let extra_conditions = Conditions::new()
             .extend(assertions)
-            .extend(taker_royalties.assertions());
+            .extend(taker_royalties.assertions())
+            .extend(maker_royalties.assertions());
 
         // Spend the assets.
         let payment_coins = self


### PR DESCRIPTION
Fixes the following issues with offers:
1. Royalties were not being calculated correctly (divided by total NFTs rather than non-zero royalty NFTs)
2. Royalty output coins could have collisions if there are multiple royalties with the same amount

More tests have been created for these edge cases