### PR TITLE
`useMemo` for `parsedParams` in `WalletConnectContext`

### DIFF
--- a/src/contexts/WalletConnectContext.tsx
+++ b/src/contexts/WalletConnectContext.tsx
@@ -36,6 +36,7 @@ import {
   ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 
@@ -634,7 +635,10 @@ function RequestDialog({
   }
 
   const CommandComponent = COMMAND_COMPONENTS[method] ?? DefaultCommandDialog;
-  const parsedParams = commandInfo.paramsType.parse(params);
+  const parsedParams = useMemo(
+    () => commandInfo.paramsType.parse(params),
+    [params, commandInfo],
+  );
 
   return (
     <Dialog open={true} onOpenChange={(open) => !open && reject(request)}>


### PR DESCRIPTION
This is to make sure commands that depends on `params` for dependencies doesn't end up in an infinite loop. That was the case for error in `CancelOfferDialog` but certainly for others.


---
**Some feedback from the WalletConnect context, although not handled in this PR:**
When an error occurs, the corresponding dialog is still displayed. I think this is a bit strange and I would expect that the request would be rejected if the user discard or click `OK` on the error dialog.

