### PR TITLE
Add DID normalize option

### DIFF
--- a/.sqlx/query-09f846328374776c4980a0f6ca31b29fbce2044d7601c642c88a6da5b131e4af.json
+++ b/.sqlx/query-09f846328374776c4980a0f6ca31b29fbce2044d7601c642c88a6da5b131e4af.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n        SELECT\n            `did_coins`.`coin_id`, `amount`, `p2_puzzle_hash`, `created_height`, `transaction_id`\n        FROM `did_coins`\n        INNER JOIN `coin_states` ON `coin_states`.coin_id = `did_coins`.coin_id\n        WHERE `did_coins`.`coin_id` = ?\n        ",
+  "query": "\n        SELECT\n            `did_coins`.`coin_id`, `amount`, `p2_puzzle_hash`,\n            `recovery_list_hash`, `created_height`, `transaction_id`\n        FROM `did_coins`\n        INNER JOIN `coin_states` ON `coin_states`.coin_id = `did_coins`.coin_id\n        WHERE `did_coins`.`coin_id` = ?\n        ",
   "describe": {
     "columns": [
       {
@@ -19,13 +19,18 @@
         "type_info": "Blob"
       },
       {
-        "name": "created_height",
+        "name": "recovery_list_hash",
         "ordinal": 3,
+        "type_info": "Blob"
+      },
+      {
+        "name": "created_height",
+        "ordinal": 4,
         "type_info": "Integer"
       },
       {
         "name": "transaction_id",
-        "ordinal": 4,
+        "ordinal": 5,
         "type_info": "Blob"
       }
     ],
@@ -37,8 +42,9 @@
       false,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "8f47974042b589d0c86cebf3928f9e1c44b7200b2c5c01ac168a0889b5978cbf"
+  "hash": "09f846328374776c4980a0f6ca31b29fbce2044d7601c642c88a6da5b131e4af"
 }

--- a/crates/sage-api/src/records/did.rs
+++ b/crates/sage-api/src/records/did.rs
@@ -11,6 +11,7 @@ pub struct DidRecord {
     pub coin_id: String,
     pub address: String,
     pub amount: Amount,
+    pub recovery_hash: Option<String>,
     pub created_height: Option<u32>,
     pub create_transaction_id: Option<String>,
 }

--- a/crates/sage-api/src/requests/transactions.rs
+++ b/crates/sage-api/src/requests/transactions.rs
@@ -167,6 +167,14 @@ pub struct TransferDids {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct NormalizeDids {
+    pub did_ids: Vec<String>,
+    pub fee: Amount,
+    #[serde(default)]
+    pub auto_submit: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct SignCoinSpends {
     pub coin_spends: Vec<CoinSpendJson>,
     #[serde(default)]
@@ -219,3 +227,4 @@ pub type TransferNftsResponse = TransactionResponse;
 pub type AddNftUriResponse = TransactionResponse;
 pub type AssignNftsToDidResponse = TransactionResponse;
 pub type TransferDidsResponse = TransactionResponse;
+pub type NormalizeDidsResponse = TransactionResponse;

--- a/crates/sage-cli/src/router.rs
+++ b/crates/sage-cli/src/router.rs
@@ -102,6 +102,7 @@ routes!(
     add_nft_uri await: AddNftUri = "/add_nft_uri",
     assign_nfts_to_did await: AssignNftsToDid = "/assign_nfts_to_did",
     transfer_dids await: TransferDids = "/transfer_dids",
+    normalize_dids await: NormalizeDids = "/normalize_dids",
     sign_coin_spends await: SignCoinSpends = "/sign_coin_spends",
     view_coin_spends await: ViewCoinSpends = "/view_coin_spends",
     submit_transaction await: SubmitTransaction = "/submit_transaction",

--- a/crates/sage-database/src/primitives/dids.rs
+++ b/crates/sage-database/src/primitives/dids.rs
@@ -277,7 +277,8 @@ async fn did_coin_info(
         DidCoinInfoSql,
         "
         SELECT
-            `did_coins`.`coin_id`, `amount`, `p2_puzzle_hash`, `created_height`, `transaction_id`
+            `did_coins`.`coin_id`, `amount`, `p2_puzzle_hash`,
+            `recovery_list_hash`, `created_height`, `transaction_id`
         FROM `did_coins`
         INNER JOIN `coin_states` ON `coin_states`.coin_id = `did_coins`.coin_id
         WHERE `did_coins`.`coin_id` = ?

--- a/crates/sage-database/src/rows/did_coin.rs
+++ b/crates/sage-database/src/rows/did_coin.rs
@@ -26,6 +26,7 @@ pub(crate) struct DidCoinInfoSql {
     pub coin_id: Vec<u8>,
     pub amount: Vec<u8>,
     pub p2_puzzle_hash: Vec<u8>,
+    pub recovery_list_hash: Option<Vec<u8>>,
     pub created_height: Option<i64>,
     pub transaction_id: Option<Vec<u8>>,
 }
@@ -35,6 +36,7 @@ pub struct DidCoinInfo {
     pub coin_id: Bytes32,
     pub amount: u64,
     pub p2_puzzle_hash: Bytes32,
+    pub recovery_list_hash: Option<Bytes32>,
     pub created_height: Option<u32>,
     pub transaction_id: Option<Bytes32>,
 }
@@ -77,6 +79,11 @@ impl IntoRow for DidCoinInfoSql {
             coin_id: to_bytes32(&self.coin_id)?,
             amount: to_u64(&self.amount)?,
             p2_puzzle_hash: to_bytes32(&self.p2_puzzle_hash)?,
+            recovery_list_hash: self
+                .recovery_list_hash
+                .as_deref()
+                .map(to_bytes32)
+                .transpose()?,
             created_height: self.created_height.map(TryInto::try_into).transpose()?,
             transaction_id: self.transaction_id.as_deref().map(to_bytes32).transpose()?,
         })

--- a/crates/sage-wallet/src/wallet/dids.rs
+++ b/crates/sage-wallet/src/wallet/dids.rs
@@ -1,4 +1,8 @@
-use chia::protocol::{Bytes32, CoinSpend};
+use chia::{
+    clvm_utils::tree_hash_atom,
+    protocol::{Bytes32, Coin, CoinSpend},
+    puzzles::{singleton::SingletonArgs, Proof},
+};
 use chia_wallet_sdk::{Conditions, Did, HashedPtr, Launcher, SpendContext, StandardLayer};
 
 use crate::WalletError;
@@ -104,6 +108,111 @@ impl Wallet {
             };
 
             let _did = did.transfer(&mut ctx, &p2, puzzle_hash, conditions)?;
+        }
+
+        if fee > 0 {
+            let mut conditions = Conditions::new()
+                .assert_concurrent_spend(did_coin_ids[0])
+                .reserve_fee(fee);
+
+            if change > 0 {
+                conditions = conditions.create_coin(p2_puzzle_hash, change, None);
+            }
+
+            self.spend_p2_coins(&mut ctx, coins, conditions).await?;
+        }
+
+        Ok(ctx.take())
+    }
+
+    pub async fn normalize_dids(
+        &self,
+        did_ids: Vec<Bytes32>,
+        fee: u64,
+        hardened: bool,
+        reuse: bool,
+    ) -> Result<Vec<CoinSpend>, WalletError> {
+        if did_ids.is_empty() {
+            return Err(WalletError::EmptyBulkTransfer);
+        }
+
+        let mut dids = Vec::new();
+
+        for did_id in did_ids {
+            let Some(did) = self.db.spendable_did(did_id).await? else {
+                return Err(WalletError::MissingDid(did_id));
+            };
+
+            dids.push(did);
+        }
+
+        let coins = if fee > 0 {
+            self.select_p2_coins(fee as u128).await?
+        } else {
+            Vec::new()
+        };
+        let selected: u128 = coins.iter().map(|coin| coin.amount as u128).sum();
+
+        let change: u64 = (selected - fee as u128)
+            .try_into()
+            .expect("change amount overflow");
+
+        let p2_puzzle_hash = self.p2_puzzle_hash(hardened, reuse).await?;
+
+        let mut ctx = SpendContext::new();
+
+        let did_coin_ids = dids
+            .iter()
+            .map(|did| did.coin.coin_id())
+            .collect::<Vec<_>>();
+
+        for (i, did) in dids.into_iter().enumerate() {
+            let did_metadata_ptr = ctx.alloc(&did.info.metadata)?;
+            let did = did.with_metadata(HashedPtr::from_ptr(&ctx.allocator, did_metadata_ptr));
+
+            let synthetic_key = self.db.synthetic_key(did.info.p2_puzzle_hash).await?;
+            let p2 = StandardLayer::new(synthetic_key);
+
+            let conditions = if did_coin_ids.len() == 1 {
+                Conditions::new()
+            } else {
+                Conditions::new().assert_concurrent_spend(
+                    did_coin_ids[if i == 0 {
+                        did_coin_ids.len() - 1
+                    } else {
+                        i - 1
+                    }],
+                )
+            };
+
+            let mut new_info = did.info;
+            new_info.recovery_list_hash = Some(Bytes32::from(tree_hash_atom(&[])));
+            let new_inner_puzzle_hash = new_info.inner_puzzle_hash();
+
+            let memos = ctx.hint(did.info.p2_puzzle_hash)?;
+
+            did.spend_with(
+                &mut ctx,
+                &p2,
+                Conditions::new().create_coin(
+                    new_inner_puzzle_hash.into(),
+                    did.coin.amount,
+                    Some(memos),
+                ),
+            )?;
+
+            let did = Did {
+                coin: Coin::new(
+                    did.coin.coin_id(),
+                    SingletonArgs::curry_tree_hash(new_info.launcher_id, new_inner_puzzle_hash)
+                        .into(),
+                    did.coin.amount,
+                ),
+                proof: Proof::Lineage(did.child_lineage_proof()),
+                info: new_info,
+            };
+
+            let _did = did.update(&mut ctx, &p2, conditions)?;
         }
 
         if fee > 0 {

--- a/crates/sage/src/endpoints/data.rs
+++ b/crates/sage/src/endpoints/data.rs
@@ -235,6 +235,7 @@ impl Sage {
                     &self.network().address_prefix,
                 )?,
                 amount: Amount::u64(did.amount),
+                recovery_hash: did.recovery_list_hash.map(hex::encode),
                 created_height: did.created_height,
                 create_transaction_id: did.transaction_id.map(hex::encode),
             });

--- a/crates/sage/src/endpoints/transactions.rs
+++ b/crates/sage/src/endpoints/transactions.rs
@@ -7,9 +7,9 @@ use chia::{
 use chia_wallet_sdk::MetadataUpdate;
 use sage_api::{
     AddNftUri, AssignNftsToDid, BulkMintNfts, BulkSendCat, BulkSendXch, CombineCat, CombineXch,
-    CreateDid, IssueCat, NftUriKind, SendCat, SendXch, SignCoinSpends, SignCoinSpendsResponse,
-    SplitCat, SplitXch, SubmitTransaction, SubmitTransactionResponse, TransactionResponse,
-    TransferDids, TransferNfts, ViewCoinSpends, ViewCoinSpendsResponse,
+    CreateDid, IssueCat, NftUriKind, NormalizeDids, SendCat, SendXch, SignCoinSpends,
+    SignCoinSpendsResponse, SplitCat, SplitXch, SubmitTransaction, SubmitTransactionResponse,
+    TransactionResponse, TransferDids, TransferNfts, ViewCoinSpends, ViewCoinSpendsResponse,
 };
 use sage_assets::fetch_uris_without_hash;
 use sage_database::CatRow;
@@ -335,6 +335,19 @@ impl Sage {
         let coin_spends = wallet
             .transfer_dids(did_ids, puzzle_hash, fee, false, true)
             .await?;
+        self.transact(coin_spends, req.auto_submit).await
+    }
+
+    pub async fn normalize_dids(&self, req: NormalizeDids) -> Result<TransactionResponse> {
+        let wallet = self.wallet()?;
+        let did_ids = req
+            .did_ids
+            .into_iter()
+            .map(parse_did_id)
+            .collect::<Result<Vec<_>>>()?;
+        let fee = self.parse_amount(req.fee)?;
+
+        let coin_spends = wallet.normalize_dids(did_ids, fee, false, true).await?;
         self.transact(coin_spends, req.auto_submit).await
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -231,6 +231,15 @@ pub async fn transfer_dids(
 
 #[command]
 #[specta]
+pub async fn normalize_dids(
+    state: State<'_, AppState>,
+    req: NormalizeDids,
+) -> Result<TransactionResponse> {
+    Ok(state.lock().await.normalize_dids(req).await?)
+}
+
+#[command]
+#[specta]
 pub async fn sign_coin_spends(
     state: State<'_, AppState>,
     req: SignCoinSpends,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::bulk_mint_nfts,
             commands::transfer_nfts,
             commands::transfer_dids,
+            commands::normalize_dids,
             commands::add_nft_uri,
             commands::assign_nfts_to_did,
             commands::sign_coin_spends,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -77,6 +77,9 @@ async transferNfts(req: TransferNfts) : Promise<TransactionResponse> {
 async transferDids(req: TransferDids) : Promise<TransactionResponse> {
     return await TAURI_INVOKE("transfer_dids", { req });
 },
+async normalizeDids(req: NormalizeDids) : Promise<TransactionResponse> {
+    return await TAURI_INVOKE("normalize_dids", { req });
+},
 async addNftUri(req: AddNftUri) : Promise<TransactionResponse> {
     return await TAURI_INVOKE("add_nft_uri", { req });
 },
@@ -268,7 +271,7 @@ export type DeleteKeyResponse = Record<string, never>
 export type DeleteOffer = { offer_id: string }
 export type DeleteOfferResponse = Record<string, never>
 export type DerivationRecord = { index: number; public_key: string; address: string }
-export type DidRecord = { launcher_id: string; name: string | null; visible: boolean; coin_id: string; address: string; amount: Amount; created_height: number | null; create_transaction_id: string | null }
+export type DidRecord = { launcher_id: string; name: string | null; visible: boolean; coin_id: string; address: string; amount: Amount; recovery_hash: string | null; created_height: number | null; create_transaction_id: string | null }
 export type Error = { kind: ErrorKind; reason: string }
 export type ErrorKind = "wallet" | "api" | "not_found" | "unauthorized" | "internal"
 export type FilterUnlockedCoins = { coin_ids: string[] }
@@ -344,6 +347,7 @@ export type NftMint = { edition_number: number | null; edition_total: number | n
 export type NftRecord = { launcher_id: string; collection_id: string | null; collection_name: string | null; minter_did: string | null; owner_did: string | null; visible: boolean; sensitive_content: boolean; name: string | null; created_height: number | null; coin_id: string; address: string; royalty_address: string; royalty_ten_thousandths: number; data_uris: string[]; data_hash: string | null; metadata_uris: string[]; metadata_hash: string | null; license_uris: string[]; license_hash: string | null; edition_number: number | null; edition_total: number | null }
 export type NftSortMode = "name" | "recent"
 export type NftUriKind = "data" | "metadata" | "license"
+export type NormalizeDids = { did_ids: string[]; fee: Amount; auto_submit?: boolean }
 export type OfferAssets = { xch: OfferXch; cats: { [key in string]: OfferCat }; nfts: { [key in string]: OfferNft } }
 export type OfferCat = { amount: Amount; royalty: Amount; name: string | null; ticker: string | null; icon_url: string | null }
 export type OfferNft = { image_data: string | null; image_mime_type: string | null; name: string | null; royalty_ten_thousandths: number; royalty_address: string }

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -13,15 +13,15 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Layout.tsx:128
+#: src/components/Layout.tsx:130
 msgid "(connecting...)"
 msgstr ""
 
-#: src/pages/DidList.tsx:89
+#: src/pages/DidList.tsx:91
 msgid "{didsCount, plural, one {You do not currently have any DID profile. Would you like to create one?} other {You do not currently have any DID profiles. Would you like to create one?}}"
 msgstr "{didsCount, plural, one {Sie haben derzeit noch kein DID-Profil. Möchten Sie eines erstellen?} other {Sie haben derzeit noch keine DID Profile. Möchten Sie eines erstellen?}}"
 
-#: src/components/Layout.tsx:74
+#: src/components/Layout.tsx:76
 #: src/components/Header.tsx:125
 msgid "{peerCount, plural, one {# peer} other {# peers}}"
 msgstr ""
@@ -168,8 +168,8 @@ msgstr "Assets"
 msgid "Assign Profile"
 msgstr "Profil zuweisen"
 
-#: src/components/Layout.tsx:75
-#: src/components/Layout.tsx:126
+#: src/components/Layout.tsx:77
+#: src/components/Layout.tsx:128
 #: src/components/Header.tsx:127
 msgid "at peak {peerMaxHeight}"
 msgstr "bei Höchststand {peerMaxHeight}"
@@ -204,7 +204,7 @@ msgstr "Massentransfer NFTs"
 #~ msgid "Bulk Unassign Profile"
 #~ msgstr "Massenaufhebung der Profilzuordnung"
 
-#: src/pages/DidList.tsx:211
+#: src/pages/DidList.tsx:243
 #: src/components/NftCard.tsx:286
 #: src/components/MultiSelectActions.tsx:136
 msgid "Burn"
@@ -214,7 +214,7 @@ msgstr "Verbrennung"
 msgid "Burn NFT"
 msgstr "NFT verbrennen"
 
-#: src/pages/DidList.tsx:310
+#: src/pages/DidList.tsx:344
 msgid "Burn Profile"
 msgstr "Profil verbrennen"
 
@@ -233,7 +233,7 @@ msgstr "Wenn Sie diese Funktion deaktivieren, erstellen Sie ein Cold Wallet, in 
 #: src/pages/Login.tsx:361
 #: src/pages/Login.tsx:389
 #: src/pages/Login.tsx:439
-#: src/pages/DidList.tsx:291
+#: src/pages/DidList.tsx:325
 #: src/pages/CreateWallet.tsx:252
 #: src/pages/Addresses.tsx:209
 #: src/components/TransferDialog.tsx:114
@@ -289,8 +289,8 @@ msgstr "Coins"
 msgid "Cold Wallet"
 msgstr "Cold Wallet"
 
-#: src/components/Layout.tsx:217
-#: src/components/Layout.tsx:228
+#: src/components/Layout.tsx:219
+#: src/components/Layout.tsx:230
 msgid "Collapse sidebar"
 msgstr ""
 
@@ -332,7 +332,7 @@ msgstr "Verbinden"
 msgid "Connected to {totalPeersCount} peers"
 msgstr "Verbunden mit {totalPeersCount} Peers"
 
-#: src/components/Layout.tsx:75
+#: src/components/Layout.tsx:77
 #: src/components/Header.tsx:128
 msgid "connecting..."
 msgstr "verbinden..."
@@ -354,7 +354,7 @@ msgstr "Erstellen"
 msgid "Create a new offer to get started with peer-to-peer trading."
 msgstr "Erstellen Sie ein neues Offer, um mit dem Peer-to-Peer-Handel zu beginnen."
 
-#: src/pages/DidList.tsx:86
+#: src/pages/DidList.tsx:88
 msgid "Create a profile?"
 msgstr "Ein Profil erstellen?"
 
@@ -363,7 +363,7 @@ msgstr "Ein Profil erstellen?"
 msgid "Create Offer"
 msgstr "Offer Erstellen"
 
-#: src/pages/DidList.tsx:66
+#: src/pages/DidList.tsx:68
 #: src/pages/CreateProfile.tsx:58
 #: src/pages/CreateProfile.tsx:105
 msgid "Create Profile"
@@ -543,7 +543,7 @@ msgstr "IP-Adresse des Peers eingeben, mit dem Sie sich verbinden möchten."
 msgid "Enter the new display details for this token"
 msgstr "Display-Details für neues Token eingeben"
 
-#: src/pages/DidList.tsx:261
+#: src/pages/DidList.tsx:295
 msgid "Enter the new display name for this profile."
 msgstr "Geben Sie den neuen Anzeigenamen für dieses Profil ein."
 
@@ -563,8 +563,8 @@ msgstr ""
 #~ msgid "Enter your mnemonic, private key, or public key below. If it's a public key, it will be imported as a read-only cold wallet."
 #~ msgstr "Geben Sie unten Ihre Mnemonic, Ihren Private Key oder Ihren Public Key ein. Wenn es sich um einen Public Key handelt, wird er als schreibgeschütztes Cold Wallet importiert."
 
-#: src/components/Layout.tsx:217
-#: src/components/Layout.tsx:228
+#: src/components/Layout.tsx:219
+#: src/components/Layout.tsx:230
 msgid "Expand sidebar"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr "Höhe:"
 
 #: src/pages/Token.tsx:259
 #: src/pages/NftList.tsx:245
-#: src/pages/DidList.tsx:240
+#: src/pages/DidList.tsx:274
 #: src/components/NftCard.tsx:334
 msgid "Hide"
 msgstr "Verstecken"
@@ -756,10 +756,10 @@ msgstr "Lizenz URLs"
 msgid "Login"
 msgstr "Anmelden"
 
-#: src/components/Layout.tsx:93
-#: src/components/Layout.tsx:97
-#: src/components/Layout.tsx:158
-#: src/components/Layout.tsx:165
+#: src/components/Layout.tsx:95
+#: src/components/Layout.tsx:99
+#: src/components/Layout.tsx:160
+#: src/components/Layout.tsx:167
 #: src/components/Header.tsx:148
 msgid "Logout"
 msgstr "Abmelden"
@@ -824,7 +824,7 @@ msgstr "Mnemonic"
 
 #: src/pages/Token.tsx:302
 #: src/pages/IssueToken.tsx:74
-#: src/pages/DidList.tsx:267
+#: src/pages/DidList.tsx:301
 #: src/pages/CreateProfile.tsx:69
 msgid "Name"
 msgstr "Name"
@@ -864,8 +864,8 @@ msgstr "Netzwerkgebührenbetrag"
 msgid "Network ID"
 msgstr "Netzwerk ID"
 
-#: src/components/Layout.tsx:61
-#: src/components/Layout.tsx:109
+#: src/components/Layout.tsx:63
+#: src/components/Layout.tsx:111
 #: src/components/Header.tsx:113
 msgid "Network status"
 msgstr "Netzwerkstatus"
@@ -924,6 +924,14 @@ msgstr "Keine Ergebnisse."
 msgid "None"
 msgstr "Nichts"
 
+#: src/pages/DidList.tsx:229
+msgid "Normalize"
+msgstr ""
+
+#: src/pages/DidList.tsx:356
+msgid "Normalize Profile"
+msgstr ""
+
 #: src/components/TransferDialog.tsx:50
 #: src/components/NftCard.tsx:144
 #: src/components/FeeOnlyDialog.tsx:49
@@ -977,7 +985,7 @@ msgstr "Offer-Text hier einfügen..."
 #~ msgid "Peak Height"
 #~ msgstr "Höchststand"
 
-#: src/components/Layout.tsx:124
+#: src/components/Layout.tsx:126
 msgid "peer"
 msgstr ""
 
@@ -985,7 +993,7 @@ msgstr ""
 msgid "Peer List"
 msgstr "Peer Liste"
 
-#: src/components/Layout.tsx:124
+#: src/components/Layout.tsx:126
 msgid "peers"
 msgstr ""
 
@@ -1043,11 +1051,11 @@ msgstr "Profil"
 msgid "Profile is required"
 msgstr "Profil ist erforderlich"
 
-#: src/pages/DidList.tsx:271
+#: src/pages/DidList.tsx:305
 msgid "Profile name"
 msgstr "Profilname"
 
-#: src/pages/DidList.tsx:60
+#: src/pages/DidList.tsx:62
 #: src/components/Nav.tsx:44
 #: src/components/Nav.tsx:47
 msgid "Profiles"
@@ -1088,12 +1096,12 @@ msgstr "Info aktualisieren"
 #: src/pages/Token.tsx:350
 #: src/pages/Login.tsx:259
 #: src/pages/Login.tsx:442
-#: src/pages/DidList.tsx:224
-#: src/pages/DidList.tsx:294
+#: src/pages/DidList.tsx:258
+#: src/pages/DidList.tsx:328
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: src/pages/DidList.tsx:258
+#: src/pages/DidList.tsx:292
 msgid "Rename Profile"
 msgstr "Profil umbenennen"
 
@@ -1213,15 +1221,15 @@ msgid "Sent"
 msgstr "Gesendet"
 
 #: src/pages/Settings.tsx:48
-#: src/components/Layout.tsx:88
-#: src/components/Layout.tsx:149
+#: src/components/Layout.tsx:90
+#: src/components/Layout.tsx:151
 #: src/components/Header.tsx:141
 msgid "Settings"
 msgstr "Einstellungen"
 
 #: src/pages/Token.tsx:259
 #: src/pages/NftList.tsx:245
-#: src/pages/DidList.tsx:240
+#: src/pages/DidList.tsx:274
 #: src/components/NftCard.tsx:334
 msgid "Show"
 msgstr "Anzeigen"
@@ -1292,8 +1300,8 @@ msgstr "Wird gesendet"
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: src/components/Layout.tsx:78
-#: src/components/Layout.tsx:132
+#: src/components/Layout.tsx:80
+#: src/components/Layout.tsx:134
 #: src/components/Header.tsx:131
 msgid "Syncing {syncedCoins} / {totalCoins}"
 msgstr "{syncedCoins} / {totalCoins} synchronisieren"
@@ -1386,11 +1394,15 @@ msgstr "Dadurch werden alle ausgewählten Coins zu einem einzigen kombiniert."
 msgid "This will delete the offer from the wallet, but if it's shared externally it can still be accepted. The only way to truly cancel a public offer is by spending one or more of its coins."
 msgstr "Dadurch wird das Offer aus dem Wallet gelöscht, aber wenn es extern geteilt wird, kann es immer noch akzeptiert werden. Der einzige Weg, ein öffentliches Angebot wirklich zu stornieren, besteht darin, einen oder mehrere seiner Coins auszugeben."
 
+#: src/pages/DidList.tsx:361
+msgid "This will modify the profile's recovery info to be compatible with the Chia reference wallet."
+msgstr ""
+
 #: src/components/NftCard.tsx:483
 msgid "This will permanently delete the NFT by sending it to the burn address."
 msgstr "Dadurch wird das NFT dauerhaft gelöscht, indem es an die Burn-Adresse gesendet wird."
 
-#: src/pages/DidList.tsx:315
+#: src/pages/DidList.tsx:349
 msgid "This will permanently delete the profile by sending it to the burn address."
 msgstr "Dadurch wird das Profil dauerhaft gelöscht, indem es an die Burn-Adresse gesendet wird."
 
@@ -1398,7 +1410,7 @@ msgstr "Dadurch wird das Profil dauerhaft gelöscht, indem es an die Burn-Adress
 msgid "This will send the NFT to the provided address."
 msgstr "Dadurch wird das NFT an die angegebene Adresse gesendet."
 
-#: src/pages/DidList.tsx:306
+#: src/pages/DidList.tsx:340
 msgid "This will send the profile to the provided address."
 msgstr "Dadurch wird das Profil an die angegebene Adresse gesendet."
 
@@ -1450,7 +1462,7 @@ msgstr "Signierte Transaktion"
 msgid "Transactions"
 msgstr "Transaktionen"
 
-#: src/pages/DidList.tsx:198
+#: src/pages/DidList.tsx:215
 #: src/components/TransferDialog.tsx:117
 #: src/components/NftCard.tsx:239
 #: src/components/MultiSelectActions.tsx:110
@@ -1463,7 +1475,7 @@ msgstr "Transferieren"
 msgid "Transfer NFT"
 msgstr "NFT transferieren"
 
-#: src/pages/DidList.tsx:301
+#: src/pages/DidList.tsx:335
 msgid "Transfer Profile"
 msgstr "Profil transferieren"
 
@@ -1522,7 +1534,7 @@ msgstr "Unbenannt"
 msgid "Unspent"
 msgstr "Nicht ausgegeben"
 
-#: src/pages/DidList.tsx:179
+#: src/pages/DidList.tsx:196
 msgid "Untitled Profile"
 msgstr "Unbenanntes Profil"
 
@@ -1551,7 +1563,7 @@ msgid "Version {version}"
 msgstr ""
 
 #: src/pages/TokenList.tsx:219
-#: src/pages/DidList.tsx:72
+#: src/pages/DidList.tsx:74
 msgid "View hidden"
 msgstr "Versteckte anzeigen"
 
@@ -1564,7 +1576,7 @@ msgstr "Offer anzeigen"
 #: src/pages/Login.tsx:507
 #: src/components/Nav.tsx:28
 #: src/components/Nav.tsx:31
-#: src/components/Layout.tsx:193
+#: src/components/Layout.tsx:195
 msgid "Wallet"
 msgstr "Wallet"
 
@@ -1572,8 +1584,8 @@ msgstr "Wallet"
 msgid "Wallet Details"
 msgstr "Wallet Details"
 
-#: src/components/Layout.tsx:175
-#: src/components/Layout.tsx:190
+#: src/components/Layout.tsx:177
+#: src/components/Layout.tsx:192
 #: src/components/Header.tsx:102
 msgid "Wallet icon"
 msgstr "Wallet Symbol"

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -13,15 +13,15 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Layout.tsx:128
+#: src/components/Layout.tsx:130
 msgid "(connecting...)"
 msgstr "(connecting...)"
 
-#: src/pages/DidList.tsx:89
+#: src/pages/DidList.tsx:91
 msgid "{didsCount, plural, one {You do not currently have any DID profile. Would you like to create one?} other {You do not currently have any DID profiles. Would you like to create one?}}"
 msgstr "{didsCount, plural, one {You do not currently have any DID profile. Would you like to create one?} other {You do not currently have any DID profiles. Would you like to create one?}}"
 
-#: src/components/Layout.tsx:74
+#: src/components/Layout.tsx:76
 #: src/components/Header.tsx:125
 msgid "{peerCount, plural, one {# peer} other {# peers}}"
 msgstr "{peerCount, plural, one {# peer} other {# peers}}"
@@ -168,8 +168,8 @@ msgstr "Assets"
 msgid "Assign Profile"
 msgstr "Assign Profile"
 
-#: src/components/Layout.tsx:75
-#: src/components/Layout.tsx:126
+#: src/components/Layout.tsx:77
+#: src/components/Layout.tsx:128
 #: src/components/Header.tsx:127
 msgid "at peak {peerMaxHeight}"
 msgstr "at peak {peerMaxHeight}"
@@ -204,7 +204,7 @@ msgstr "Bulk Transfer NFTs"
 #~ msgid "Bulk Unassign Profile"
 #~ msgstr "Bulk Unassign Profile"
 
-#: src/pages/DidList.tsx:211
+#: src/pages/DidList.tsx:243
 #: src/components/NftCard.tsx:286
 #: src/components/MultiSelectActions.tsx:136
 msgid "Burn"
@@ -214,7 +214,7 @@ msgstr "Burn"
 msgid "Burn NFT"
 msgstr "Burn NFT"
 
-#: src/pages/DidList.tsx:310
+#: src/pages/DidList.tsx:344
 msgid "Burn Profile"
 msgstr "Burn Profile"
 
@@ -233,7 +233,7 @@ msgstr "By disabling this you are creating a cold wallet, with no ability to sig
 #: src/pages/Login.tsx:361
 #: src/pages/Login.tsx:389
 #: src/pages/Login.tsx:439
-#: src/pages/DidList.tsx:291
+#: src/pages/DidList.tsx:325
 #: src/pages/CreateWallet.tsx:252
 #: src/pages/Addresses.tsx:209
 #: src/components/TransferDialog.tsx:114
@@ -289,8 +289,8 @@ msgstr "Coins"
 msgid "Cold Wallet"
 msgstr "Cold Wallet"
 
-#: src/components/Layout.tsx:217
-#: src/components/Layout.tsx:228
+#: src/components/Layout.tsx:219
+#: src/components/Layout.tsx:230
 msgid "Collapse sidebar"
 msgstr "Collapse sidebar"
 
@@ -332,7 +332,7 @@ msgstr "Connect"
 msgid "Connected to {totalPeersCount} peers"
 msgstr "Connected to {totalPeersCount} peers"
 
-#: src/components/Layout.tsx:75
+#: src/components/Layout.tsx:77
 #: src/components/Header.tsx:128
 msgid "connecting..."
 msgstr "connecting..."
@@ -354,7 +354,7 @@ msgstr "Create"
 msgid "Create a new offer to get started with peer-to-peer trading."
 msgstr "Create a new offer to get started with peer-to-peer trading."
 
-#: src/pages/DidList.tsx:86
+#: src/pages/DidList.tsx:88
 msgid "Create a profile?"
 msgstr "Create a profile?"
 
@@ -363,7 +363,7 @@ msgstr "Create a profile?"
 msgid "Create Offer"
 msgstr "Create Offer"
 
-#: src/pages/DidList.tsx:66
+#: src/pages/DidList.tsx:68
 #: src/pages/CreateProfile.tsx:58
 #: src/pages/CreateProfile.tsx:105
 msgid "Create Profile"
@@ -543,7 +543,7 @@ msgstr "Enter the IP address of the peer you want to connect to."
 msgid "Enter the new display details for this token"
 msgstr "Enter the new display details for this token"
 
-#: src/pages/DidList.tsx:261
+#: src/pages/DidList.tsx:295
 msgid "Enter the new display name for this profile."
 msgstr "Enter the new display name for this profile."
 
@@ -563,8 +563,8 @@ msgstr "Enter your mnemonic, private key, or public key above. If it's a public 
 #~ msgid "Enter your mnemonic, private key, or public key below. If it's a public key, it will be imported as a read-only cold wallet."
 #~ msgstr "Enter your mnemonic, private key, or public key below. If it's a public key, it will be imported as a read-only cold wallet."
 
-#: src/components/Layout.tsx:217
-#: src/components/Layout.tsx:228
+#: src/components/Layout.tsx:219
+#: src/components/Layout.tsx:230
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
 
@@ -637,7 +637,7 @@ msgstr "Height:"
 
 #: src/pages/Token.tsx:259
 #: src/pages/NftList.tsx:245
-#: src/pages/DidList.tsx:240
+#: src/pages/DidList.tsx:274
 #: src/components/NftCard.tsx:334
 msgid "Hide"
 msgstr "Hide"
@@ -756,10 +756,10 @@ msgstr "License URLs"
 msgid "Login"
 msgstr "Login"
 
-#: src/components/Layout.tsx:93
-#: src/components/Layout.tsx:97
-#: src/components/Layout.tsx:158
-#: src/components/Layout.tsx:165
+#: src/components/Layout.tsx:95
+#: src/components/Layout.tsx:99
+#: src/components/Layout.tsx:160
+#: src/components/Layout.tsx:167
 #: src/components/Header.tsx:148
 msgid "Logout"
 msgstr "Logout"
@@ -824,7 +824,7 @@ msgstr "Mnemonic"
 
 #: src/pages/Token.tsx:302
 #: src/pages/IssueToken.tsx:74
-#: src/pages/DidList.tsx:267
+#: src/pages/DidList.tsx:301
 #: src/pages/CreateProfile.tsx:69
 msgid "Name"
 msgstr "Name"
@@ -864,8 +864,8 @@ msgstr "Network fee amount"
 msgid "Network ID"
 msgstr "Network ID"
 
-#: src/components/Layout.tsx:61
-#: src/components/Layout.tsx:109
+#: src/components/Layout.tsx:63
+#: src/components/Layout.tsx:111
 #: src/components/Header.tsx:113
 msgid "Network status"
 msgstr "Network status"
@@ -924,6 +924,14 @@ msgstr "No results."
 msgid "None"
 msgstr "None"
 
+#: src/pages/DidList.tsx:229
+msgid "Normalize"
+msgstr "Normalize"
+
+#: src/pages/DidList.tsx:356
+msgid "Normalize Profile"
+msgstr "Normalize Profile"
+
 #: src/components/TransferDialog.tsx:50
 #: src/components/NftCard.tsx:144
 #: src/components/FeeOnlyDialog.tsx:49
@@ -977,7 +985,7 @@ msgstr "Paste your offer string here..."
 #~ msgid "Peak Height"
 #~ msgstr "Peak Height"
 
-#: src/components/Layout.tsx:124
+#: src/components/Layout.tsx:126
 msgid "peer"
 msgstr "peer"
 
@@ -985,7 +993,7 @@ msgstr "peer"
 msgid "Peer List"
 msgstr "Peer List"
 
-#: src/components/Layout.tsx:124
+#: src/components/Layout.tsx:126
 msgid "peers"
 msgstr "peers"
 
@@ -1043,11 +1051,11 @@ msgstr "Profile"
 msgid "Profile is required"
 msgstr "Profile is required"
 
-#: src/pages/DidList.tsx:271
+#: src/pages/DidList.tsx:305
 msgid "Profile name"
 msgstr "Profile name"
 
-#: src/pages/DidList.tsx:60
+#: src/pages/DidList.tsx:62
 #: src/components/Nav.tsx:44
 #: src/components/Nav.tsx:47
 msgid "Profiles"
@@ -1088,12 +1096,12 @@ msgstr "Refresh Info"
 #: src/pages/Token.tsx:350
 #: src/pages/Login.tsx:259
 #: src/pages/Login.tsx:442
-#: src/pages/DidList.tsx:224
-#: src/pages/DidList.tsx:294
+#: src/pages/DidList.tsx:258
+#: src/pages/DidList.tsx:328
 msgid "Rename"
 msgstr "Rename"
 
-#: src/pages/DidList.tsx:258
+#: src/pages/DidList.tsx:292
 msgid "Rename Profile"
 msgstr "Rename Profile"
 
@@ -1213,15 +1221,15 @@ msgid "Sent"
 msgstr "Sent"
 
 #: src/pages/Settings.tsx:48
-#: src/components/Layout.tsx:88
-#: src/components/Layout.tsx:149
+#: src/components/Layout.tsx:90
+#: src/components/Layout.tsx:151
 #: src/components/Header.tsx:141
 msgid "Settings"
 msgstr "Settings"
 
 #: src/pages/Token.tsx:259
 #: src/pages/NftList.tsx:245
-#: src/pages/DidList.tsx:240
+#: src/pages/DidList.tsx:274
 #: src/components/NftCard.tsx:334
 msgid "Show"
 msgstr "Show"
@@ -1292,8 +1300,8 @@ msgstr "Submitting"
 msgid "Summary"
 msgstr "Summary"
 
-#: src/components/Layout.tsx:78
-#: src/components/Layout.tsx:132
+#: src/components/Layout.tsx:80
+#: src/components/Layout.tsx:134
 #: src/components/Header.tsx:131
 msgid "Syncing {syncedCoins} / {totalCoins}"
 msgstr "Syncing {syncedCoins} / {totalCoins}"
@@ -1386,11 +1394,15 @@ msgstr "This will combine all of the selected coins into one."
 msgid "This will delete the offer from the wallet, but if it's shared externally it can still be accepted. The only way to truly cancel a public offer is by spending one or more of its coins."
 msgstr "This will delete the offer from the wallet, but if it's shared externally it can still be accepted. The only way to truly cancel a public offer is by spending one or more of its coins."
 
+#: src/pages/DidList.tsx:361
+msgid "This will modify the profile's recovery info to be compatible with the Chia reference wallet."
+msgstr "This will modify the profile's recovery info to be compatible with the Chia reference wallet."
+
 #: src/components/NftCard.tsx:483
 msgid "This will permanently delete the NFT by sending it to the burn address."
 msgstr "This will permanently delete the NFT by sending it to the burn address."
 
-#: src/pages/DidList.tsx:315
+#: src/pages/DidList.tsx:349
 msgid "This will permanently delete the profile by sending it to the burn address."
 msgstr "This will permanently delete the profile by sending it to the burn address."
 
@@ -1398,7 +1410,7 @@ msgstr "This will permanently delete the profile by sending it to the burn addre
 msgid "This will send the NFT to the provided address."
 msgstr "This will send the NFT to the provided address."
 
-#: src/pages/DidList.tsx:306
+#: src/pages/DidList.tsx:340
 msgid "This will send the profile to the provided address."
 msgstr "This will send the profile to the provided address."
 
@@ -1450,7 +1462,7 @@ msgstr "Transaction Signed"
 msgid "Transactions"
 msgstr "Transactions"
 
-#: src/pages/DidList.tsx:198
+#: src/pages/DidList.tsx:215
 #: src/components/TransferDialog.tsx:117
 #: src/components/NftCard.tsx:239
 #: src/components/MultiSelectActions.tsx:110
@@ -1463,7 +1475,7 @@ msgstr "Transfer"
 msgid "Transfer NFT"
 msgstr "Transfer NFT"
 
-#: src/pages/DidList.tsx:301
+#: src/pages/DidList.tsx:335
 msgid "Transfer Profile"
 msgstr "Transfer Profile"
 
@@ -1522,7 +1534,7 @@ msgstr "Unnamed"
 msgid "Unspent"
 msgstr "Unspent"
 
-#: src/pages/DidList.tsx:179
+#: src/pages/DidList.tsx:196
 msgid "Untitled Profile"
 msgstr "Untitled Profile"
 
@@ -1551,7 +1563,7 @@ msgid "Version {version}"
 msgstr "Version {version}"
 
 #: src/pages/TokenList.tsx:219
-#: src/pages/DidList.tsx:72
+#: src/pages/DidList.tsx:74
 msgid "View hidden"
 msgstr "View hidden"
 
@@ -1564,7 +1576,7 @@ msgstr "View Offer"
 #: src/pages/Login.tsx:507
 #: src/components/Nav.tsx:28
 #: src/components/Nav.tsx:31
-#: src/components/Layout.tsx:193
+#: src/components/Layout.tsx:195
 msgid "Wallet"
 msgstr "Wallet"
 
@@ -1572,8 +1584,8 @@ msgstr "Wallet"
 msgid "Wallet Details"
 msgstr "Wallet Details"
 
-#: src/components/Layout.tsx:175
-#: src/components/Layout.tsx:190
+#: src/components/Layout.tsx:177
+#: src/components/Layout.tsx:192
 #: src/components/Header.tsx:102
 msgid "Wallet icon"
 msgstr "Wallet icon"

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -13,15 +13,15 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: Poedit 3.5\n"
 
-#: src/components/Layout.tsx:128
+#: src/components/Layout.tsx:130
 msgid "(connecting...)"
 msgstr ""
 
-#: src/pages/DidList.tsx:89
+#: src/pages/DidList.tsx:91
 msgid "{didsCount, plural, one {You do not currently have any DID profile. Would you like to create one?} other {You do not currently have any DID profiles. Would you like to create one?}}"
 msgstr "{didsCount, plural, one {当前还没有任何DID. 立即创建一个?} other {当前还没有任何DID. 立即创建一个?}}"
 
-#: src/components/Layout.tsx:74
+#: src/components/Layout.tsx:76
 #: src/components/Header.tsx:125
 msgid "{peerCount, plural, one {# peer} other {# peers}}"
 msgstr "{peerCount, plural, one {# 节点} other {# 节点}}"
@@ -168,8 +168,8 @@ msgstr "资产"
 msgid "Assign Profile"
 msgstr "分配个人资料"
 
-#: src/components/Layout.tsx:75
-#: src/components/Layout.tsx:126
+#: src/components/Layout.tsx:77
+#: src/components/Layout.tsx:128
 #: src/components/Header.tsx:127
 msgid "at peak {peerMaxHeight}"
 msgstr "于高度 {peerMaxHeight}"
@@ -204,7 +204,7 @@ msgstr "批量转移NFT"
 #~ msgid "Bulk Unassign Profile"
 #~ msgstr "批量解除分配个人资料"
 
-#: src/pages/DidList.tsx:211
+#: src/pages/DidList.tsx:243
 #: src/components/NftCard.tsx:286
 #: src/components/MultiSelectActions.tsx:136
 msgid "Burn"
@@ -214,7 +214,7 @@ msgstr "销毁"
 msgid "Burn NFT"
 msgstr "销毁NFT"
 
-#: src/pages/DidList.tsx:310
+#: src/pages/DidList.tsx:344
 msgid "Burn Profile"
 msgstr "销毁个人资料"
 
@@ -233,7 +233,7 @@ msgstr "禁用此功能后, 将创建一个冷钱包, 该钱包无法签署交�
 #: src/pages/Login.tsx:361
 #: src/pages/Login.tsx:389
 #: src/pages/Login.tsx:439
-#: src/pages/DidList.tsx:291
+#: src/pages/DidList.tsx:325
 #: src/pages/CreateWallet.tsx:252
 #: src/pages/Addresses.tsx:209
 #: src/components/TransferDialog.tsx:114
@@ -288,8 +288,8 @@ msgstr "硬币"
 msgid "Cold Wallet"
 msgstr "冷钱包"
 
-#: src/components/Layout.tsx:217
-#: src/components/Layout.tsx:228
+#: src/components/Layout.tsx:219
+#: src/components/Layout.tsx:230
 msgid "Collapse sidebar"
 msgstr ""
 
@@ -331,7 +331,7 @@ msgstr "连接"
 msgid "Connected to {totalPeersCount} peers"
 msgstr "已连接到 {totalPeersCount} 个节点"
 
-#: src/components/Layout.tsx:75
+#: src/components/Layout.tsx:77
 #: src/components/Header.tsx:128
 msgid "connecting..."
 msgstr "连接中..."
@@ -353,7 +353,7 @@ msgstr "创建"
 msgid "Create a new offer to get started with peer-to-peer trading."
 msgstr "创建一个新报价以开始点对点交易."
 
-#: src/pages/DidList.tsx:86
+#: src/pages/DidList.tsx:88
 msgid "Create a profile?"
 msgstr "创建个人资料?"
 
@@ -362,7 +362,7 @@ msgstr "创建个人资料?"
 msgid "Create Offer"
 msgstr "创建报价"
 
-#: src/pages/DidList.tsx:66
+#: src/pages/DidList.tsx:68
 #: src/pages/CreateProfile.tsx:58
 #: src/pages/CreateProfile.tsx:105
 msgid "Create Profile"
@@ -542,7 +542,7 @@ msgstr "输入想连接的节点 IP 地址."
 msgid "Enter the new display details for this token"
 msgstr "输入此代币的新显示详情"
 
-#: src/pages/DidList.tsx:261
+#: src/pages/DidList.tsx:295
 msgid "Enter the new display name for this profile."
 msgstr "输入此个人资料的新显示名称."
 
@@ -562,8 +562,8 @@ msgstr ""
 #~ msgid "Enter your mnemonic, private key, or public key below. If it's a public key, it will be imported as a read-only cold wallet."
 #~ msgstr "请输入助记词、私钥或公钥. 如果是公钥, 它将作为只读冷钱包导入."
 
-#: src/components/Layout.tsx:217
-#: src/components/Layout.tsx:228
+#: src/components/Layout.tsx:219
+#: src/components/Layout.tsx:230
 msgid "Expand sidebar"
 msgstr ""
 
@@ -635,7 +635,7 @@ msgstr "高度:"
 
 #: src/pages/Token.tsx:259
 #: src/pages/NftList.tsx:245
-#: src/pages/DidList.tsx:240
+#: src/pages/DidList.tsx:274
 #: src/components/NftCard.tsx:334
 msgid "Hide"
 msgstr "隐藏"
@@ -754,10 +754,10 @@ msgstr "许可证网址"
 msgid "Login"
 msgstr "登录"
 
-#: src/components/Layout.tsx:93
-#: src/components/Layout.tsx:97
-#: src/components/Layout.tsx:158
-#: src/components/Layout.tsx:165
+#: src/components/Layout.tsx:95
+#: src/components/Layout.tsx:99
+#: src/components/Layout.tsx:160
+#: src/components/Layout.tsx:167
 #: src/components/Header.tsx:148
 msgid "Logout"
 msgstr "退出"
@@ -822,7 +822,7 @@ msgstr "助记词"
 
 #: src/pages/Token.tsx:302
 #: src/pages/IssueToken.tsx:74
-#: src/pages/DidList.tsx:267
+#: src/pages/DidList.tsx:301
 #: src/pages/CreateProfile.tsx:69
 msgid "Name"
 msgstr "名称"
@@ -862,8 +862,8 @@ msgstr "网络手续费金额"
 msgid "Network ID"
 msgstr "网络ID"
 
-#: src/components/Layout.tsx:61
-#: src/components/Layout.tsx:109
+#: src/components/Layout.tsx:63
+#: src/components/Layout.tsx:111
 #: src/components/Header.tsx:113
 msgid "Network status"
 msgstr "网络状态"
@@ -922,6 +922,14 @@ msgstr "无结果."
 msgid "None"
 msgstr "无"
 
+#: src/pages/DidList.tsx:229
+msgid "Normalize"
+msgstr ""
+
+#: src/pages/DidList.tsx:356
+msgid "Normalize Profile"
+msgstr ""
+
 #: src/components/TransferDialog.tsx:50
 #: src/components/NftCard.tsx:144
 #: src/components/FeeOnlyDialog.tsx:49
@@ -975,7 +983,7 @@ msgstr "在这里粘贴报价文本..."
 #~ msgid "Peak Height"
 #~ msgstr "最高高度"
 
-#: src/components/Layout.tsx:124
+#: src/components/Layout.tsx:126
 msgid "peer"
 msgstr ""
 
@@ -983,7 +991,7 @@ msgstr ""
 msgid "Peer List"
 msgstr "节点列表"
 
-#: src/components/Layout.tsx:124
+#: src/components/Layout.tsx:126
 msgid "peers"
 msgstr ""
 
@@ -1040,11 +1048,11 @@ msgstr "个人资料"
 msgid "Profile is required"
 msgstr "需提供个人资料"
 
-#: src/pages/DidList.tsx:271
+#: src/pages/DidList.tsx:305
 msgid "Profile name"
 msgstr "个人资料名称"
 
-#: src/pages/DidList.tsx:60
+#: src/pages/DidList.tsx:62
 #: src/components/Nav.tsx:44
 #: src/components/Nav.tsx:47
 msgid "Profiles"
@@ -1085,12 +1093,12 @@ msgstr "刷新信息"
 #: src/pages/Token.tsx:350
 #: src/pages/Login.tsx:259
 #: src/pages/Login.tsx:442
-#: src/pages/DidList.tsx:224
-#: src/pages/DidList.tsx:294
+#: src/pages/DidList.tsx:258
+#: src/pages/DidList.tsx:328
 msgid "Rename"
 msgstr "重命名"
 
-#: src/pages/DidList.tsx:258
+#: src/pages/DidList.tsx:292
 msgid "Rename Profile"
 msgstr "重命名个人资料"
 
@@ -1210,15 +1218,15 @@ msgid "Sent"
 msgstr "已发送"
 
 #: src/pages/Settings.tsx:48
-#: src/components/Layout.tsx:88
-#: src/components/Layout.tsx:149
+#: src/components/Layout.tsx:90
+#: src/components/Layout.tsx:151
 #: src/components/Header.tsx:141
 msgid "Settings"
 msgstr "设置"
 
 #: src/pages/Token.tsx:259
 #: src/pages/NftList.tsx:245
-#: src/pages/DidList.tsx:240
+#: src/pages/DidList.tsx:274
 #: src/components/NftCard.tsx:334
 msgid "Show"
 msgstr "显示"
@@ -1289,8 +1297,8 @@ msgstr "正在提交"
 msgid "Summary"
 msgstr "摘要"
 
-#: src/components/Layout.tsx:78
-#: src/components/Layout.tsx:132
+#: src/components/Layout.tsx:80
+#: src/components/Layout.tsx:134
 #: src/components/Header.tsx:131
 msgid "Syncing {syncedCoins} / {totalCoins}"
 msgstr "正在同步 {syncedCoins} / {totalCoins}"
@@ -1380,11 +1388,15 @@ msgstr "这将把所有选中的币合并为一个."
 msgid "This will delete the offer from the wallet, but if it's shared externally it can still be accepted. The only way to truly cancel a public offer is by spending one or more of its coins."
 msgstr "这将从钱包中删除该报价, 但如果已被外部共享, 仍然可以被接受. 真正取消公共报价的唯一方式是花费其中一个或多个币."
 
+#: src/pages/DidList.tsx:361
+msgid "This will modify the profile's recovery info to be compatible with the Chia reference wallet."
+msgstr ""
+
 #: src/components/NftCard.tsx:483
 msgid "This will permanently delete the NFT by sending it to the burn address."
 msgstr "这将通过把 NFT 发送到销毁地址来永久删除它."
 
-#: src/pages/DidList.tsx:315
+#: src/pages/DidList.tsx:349
 msgid "This will permanently delete the profile by sending it to the burn address."
 msgstr "这将通过把个人资料发送到销毁地址来永久删除它."
 
@@ -1392,7 +1404,7 @@ msgstr "这将通过把个人资料发送到销毁地址来永久删除它."
 msgid "This will send the NFT to the provided address."
 msgstr "这将把NFT发送到提供的地址."
 
-#: src/pages/DidList.tsx:306
+#: src/pages/DidList.tsx:340
 msgid "This will send the profile to the provided address."
 msgstr "这将把个人资料发送到提供的地址."
 
@@ -1444,7 +1456,7 @@ msgstr "已签名交易"
 msgid "Transactions"
 msgstr "交易"
 
-#: src/pages/DidList.tsx:198
+#: src/pages/DidList.tsx:215
 #: src/components/TransferDialog.tsx:117
 #: src/components/NftCard.tsx:239
 #: src/components/MultiSelectActions.tsx:110
@@ -1457,7 +1469,7 @@ msgstr "转移"
 msgid "Transfer NFT"
 msgstr "转移NFT"
 
-#: src/pages/DidList.tsx:301
+#: src/pages/DidList.tsx:335
 msgid "Transfer Profile"
 msgstr "转移个人资料"
 
@@ -1515,7 +1527,7 @@ msgstr "未命名"
 msgid "Unspent"
 msgstr "未花费"
 
-#: src/pages/DidList.tsx:179
+#: src/pages/DidList.tsx:196
 msgid "Untitled Profile"
 msgstr "未命名个人资料"
 
@@ -1544,7 +1556,7 @@ msgid "Version {version}"
 msgstr ""
 
 #: src/pages/TokenList.tsx:219
-#: src/pages/DidList.tsx:72
+#: src/pages/DidList.tsx:74
 msgid "View hidden"
 msgstr "查看已隐藏的"
 
@@ -1557,7 +1569,7 @@ msgstr "查看报价"
 #: src/pages/Login.tsx:507
 #: src/components/Nav.tsx:28
 #: src/components/Nav.tsx:31
-#: src/components/Layout.tsx:193
+#: src/components/Layout.tsx:195
 msgid "Wallet"
 msgstr "钱包"
 
@@ -1565,8 +1577,8 @@ msgstr "钱包"
 msgid "Wallet Details"
 msgstr "钱包详情"
 
-#: src/components/Layout.tsx:175
-#: src/components/Layout.tsx:190
+#: src/components/Layout.tsx:177
+#: src/components/Layout.tsx:192
 #: src/components/Header.tsx:102
 msgid "Wallet icon"
 msgstr "钱包硬币"


### PR DESCRIPTION
In the Chia reference wallet, you can't load DIDs created by Sage - this provides a way to change the DID recovery list hash to be compatible with the reference wallet.