### PR TITLE
Enhance error handling in WalletConnectProvider

### DIFF
--- a/src/contexts/WalletConnectContext.tsx
+++ b/src/contexts/WalletConnectContext.tsx
@@ -108,7 +108,11 @@ export function WalletConnectProvider({ children }: { children: ReactNode }) {
         });
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : 'Request failed';
+          error instanceof Error
+            ? error.message
+            : typeof error === 'object' && error !== null && 'reason' in error
+              ? (error.reason as string)
+              : 'Request failed';
         addError({ kind: 'walletconnect', reason: errorMessage });
         console.error('WalletConnect request failed:', error);
 


### PR DESCRIPTION
Enhance error handling in WalletConnectProvider to include specific error reasons. Now captures additional error details when available, improving debugging and user feedback.

I realized that sometime the error come with a reason so it is better to show it to the user.

In my case it was `{kind: "walletconnect", reason: "Wallet error: Coin selection error: no spendable coins"}` So it is more clear than just `"Request failed"`