### PR TITLE
Collection view improvements

### DIFF
--- a/src/components/NftCardList.tsx
+++ b/src/components/NftCardList.tsx
@@ -93,7 +93,7 @@ export function NftCardList({
               }}
             />
           ))}
-          {nfts.length < pageSize && (
+          {collections.length < pageSize && (
             <NftGroupCard
               type='collection'
               item={{

--- a/src/components/NftCardList.tsx
+++ b/src/components/NftCardList.tsx
@@ -84,8 +84,8 @@ export function NftCardList({
               page={page}
               onToggleVisibility={() => {
                 commands
-                  .updateNft({
-                    nft_id: col.collection_id,
+                  .updateNftCollection({
+                    collection_id: col.collection_id,
                     visible: !col.visible,
                   })
                   .then(() => updateNfts(page))
@@ -104,6 +104,7 @@ export function NftCardList({
                 collection_id: 'No collection',
                 visible: true,
               }}
+              canToggleVisibility={false}
               updateNfts={updateNfts}
               page={page}
             />

--- a/src/components/NftGroupCard.tsx
+++ b/src/components/NftGroupCard.tsx
@@ -52,7 +52,6 @@ export function NftGroupCard({
   onToggleVisibility = () => {},
   isLoading,
   error,
-  showHidden,
 }: NftGroupCardProps) {
   const navigate = useNavigate();
   const isCollection = type === 'collection';
@@ -140,8 +139,8 @@ export function NftGroupCard({
       }}
       role='button'
       tabIndex={0}
-      className={`cursor-pointer group border border-neutral-200 dark:border-neutral-800 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary${
-        !item.visible ? ' opacity-50 grayscale' : ''
+      className={`cursor-pointer group border border-neutral-200 dark:border-neutral-800 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary ${
+        isCollection && !item.visible ? 'opacity-50' : ''
       }`}
       aria-label={
         isCollection
@@ -250,6 +249,7 @@ export function NftGroupCard({
                       open(`https://mintgarden.io/collections/${getId()}`);
                     }}
                     aria-label={t`View on Mintgarden`}
+                    disabled={true}
                   >
                     <ExternalLink className='mr-2 h-4 w-4' />
                     <span>

--- a/src/components/NftGroupCard.tsx
+++ b/src/components/NftGroupCard.tsx
@@ -3,14 +3,14 @@ import { NftGroupMode } from '@/hooks/useNftParams';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import {
-  EyeIcon,
-  EyeOff,
-  Icon,
-  icons,
   LibraryBig,
-  MoreVerticalIcon,
   Paintbrush,
   UserIcon,
+  Copy,
+  MoreVertical,
+  ExternalLink,
+  EyeIcon,
+  EyeOff,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from './ui/button';
@@ -27,6 +27,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from './ui/tooltip';
+import { writeText } from '@tauri-apps/plugin-clipboard-manager';
+import { toast } from 'react-toastify';
+import { open } from '@tauri-apps/plugin-shell';
 
 interface NftGroupCardProps {
   type: 'collection' | 'did';
@@ -37,6 +40,7 @@ interface NftGroupCardProps {
   onToggleVisibility?: () => void;
   isLoading?: boolean;
   error?: Error;
+  showHidden?: boolean;
 }
 
 export function NftGroupCard({
@@ -45,13 +49,13 @@ export function NftGroupCard({
   item,
   updateNfts,
   page,
-  onToggleVisibility,
+  onToggleVisibility = () => {},
   isLoading,
   error,
+  showHidden,
 }: NftGroupCardProps) {
   const navigate = useNavigate();
   const isCollection = type === 'collection';
-  const allowToggleVisibility = false; //isCollection && onToggleVisibility; // not implemented yet
   // Type guards to help TypeScript narrow the types
   const isDidRecord = (
     item: NftCollectionRecord | DidRecord,
@@ -79,7 +83,7 @@ export function NftGroupCard({
 
   const getDefaultName = () => {
     if (isCollection) {
-      return t`Unnamed`;
+      return t`Unnamed Collection`;
     }
     return groupMode === NftGroupMode.OwnerDid ? (
       <Trans>Untitled Profile</Trans>
@@ -136,7 +140,9 @@ export function NftGroupCard({
       }}
       role='button'
       tabIndex={0}
-      className='cursor-pointer group border border-neutral-200 dark:border-neutral-800 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary'
+      className={`cursor-pointer group border border-neutral-200 dark:border-neutral-800 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary${
+        !item.visible ? ' opacity-50 grayscale' : ''
+      }`}
       aria-label={
         isCollection
           ? `Collection ${item.name || t`Unnamed`}`
@@ -154,20 +160,22 @@ export function NftGroupCard({
             className='bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center aspect-square'
             aria-hidden='true'
           >
-            {item?.icon ? (
+            {isCollectionRecord(item) && item.icon ? (
               <img
                 src={item.icon}
-                alt={t`Icon for ${item.name}`}
+                alt={(() => {
+                  const name = item.name || '';
+                  return t`Icon for ${name}`;
+                })()}
                 className='object-cover h-full w-full'
                 aria-hidden='true'
               />
             ) : (
-            <LibraryBig
-              className='h-12 w-12 text-neutral-400 dark:text-neutral-600'
-              aria-hidden='true'
-            />
+              <LibraryBig
+                className='h-12 w-12 text-neutral-400 dark:text-neutral-600'
+                aria-hidden='true'
+              />
             )}
-
           </div>
         ) : (
           <div
@@ -220,41 +228,84 @@ export function NftGroupCard({
           </TooltipProvider>
         </span>
 
-        {allowToggleVisibility && onToggleVisibility && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant='ghost'
-                size='icon'
-                onClick={(e) => e.stopPropagation()}
-                aria-label={
-                  item.visible ? t`Hide collection` : t`Show collection`
-                }
-                aria-expanded='false'
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant='ghost'
+              size='icon'
+              aria-label={t`Options`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreVertical className='h-5 w-5' />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end'>
+            <DropdownMenuGroup>
+              {isCollection && (
+                <>
+                  <DropdownMenuItem
+                    className='cursor-pointer'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      open(`https://mintgarden.io/collections/${getId()}`);
+                    }}
+                    aria-label={t`View on Mintgarden`}
+                  >
+                    <ExternalLink className='mr-2 h-4 w-4' />
+                    <span>
+                      <Trans>View on Mintgarden</Trans>
+                    </span>
+                  </DropdownMenuItem>
+
+                  <DropdownMenuItem
+                    className='cursor-pointer'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onToggleVisibility();
+                    }}
+                  >
+                    {item.visible ? (
+                      <>
+                        <EyeOff className='mr-2 h-4 w-4' />
+                        <span>
+                          <Trans>Hide</Trans>
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <EyeIcon className='mr-2 h-4 w-4' />
+                        <span>
+                          <Trans>Show</Trans>
+                        </span>
+                      </>
+                    )}
+                  </DropdownMenuItem>
+                </>
+              )}
+
+              <DropdownMenuItem
+                className='cursor-pointer'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  writeText(getId());
+                  toast.success(
+                    isCollection
+                      ? t`Collection ID copied to clipboard`
+                      : groupMode === NftGroupMode.OwnerDid
+                        ? t`Profile ID copied to clipboard`
+                        : t`Minter ID copied to clipboard`,
+                  );
+                }}
+                aria-label={t`Copy ID to clipboard`}
               >
-                <MoreVerticalIcon className='h-5 w-5' aria-hidden='true' />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align='end'>
-              <DropdownMenuGroup>
-                <DropdownMenuItem
-                  className='cursor-pointer'
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleVisibility();
-                  }}
-                >
-                  {item.visible ? (
-                    <EyeOff className='mr-2 h-4 w-4' aria-hidden='true' />
-                  ) : (
-                    <EyeIcon className='mr-2 h-4 w-4' aria-hidden='true' />
-                  )}
-                  <span>{item.visible ? t`Hide` : t`Show`}</span>
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+                <Copy className='mr-2 h-4 w-4' />
+                <span>
+                  <Trans>Copy ID</Trans>
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/src/components/NftGroupCard.tsx
+++ b/src/components/NftGroupCard.tsx
@@ -6,6 +6,7 @@ import {
   EyeIcon,
   EyeOff,
   Icon,
+  icons,
   LibraryBig,
   MoreVerticalIcon,
   Paintbrush,
@@ -156,8 +157,9 @@ export function NftGroupCard({
             {item?.icon ? (
               <img
                 src={item.icon}
-                alt=''
+                alt={t`Icon for ${item.name}`}
                 className='object-cover h-full w-full'
+                aria-hidden='true'
               />
             ) : (
             <LibraryBig

--- a/src/components/NftGroupCard.tsx
+++ b/src/components/NftGroupCard.tsx
@@ -40,7 +40,7 @@ interface NftGroupCardProps {
   onToggleVisibility?: () => void;
   isLoading?: boolean;
   error?: Error;
-  showHidden?: boolean;
+  canToggleVisibility?: boolean;
 }
 
 export function NftGroupCard({
@@ -52,6 +52,7 @@ export function NftGroupCard({
   onToggleVisibility = () => {},
   isLoading,
   error,
+  canToggleVisibility = true,
 }: NftGroupCardProps) {
   const navigate = useNavigate();
   const isCollection = type === 'collection';
@@ -249,7 +250,6 @@ export function NftGroupCard({
                       open(`https://mintgarden.io/collections/${getId()}`);
                     }}
                     aria-label={t`View on Mintgarden`}
-                    disabled={true}
                   >
                     <ExternalLink className='mr-2 h-4 w-4' />
                     <span>
@@ -263,6 +263,7 @@ export function NftGroupCard({
                       e.stopPropagation();
                       onToggleVisibility();
                     }}
+                    disabled={!canToggleVisibility}
                   >
                     {item.visible ? (
                       <>

--- a/src/components/NftGroupCard.tsx
+++ b/src/components/NftGroupCard.tsx
@@ -5,6 +5,7 @@ import { Trans } from '@lingui/react/macro';
 import {
   EyeIcon,
   EyeOff,
+  Icon,
   LibraryBig,
   MoreVerticalIcon,
   Paintbrush,
@@ -152,10 +153,19 @@ export function NftGroupCard({
             className='bg-neutral-100 dark:bg-neutral-800 flex items-center justify-center aspect-square'
             aria-hidden='true'
           >
+            {item?.icon ? (
+              <img
+                src={item.icon}
+                alt=''
+                className='object-cover h-full w-full'
+              />
+            ) : (
             <LibraryBig
               className='h-12 w-12 text-neutral-400 dark:text-neutral-600'
               aria-hidden='true'
             />
+            )}
+
           </div>
         ) : (
           <div

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -182,205 +182,183 @@ export function NftOptions({
             </Button>
           )}
 
-          {(group === NftGroupMode.None || isFilteredView) && (
-            <>
-              <Button
-                variant='outline'
-                size='icon'
-                onClick={() => setMultiSelect(!multiSelect)}
-                aria-label={t`Toggle multi-select`}
-                title={t`Toggle multi-select`}
-              >
-                <CopyPlus
-                  className={`h-4 w-4 ${multiSelect ? 'text-green-600 dark:text-green-400' : ''}`}
-                  aria-hidden='true'
-                />
-              </Button>
+          <Button
+            variant='outline'
+            size='icon'
+            onClick={() => setMultiSelect(!multiSelect)}
+            aria-label={t`Toggle multi-select`}
+            title={t`Toggle multi-select`}
+            disabled={!(group === NftGroupMode.None || isFilteredView)}
+          >
+            <CopyPlus
+              className={`h-4 w-4 ${multiSelect ? 'text-green-600 dark:text-green-400' : ''}`}
+              aria-hidden='true'
+            />
+          </Button>
 
+          <Button
+            variant='outline'
+            size='icon'
+            onClick={() => setParams({ showHidden: !showHidden })}
+            aria-label={showHidden ? t`Hide hidden items` : t`Show hidden items`}
+            title={showHidden ? t`Hide hidden items` : t`Show hidden items`}
+            disabled={!(group === NftGroupMode.None || isFilteredView || group === NftGroupMode.Collection)}
+          >
+            {showHidden ? (
+              <EyeIcon className='h-4 w-4' aria-hidden='true' />
+            ) : (
+              <EyeOff className='h-4 w-4' aria-hidden='true' />
+            )}
+          </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <Button
                 variant='outline'
                 size='icon'
-                onClick={() => setParams({ showHidden: !showHidden })}
-                aria-label={
-                  showHidden ? t`Hide hidden items` : t`Show hidden items`
-                }
-                title={showHidden ? t`Hide hidden items` : t`Show hidden items`}
+                aria-label={sortLabel}
+                title={sortLabel}
+                disabled={!(group === NftGroupMode.None || isFilteredView)}
               >
-                {showHidden ? (
-                  <EyeIcon className='h-4 w-4' aria-hidden='true' />
+                {sort === NftSortMode.Name ? (
+                  <ArrowDownAz className='h-4 w-4' aria-hidden='true' />
                 ) : (
-                  <EyeOff className='h-4 w-4' aria-hidden='true' />
+                  <Clock2 className='h-4 w-4' aria-hidden='true' />
                 )}
               </Button>
-
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant='outline'
-                    size='icon'
-                    aria-label={sortLabel}
-                    title={sortLabel}
-                  >
-                    {sort === NftSortMode.Name ? (
-                      <ArrowDownAz className='h-4 w-4' aria-hidden='true' />
-                    ) : (
-                      <Clock2 className='h-4 w-4' aria-hidden='true' />
-                    )}
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align='end'>
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
-                      className='cursor-pointer'
-                      onClick={() =>
-                        setParams({ sort: NftSortMode.Name, page: 1 })
-                      }
-                      aria-label={t`Sort by name`}
-                    >
-                      <ArrowDownAz
-                        className='mr-2 h-4 w-4'
-                        aria-hidden='true'
-                      />
-                      <span>
-                        <Trans>Name</Trans>
-                      </span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className='cursor-pointer'
-                      onClick={() =>
-                        setParams({ sort: NftSortMode.Recent, page: 1 })
-                      }
-                      aria-label={t`Sort by recent`}
-                    >
-                      <Clock2 className='mr-2 h-4 w-4' aria-hidden='true' />
-                      <span>
-                        <Trans>Recent</Trans>
-                      </span>
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </>
-          )}
-
-          {!isCollection && !isFilteredView && (
-            <>
-              {group === NftGroupMode.Collection && (
-                <Button
-                  variant='outline'
-                  size='icon'
-                  onClick={() => setParams({ showHidden: !showHidden })}
-                  aria-label={showHidden ? t`Hide hidden items` : t`Show hidden items`}
-                  title={showHidden ? t`Hide hidden items` : t`Show hidden items`}
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuGroup>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  onClick={() =>
+                    setParams({ sort: NftSortMode.Name, page: 1 })
+                  }
+                  aria-label={t`Sort by name`}
                 >
-                  {showHidden ? (
-                    <EyeIcon className='h-4 w-4' aria-hidden='true' />
-                  ) : (
-                    <EyeOff className='h-4 w-4' aria-hidden='true' />
-                  )}
-                </Button>
-              )}
+                  <ArrowDownAz
+                    className='mr-2 h-4 w-4'
+                    aria-hidden='true'
+                  />
+                  <span>
+                    <Trans>Name</Trans>
+                  </span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  onClick={() =>
+                    setParams({ sort: NftSortMode.Recent, page: 1 })
+                  }
+                  aria-label={t`Sort by recent`}
+                >
+                  <Clock2 className='mr-2 h-4 w-4' aria-hidden='true' />
+                  <span>
+                    <Trans>Recent</Trans>
+                  </span>
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant='outline'
-                    size='icon'
-                    aria-label={groupLabel}
-                    title={groupLabel}
-                  >
-                    {group === NftGroupMode.Collection ? (
-                      <LibraryBigIcon className='h-4 w-4' aria-hidden='true' />
-                    ) : group === NftGroupMode.OwnerDid ? (
-                      <UserIcon className='h-4 w-4' aria-hidden='true' />
-                    ) : group === NftGroupMode.MinterDid ? (
-                      <Paintbrush className='h-4 w-4' aria-hidden='true' />
-                    ) : (
-                      <LayoutGrid className='h-4 w-4' aria-hidden='true' />
-                    )}
-                  </Button>
-                </DropdownMenuTrigger>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant='outline'
+                size='icon'
+                aria-label={groupLabel}
+                title={groupLabel}
+                disabled={isCollection || isFilteredView}
+              >
+                {group === NftGroupMode.Collection ? (
+                  <LibraryBigIcon className='h-4 w-4' aria-hidden='true' />
+                ) : group === NftGroupMode.OwnerDid ? (
+                  <UserIcon className='h-4 w-4' aria-hidden='true' />
+                ) : group === NftGroupMode.MinterDid ? (
+                  <Paintbrush className='h-4 w-4' aria-hidden='true' />
+                ) : (
+                  <LayoutGrid className='h-4 w-4' aria-hidden='true' />
+                )}
+              </Button>
+            </DropdownMenuTrigger>
 
-                <DropdownMenuContent align='end'>
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
-                      className='cursor-pointer'
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setParams({
-                          page: 1,
-                          group: NftGroupMode.None,
-                        });
-                      }}
-                      aria-label={t`No Grouping`}
-                    >
-                      <LayoutGrid className='mr-2 h-4 w-4' aria-hidden='true' />
-                      <span>
-                        <Trans>No Grouping</Trans>
-                      </span>
-                    </DropdownMenuItem>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuGroup>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setParams({
+                      page: 1,
+                      group: NftGroupMode.None,
+                    });
+                  }}
+                  aria-label={t`No Grouping`}
+                >
+                  <LayoutGrid className='mr-2 h-4 w-4' aria-hidden='true' />
+                  <span>
+                    <Trans>No Grouping</Trans>
+                  </span>
+                </DropdownMenuItem>
 
-                    <DropdownMenuItem
-                      className='cursor-pointer'
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setParams({
-                          page: 1,
-                          group: NftGroupMode.Collection,
-                          query: '',
-                        });
-                      }}
-                      aria-label={t`Group by Collections`}
-                    >
-                      <LibraryBigIcon
-                        className='mr-2 h-4 w-4'
-                        aria-hidden='true'
-                      />
-                      <span>
-                        <Trans>Group by Collections</Trans>
-                      </span>
-                    </DropdownMenuItem>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setParams({
+                      page: 1,
+                      group: NftGroupMode.Collection,
+                      query: '',
+                    });
+                  }}
+                  aria-label={t`Group by Collections`}
+                >
+                  <LibraryBigIcon
+                    className='mr-2 h-4 w-4'
+                    aria-hidden='true'
+                  />
+                  <span>
+                    <Trans>Group by Collections</Trans>
+                  </span>
+                </DropdownMenuItem>
 
-                    <DropdownMenuItem
-                      className='cursor-pointer'
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setParams({
-                          page: 1,
-                          group: NftGroupMode.OwnerDid,
-                          query: '',
-                        });
-                      }}
-                      aria-label={t`Group by Owners`}
-                    >
-                      <UserIcon className='mr-2 h-4 w-4' aria-hidden='true' />
-                      <span>
-                        <Trans>Group by Owners</Trans>
-                      </span>
-                    </DropdownMenuItem>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setParams({
+                      page: 1,
+                      group: NftGroupMode.OwnerDid,
+                      query: '',
+                    });
+                  }}
+                  aria-label={t`Group by Owners`}
+                >
+                  <UserIcon className='mr-2 h-4 w-4' aria-hidden='true' />
+                  <span>
+                    <Trans>Group by Owners</Trans>
+                  </span>
+                </DropdownMenuItem>
 
-                    <DropdownMenuItem
-                      className='cursor-pointer'
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setParams({
-                          page: 1,
-                          group: NftGroupMode.MinterDid,
-                          query: '',
-                        });
-                      }}
-                      aria-label={t`Group by Minters`}
-                    >
-                      <Paintbrush className='mr-2 h-4 w-4' aria-hidden='true' />
-                      <span>
-                        <Trans>Group by Minters</Trans>
-                      </span>
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </>
-          )}
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setParams({
+                      page: 1,
+                      group: NftGroupMode.MinterDid,
+                      query: '',
+                    });
+                  }}
+                  aria-label={t`Group by Minters`}
+                >
+                  <Paintbrush className='mr-2 h-4 w-4' aria-hidden='true' />
+                  <span>
+                    <Trans>Group by Minters</Trans>
+                  </span>
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
     </div>

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { Input } from './ui/input';
+import { cn } from '@/lib/utils';
 
 export interface NftOptionsProps {
   isCollection?: boolean;
@@ -201,10 +202,9 @@ export function NftOptions({
                 size='icon'
                 onClick={() => setParams({ showHidden: !showHidden })}
                 aria-label={
-                  showHidden ? t`Hide hidden NFTs` : t`Show hidden NFTs`
+                  showHidden ? t`Hide hidden items` : t`Show hidden items`
                 }
-                aria-pressed={showHidden}
-                title={showHidden ? t`Hide hidden NFTs` : t`Show hidden NFTs`}
+                title={showHidden ? t`Hide hidden items` : t`Show hidden items`}
               >
                 {showHidden ? (
                   <EyeIcon className='h-4 w-4' aria-hidden='true' />
@@ -264,104 +264,122 @@ export function NftOptions({
           )}
 
           {!isCollection && !isFilteredView && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
+            <>
+              {group === NftGroupMode.Collection && (
                 <Button
                   variant='outline'
                   size='icon'
-                  aria-label={groupLabel}
-                  title={groupLabel}
+                  onClick={() => setParams({ showHidden: !showHidden })}
+                  aria-label={showHidden ? t`Hide hidden items` : t`Show hidden items`}
+                  title={showHidden ? t`Hide hidden items` : t`Show hidden items`}
                 >
-                  {group === NftGroupMode.Collection ? (
-                    <LibraryBigIcon className='h-4 w-4' aria-hidden='true' />
-                  ) : group === NftGroupMode.OwnerDid ? (
-                    <UserIcon className='h-4 w-4' aria-hidden='true' />
-                  ) : group === NftGroupMode.MinterDid ? (
-                    <Paintbrush className='h-4 w-4' aria-hidden='true' />
+                  {showHidden ? (
+                    <EyeIcon className='h-4 w-4' aria-hidden='true' />
                   ) : (
-                    <LayoutGrid className='h-4 w-4' aria-hidden='true' />
+                    <EyeOff className='h-4 w-4' aria-hidden='true' />
                   )}
                 </Button>
-              </DropdownMenuTrigger>
+              )}
 
-              <DropdownMenuContent align='end'>
-                <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    className='cursor-pointer'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setParams({
-                        page: 1,
-                        group: NftGroupMode.None,
-                      });
-                    }}
-                    aria-label={t`No Grouping`}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    aria-label={groupLabel}
+                    title={groupLabel}
                   >
-                    <LayoutGrid className='mr-2 h-4 w-4' aria-hidden='true' />
-                    <span>
-                      <Trans>No Grouping</Trans>
-                    </span>
-                  </DropdownMenuItem>
+                    {group === NftGroupMode.Collection ? (
+                      <LibraryBigIcon className='h-4 w-4' aria-hidden='true' />
+                    ) : group === NftGroupMode.OwnerDid ? (
+                      <UserIcon className='h-4 w-4' aria-hidden='true' />
+                    ) : group === NftGroupMode.MinterDid ? (
+                      <Paintbrush className='h-4 w-4' aria-hidden='true' />
+                    ) : (
+                      <LayoutGrid className='h-4 w-4' aria-hidden='true' />
+                    )}
+                  </Button>
+                </DropdownMenuTrigger>
 
-                  <DropdownMenuItem
-                    className='cursor-pointer'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setParams({
-                        page: 1,
-                        group: NftGroupMode.Collection,
-                        query: '',
-                      });
-                    }}
-                    aria-label={t`Group by Collections`}
-                  >
-                    <LibraryBigIcon
-                      className='mr-2 h-4 w-4'
-                      aria-hidden='true'
-                    />
-                    <span>
-                      <Trans>Group by Collections</Trans>
-                    </span>
-                  </DropdownMenuItem>
+                <DropdownMenuContent align='end'>
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem
+                      className='cursor-pointer'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setParams({
+                          page: 1,
+                          group: NftGroupMode.None,
+                        });
+                      }}
+                      aria-label={t`No Grouping`}
+                    >
+                      <LayoutGrid className='mr-2 h-4 w-4' aria-hidden='true' />
+                      <span>
+                        <Trans>No Grouping</Trans>
+                      </span>
+                    </DropdownMenuItem>
 
-                  <DropdownMenuItem
-                    className='cursor-pointer'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setParams({
-                        page: 1,
-                        group: NftGroupMode.OwnerDid,
-                        query: '',
-                      });
-                    }}
-                    aria-label={t`Group by Owners`}
-                  >
-                    <UserIcon className='mr-2 h-4 w-4' aria-hidden='true' />
-                    <span>
-                      <Trans>Group by Owners</Trans>
-                    </span>
-                  </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className='cursor-pointer'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setParams({
+                          page: 1,
+                          group: NftGroupMode.Collection,
+                          query: '',
+                        });
+                      }}
+                      aria-label={t`Group by Collections`}
+                    >
+                      <LibraryBigIcon
+                        className='mr-2 h-4 w-4'
+                        aria-hidden='true'
+                      />
+                      <span>
+                        <Trans>Group by Collections</Trans>
+                      </span>
+                    </DropdownMenuItem>
 
-                  <DropdownMenuItem
-                    className='cursor-pointer'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setParams({
-                        page: 1,
-                        group: NftGroupMode.MinterDid,
-                        query: '',
-                      });
-                    }}
-                    aria-label={t`Group by Minters`}
-                  >
-                    <Paintbrush className='mr-2 h-4 w-4' aria-hidden='true' />
-                    <span>
-                      <Trans>Group by Minters</Trans>
-                    </span>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                    <DropdownMenuItem
+                      className='cursor-pointer'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setParams({
+                          page: 1,
+                          group: NftGroupMode.OwnerDid,
+                          query: '',
+                        });
+                      }}
+                      aria-label={t`Group by Owners`}
+                    >
+                      <UserIcon className='mr-2 h-4 w-4' aria-hidden='true' />
+                      <span>
+                        <Trans>Group by Owners</Trans>
+                      </span>
+                    </DropdownMenuItem>
+
+                    <DropdownMenuItem
+                      className='cursor-pointer'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setParams({
+                          page: 1,
+                          group: NftGroupMode.MinterDid,
+                          query: '',
+                        });
+                      }}
+                      aria-label={t`Group by Minters`}
+                    >
+                      <Paintbrush className='mr-2 h-4 w-4' aria-hidden='true' />
+                      <span>
+                        <Trans>Group by Minters</Trans>
+                      </span>
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </>
           )}
         </div>
       </div>

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -199,9 +199,17 @@ export function NftOptions({
             variant='outline'
             size='icon'
             onClick={() => setParams({ showHidden: !showHidden })}
-            aria-label={showHidden ? t`Hide hidden items` : t`Show hidden items`}
+            aria-label={
+              showHidden ? t`Hide hidden items` : t`Show hidden items`
+            }
             title={showHidden ? t`Hide hidden items` : t`Show hidden items`}
-            disabled={!(group === NftGroupMode.None || isFilteredView || group === NftGroupMode.Collection)}
+            disabled={
+              !(
+                group === NftGroupMode.None ||
+                isFilteredView ||
+                group === NftGroupMode.Collection
+              )
+            }
           >
             {showHidden ? (
               <EyeIcon className='h-4 w-4' aria-hidden='true' />
@@ -230,15 +238,10 @@ export function NftOptions({
               <DropdownMenuGroup>
                 <DropdownMenuItem
                   className='cursor-pointer'
-                  onClick={() =>
-                    setParams({ sort: NftSortMode.Name, page: 1 })
-                  }
+                  onClick={() => setParams({ sort: NftSortMode.Name, page: 1 })}
                   aria-label={t`Sort by name`}
                 >
-                  <ArrowDownAz
-                    className='mr-2 h-4 w-4'
-                    aria-hidden='true'
-                  />
+                  <ArrowDownAz className='mr-2 h-4 w-4' aria-hidden='true' />
                   <span>
                     <Trans>Name</Trans>
                   </span>
@@ -311,10 +314,7 @@ export function NftOptions({
                   }}
                   aria-label={t`Group by Collections`}
                 >
-                  <LibraryBigIcon
-                    className='mr-2 h-4 w-4'
-                    aria-hidden='true'
-                  />
+                  <LibraryBigIcon className='mr-2 h-4 w-4' aria-hidden='true' />
                   <span>
                     <Trans>Group by Collections</Trans>
                   </span>

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -32,7 +32,6 @@ import {
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { Input } from './ui/input';
-import { cn } from '@/lib/utils';
 
 export interface NftOptionsProps {
   isCollection?: boolean;

--- a/src/pages/NftList.tsx
+++ b/src/pages/NftList.tsx
@@ -8,7 +8,7 @@ import { ReceiveAddress } from '@/components/ReceiveAddress';
 import { Button } from '@/components/ui/button';
 import { useNftParams, NftGroupMode } from '@/hooks/useNftParams';
 import { Trans } from '@lingui/react/macro';
-import { ImagePlusIcon } from 'lucide-react';
+import { ImagePlusIcon, EyeIcon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useNftData } from '@/hooks/useNftData';


### PR DESCRIPTION
This adds some imrpovements to the view that groups NFTs by collection

- hide/show collection option
- Copy collection id (for minter group cards too)
- view on mintgarden
- display the mintgarden logo on the group card (part of https://github.com/xch-dev/sage/issues/158 and https://github.com/xch-dev/sage/issues/71)

Also made it so view option buttons on that entire page are always visible but get disabled when not applicable. less confusing ux
