### PR TITLE
add onBlur handler to compensate for no onChange after a paste

### DIFF
--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -542,7 +542,13 @@ function AssetSelector({
                 className='border-l-0 z-10 rounded-l-none rounded-r-none w-[100px] h-12'
                 placeholder={t`Amount`}
                 value={cat.amount}
+                onBlur={(e) => {
+                  console.log('onBlur CAT' + e.target.value);
+                  assets.cats[i].amount = e.target.value;
+                  setAssets({ ...assets });
+                }}
                 onChange={(e) => {
+                  console.log('onChange CAT' + e.target.value);
                   assets.cats[i].amount = e.target.value;
                   setAssets({ ...assets });
                 }}

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -176,12 +176,15 @@ export function MakeOffer() {
                 <Trans>Network Fee</Trans>
               </Label>
               <div className='relative'>
-                <Input
+                <TokenAmountInput
                   id='fee'
                   type='text'
                   placeholder={'0.00'}
                   className='pr-12'
                   value={state.fee}
+                  onBlur={(e) =>
+                    useOfferState.setState({ fee: e.target.value })
+                  }
                   onChange={(e) =>
                     useOfferState.setState({ fee: e.target.value })
                   }
@@ -449,11 +452,12 @@ function AssetSelector({
         <div className='mt-4 flex flex-col space-y-1.5'>
           <Label htmlFor={`${prefix}-amount`}>XCH</Label>
           <div className='flex'>
-            <Input
+            <TokenAmountInput
               id={`${prefix}-amount`}
               className='rounded-r-none z-10'
               placeholder={t`Enter amount`}
               value={assets.xch}
+              onBlur={(e) => setAssets({ ...assets, xch: e.target.value })}
               onChange={(e) => setAssets({ ...assets, xch: e.target.value })}
             />
             <Button

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -543,12 +543,10 @@ function AssetSelector({
                 placeholder={t`Amount`}
                 value={cat.amount}
                 onBlur={(e) => {
-                  console.log('onBlur CAT' + e.target.value);
                   assets.cats[i].amount = e.target.value;
                   setAssets({ ...assets });
                 }}
                 onChange={(e) => {
-                  console.log('onChange CAT' + e.target.value);
                   assets.cats[i].amount = e.target.value;
                   setAssets({ ...assets });
                 }}


### PR DESCRIPTION
Fix https://github.com/xch-dev/sage/issues/315

`MaskedInput` is not raising `onChange` when a value that gets masked is pasted. Specically, if a value like " 1.0" is pasted this handler isn't being triggered.

https://github.com/uNmAnNeR/imaskjs/issues/1063

```
onChange={(e) => {
  assets.cats[i].amount = e.target.value;
  setAssets({ ...assets });
}}
```

Since that is idempotent, adding an identical `onBlur` handler seems to work around this limitation.

Video showing repro steps. The value pasted is " 111.11", the leading non-numeric value is the trigger.

https://share.icloud.com/photos/0f5XhZUHCc7mOZ4uXJQdQn7eg

