### PR TITLE
Default offer expiry

### DIFF
--- a/src/hooks/useDefaultOfferExpiry.ts
+++ b/src/hooks/useDefaultOfferExpiry.ts
@@ -1,62 +1,62 @@
 import { useLocalStorage } from 'usehooks-ts';
 
 export interface DefaultOfferExpiry {
-    enabled: boolean;
-    days: string;
-    hours: string;
-    minutes: string;
+  enabled: boolean;
+  days: string;
+  hours: string;
+  minutes: string;
 }
 
 const validateNumber = (value: string): string => {
-    if (!value) return '';
-    const num = parseInt(value);
-    if (isNaN(num) || num < 0) return '';
-    return num.toString();
+  if (!value) return '';
+  const num = parseInt(value);
+  if (isNaN(num) || num < 0) return '';
+  return num.toString();
 };
 
 const validateExpiry = (expiry: DefaultOfferExpiry): DefaultOfferExpiry => {
-    return {
-        enabled: expiry.enabled,
-        days: validateNumber(expiry.days),
-        hours: validateNumber(expiry.hours),
-        minutes: validateNumber(expiry.minutes)
-    };
+  return {
+    enabled: expiry.enabled,
+    days: validateNumber(expiry.days),
+    hours: validateNumber(expiry.hours),
+    minutes: validateNumber(expiry.minutes),
+  };
 };
 
 export function useDefaultOfferExpiry() {
-    const [expiry, setExpiry] = useLocalStorage<DefaultOfferExpiry>(
-        'default-offer-expiry',
-        {
-            enabled: false,
-            days: '1',
-            hours: '',
-            minutes: '',
-        }
-    );
+  const [expiry, setExpiry] = useLocalStorage<DefaultOfferExpiry>(
+    'default-offer-expiry',
+    {
+      enabled: false,
+      days: '1',
+      hours: '',
+      minutes: '',
+    },
+  );
 
-    // Ensure stored values are valid on load
-    const validatedExpiry = validateExpiry(expiry);
+  // Ensure stored values are valid on load
+  const validatedExpiry = validateExpiry(expiry);
 
-    const setValidatedExpiry = (newExpiry: DefaultOfferExpiry) => {
-        setExpiry(validateExpiry(newExpiry));
-    };
+  const setValidatedExpiry = (newExpiry: DefaultOfferExpiry) => {
+    setExpiry(validateExpiry(newExpiry));
+  };
 
-    // Calculate total seconds
-    const getTotalSeconds = (): number | null => {
-        if (!validatedExpiry.enabled) return null;
+  // Calculate total seconds
+  const getTotalSeconds = (): number | null => {
+    if (!validatedExpiry.enabled) return null;
 
-        // the || operates on the result of parseInt, so if parseInt returns NaN, 
-        // it will return 1 etc. because NaN is falsy
-        const days = parseInt(validatedExpiry.days) || 1;
-        const hours = parseInt(validatedExpiry.hours) || 0;
-        const minutes = parseInt(validatedExpiry.minutes) || 0;
+    // the || operates on the result of parseInt, so if parseInt returns NaN,
+    // it will return 1 etc. because NaN is falsy
+    const days = parseInt(validatedExpiry.days) || 1;
+    const hours = parseInt(validatedExpiry.hours) || 0;
+    const minutes = parseInt(validatedExpiry.minutes) || 0;
 
-        return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60;
-    };
+    return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60;
+  };
 
-    return {
-        expiry: validatedExpiry,
-        setExpiry: setValidatedExpiry,
-        getTotalSeconds
-    };
-} 
+  return {
+    expiry: validatedExpiry,
+    setExpiry: setValidatedExpiry,
+    getTotalSeconds,
+  };
+}

--- a/src/hooks/useDefaultOfferExpiry.ts
+++ b/src/hooks/useDefaultOfferExpiry.ts
@@ -1,0 +1,62 @@
+import { useLocalStorage } from 'usehooks-ts';
+
+export interface DefaultOfferExpiry {
+    enabled: boolean;
+    days: string;
+    hours: string;
+    minutes: string;
+}
+
+const validateNumber = (value: string): string => {
+    if (!value) return '';
+    const num = parseInt(value);
+    if (isNaN(num) || num < 0) return '';
+    return num.toString();
+};
+
+const validateExpiry = (expiry: DefaultOfferExpiry): DefaultOfferExpiry => {
+    return {
+        enabled: expiry.enabled,
+        days: validateNumber(expiry.days),
+        hours: validateNumber(expiry.hours),
+        minutes: validateNumber(expiry.minutes)
+    };
+};
+
+export function useDefaultOfferExpiry() {
+    const [expiry, setExpiry] = useLocalStorage<DefaultOfferExpiry>(
+        'default-offer-expiry',
+        {
+            enabled: false,
+            days: '1',
+            hours: '',
+            minutes: '',
+        }
+    );
+
+    // Ensure stored values are valid on load
+    const validatedExpiry = validateExpiry(expiry);
+
+    const setValidatedExpiry = (newExpiry: DefaultOfferExpiry) => {
+        setExpiry(validateExpiry(newExpiry));
+    };
+
+    // Calculate total seconds
+    const getTotalSeconds = (): number | null => {
+        if (!validatedExpiry.enabled) return null;
+
+        // the || operates on the result of parseInt, so if parseInt returns NaN, 
+        // it will return 1 etc. because NaN is falsy
+        const days = parseInt(validatedExpiry.days) || 1;
+        const hours = parseInt(validatedExpiry.hours) || 0;
+        const minutes = parseInt(validatedExpiry.minutes) || 0;
+
+        return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60;
+    };
+
+    return {
+        expiry: validatedExpiry,
+        setExpiry: setValidatedExpiry,
+        getTotalSeconds
+    };
+} 

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -83,7 +83,7 @@ export function MakeOffer() {
         },
       });
     }
-  }, [defaultOfferExpiry]);
+  }, [defaultOfferExpiry, state.expiration]);
 
   const handleMake = async () => {
     setPending(true);

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -35,6 +35,8 @@ import {
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useLocalStorage } from 'usehooks-ts';
+import { DefaultOfferExpiry } from './Settings';
 
 export function MakeOffer() {
   const state = useOfferState();
@@ -52,6 +54,16 @@ export function MakeOffer() {
   const [config, setConfig] = useState<NetworkConfig | null>(null);
   const network = config?.network_id ?? 'mainnet';
 
+  const [defaultOfferExpiry] = useLocalStorage<DefaultOfferExpiry>(
+    'default-offer-expiry',
+    {
+      enabled: false,
+      days: '1',
+      hours: '',
+      minutes: '',
+    },
+  );
+
   useEffect(() => {
     commands.networkConfig().then((config) => setConfig(config));
   }, []);
@@ -60,6 +72,18 @@ export function MakeOffer() {
     setDexieLink('');
     setMintGardenLink('');
   }, [offer]);
+
+  useEffect(() => {
+    if (defaultOfferExpiry.enabled && state.expiration === null) {
+      useOfferState.setState({
+        expiration: {
+          days: defaultOfferExpiry.days,
+          hours: defaultOfferExpiry.hours,
+          minutes: defaultOfferExpiry.minutes,
+        },
+      });
+    }
+  }, [defaultOfferExpiry]);
 
   const handleMake = async () => {
     setPending(true);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -34,7 +34,7 @@ import {
 } from '../bindings';
 import { isValidU32 } from '../validation';
 import { getVersion } from '@tauri-apps/api/app';
-import { useLocalStorage } from 'usehooks-ts';
+import { useDefaultOfferExpiry } from '@/hooks/useDefaultOfferExpiry';
 
 export interface DefaultOfferExpiry {
   enabled: boolean;
@@ -73,13 +73,7 @@ function GlobalSettings() {
   const { dark, setDark } = useContext(DarkModeContext);
   const { locale, changeLanguage } = useLanguage();
 
-  const [defaultOfferExpiry, setDefaultOfferExpiry] =
-    useLocalStorage<DefaultOfferExpiry>('default-offer-expiry', {
-      enabled: false,
-      days: '1',
-      hours: '',
-      minutes: '',
-    });
+  const { expiry, setExpiry } = useDefaultOfferExpiry();
 
   return (
     <Card>
@@ -124,10 +118,10 @@ function GlobalSettings() {
               </label>
               <Switch
                 id='default-offer-expiry'
-                checked={defaultOfferExpiry.enabled}
+                checked={expiry.enabled}
                 onCheckedChange={(checked) => {
-                  setDefaultOfferExpiry({
-                    ...defaultOfferExpiry,
+                  setExpiry({
+                    ...expiry,
                     enabled: checked,
                     days: checked ? '1' : '',
                   });
@@ -135,16 +129,16 @@ function GlobalSettings() {
               />
             </div>
 
-            {defaultOfferExpiry.enabled && (
+            {expiry.enabled && (
               <div className='flex gap-2'>
                 <div className='relative'>
                   <Input
                     className='pr-12'
-                    value={defaultOfferExpiry.days}
+                    value={expiry.days}
                     placeholder='0'
                     onChange={(e) => {
-                      setDefaultOfferExpiry({
-                        ...defaultOfferExpiry,
+                      setExpiry({
+                        ...expiry,
                         days: e.target.value,
                       });
                     }}
@@ -159,11 +153,11 @@ function GlobalSettings() {
                 <div className='relative'>
                   <Input
                     className='pr-12'
-                    value={defaultOfferExpiry.hours}
+                    value={expiry.hours}
                     placeholder='0'
                     onChange={(e) => {
-                      setDefaultOfferExpiry({
-                        ...defaultOfferExpiry,
+                      setExpiry({
+                        ...expiry,
                         hours: e.target.value,
                       });
                     }}
@@ -178,11 +172,11 @@ function GlobalSettings() {
                 <div className='relative'>
                   <Input
                     className='pr-12'
-                    value={defaultOfferExpiry.minutes}
+                    value={expiry.minutes}
                     placeholder='0'
                     onChange={(e) => {
-                      setDefaultOfferExpiry({
-                        ...defaultOfferExpiry,
+                      setExpiry({
+                        ...expiry,
                         minutes: e.target.value,
                       });
                     }}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -34,6 +34,14 @@ import {
 } from '../bindings';
 import { isValidU32 } from '../validation';
 import { getVersion } from '@tauri-apps/api/app';
+import { useLocalStorage } from 'usehooks-ts';
+
+export interface DefaultOfferExpiry {
+  enabled: boolean;
+  days: string;
+  hours: string;
+  minutes: string;
+}
 
 export default function Settings() {
   const initialized = useInitialization();
@@ -64,6 +72,14 @@ export default function Settings() {
 function GlobalSettings() {
   const { dark, setDark } = useContext(DarkModeContext);
   const { locale, changeLanguage } = useLanguage();
+
+  const [defaultOfferExpiry, setDefaultOfferExpiry] =
+    useLocalStorage<DefaultOfferExpiry>('default-offer-expiry', {
+      enabled: false,
+      days: '1',
+      hours: '',
+      minutes: '',
+    });
 
   return (
     <Card>
@@ -99,6 +115,87 @@ function GlobalSettings() {
               <SelectItem value='zh-CN'>Chinese</SelectItem>
             </SelectContent>
           </Select>
+        </div>
+        <div className='grid gap-3'>
+          <div className='flex flex-col gap-2'>
+            <div className='flex items-center gap-2'>
+              <label htmlFor='default-offer-expiry'>
+                <Trans>Default Offer Expiry</Trans>
+              </label>
+              <Switch
+                id='default-offer-expiry'
+                checked={defaultOfferExpiry.enabled}
+                onCheckedChange={(checked) => {
+                  setDefaultOfferExpiry({
+                    ...defaultOfferExpiry,
+                    enabled: checked,
+                    days: checked ? '1' : '',
+                  });
+                }}
+              />
+            </div>
+
+            {defaultOfferExpiry.enabled && (
+              <div className='flex gap-2'>
+                <div className='relative'>
+                  <Input
+                    className='pr-12'
+                    value={defaultOfferExpiry.days}
+                    placeholder='0'
+                    onChange={(e) => {
+                      setDefaultOfferExpiry({
+                        ...defaultOfferExpiry,
+                        days: e.target.value,
+                      });
+                    }}
+                  />
+                  <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
+                    <span className='text-gray-500 text-sm'>
+                      <Trans>Days</Trans>
+                    </span>
+                  </div>
+                </div>
+
+                <div className='relative'>
+                  <Input
+                    className='pr-12'
+                    value={defaultOfferExpiry.hours}
+                    placeholder='0'
+                    onChange={(e) => {
+                      setDefaultOfferExpiry({
+                        ...defaultOfferExpiry,
+                        hours: e.target.value,
+                      });
+                    }}
+                  />
+                  <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
+                    <span className='text-gray-500 text-sm'>
+                      <Trans>Hours</Trans>
+                    </span>
+                  </div>
+                </div>
+
+                <div className='relative'>
+                  <Input
+                    className='pr-12'
+                    value={defaultOfferExpiry.minutes}
+                    placeholder='0'
+                    onChange={(e) => {
+                      setDefaultOfferExpiry({
+                        ...defaultOfferExpiry,
+                        minutes: e.target.value,
+                      });
+                    }}
+                  />
+                  <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
+                    <span className='text-gray-500 text-sm'>
+                      <Trans>Minutes</Trans>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
Fixes: https://github.com/xch-dev/sage/issues/319

- adds a setting for default offer expiry to the settings page
- defaults to off
- when enabled defaults to 1 day
- saved in local storage
- the setting is consumed by `MakeOffer.tsx`