### PR TITLE
Fix default expiry

### DIFF
--- a/src/components/ui/masked-input.tsx
+++ b/src/components/ui/masked-input.tsx
@@ -78,4 +78,35 @@ const TokenAmountInput = React.forwardRef<HTMLInputElement, XchInputProps>(
 
 TokenAmountInput.displayName = 'TokenAmountInput';
 
-export { MaskedInput, TokenAmountInput };
+// Integer input that only accepts positive integers
+interface IntegerInputProps extends MaskedInputProps {
+  min?: number;
+  max?: number;
+}
+
+const IntegerInput = React.forwardRef<HTMLInputElement, IntegerInputProps>(
+  ({ min = 0, max, ...props }, ref) => (
+    <MaskedInput
+      placeholder='0'
+      {...props}
+      type='text'
+      inputRef={ref}
+      decimalScale={0}
+      allowLeadingZeros={false}
+      allowNegative={false}
+      isAllowed={(values) => {
+        const { floatValue } = values;
+        if (floatValue === undefined) return true;
+
+        if (min !== undefined && floatValue < min) return false;
+        if (max !== undefined && floatValue > max) return false;
+
+        return true;
+      }}
+    />
+  ),
+);
+
+IntegerInput.displayName = 'IntegerInput';
+
+export { MaskedInput, TokenAmountInput, IntegerInput };

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -18,7 +18,7 @@ import {
 import { ErrorKind } from '../bindings';
 
 export interface CustomError {
-  kind: ErrorKind | 'walletconnect' | 'upload';
+  kind: ErrorKind | 'walletconnect' | 'upload' | 'invalid';
   reason: string;
 }
 

--- a/src/hooks/useDefaultOfferExpiry.ts
+++ b/src/hooks/useDefaultOfferExpiry.ts
@@ -41,22 +41,8 @@ export function useDefaultOfferExpiry() {
     setExpiry(validateExpiry(newExpiry));
   };
 
-  // Calculate total seconds
-  const getTotalSeconds = (): number | null => {
-    if (!validatedExpiry.enabled) return null;
-
-    // the || operates on the result of parseInt, so if parseInt returns NaN,
-    // it will return 1 etc. because NaN is falsy
-    const days = parseInt(validatedExpiry.days) || 1;
-    const hours = parseInt(validatedExpiry.hours) || 0;
-    const minutes = parseInt(validatedExpiry.minutes) || 0;
-
-    return days * 24 * 60 * 60 + hours * 60 * 60 + minutes * 60;
-  };
-
   return {
     expiry: validatedExpiry,
-    setExpiry: setValidatedExpiry,
-    getTotalSeconds,
+    setExpiry: setValidatedExpiry
   };
 }

--- a/src/hooks/useDefaultOfferExpiry.ts
+++ b/src/hooks/useDefaultOfferExpiry.ts
@@ -43,6 +43,6 @@ export function useDefaultOfferExpiry() {
 
   return {
     expiry: validatedExpiry,
-    setExpiry: setValidatedExpiry
+    setExpiry: setValidatedExpiry,
   };
 }

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { TokenAmountInput } from '@/components/ui/masked-input';
+import { IntegerInput, TokenAmountInput } from '@/components/ui/masked-input';
 import { Switch } from '@/components/ui/switch';
 import { useErrors } from '@/hooks/useErrors';
 import { uploadToDexie, uploadToMintGarden } from '@/lib/offerUpload';
@@ -156,12 +156,9 @@ export function MakeOffer() {
 
   const invalid =
     state.expiration !== null &&
-    (isNaN(Number(state.expiration.days)) ||
-      isNaN(Number(state.expiration.hours)) ||
-      isNaN(Number(state.expiration.minutes)) ||
-      ((parseInt(state.expiration.days) || 0) === 0 &&
-        (parseInt(state.expiration.hours) || 0) === 0 &&
-        (parseInt(state.expiration.minutes) || 0) === 0));
+    (parseInt(state.expiration.days) || 0) === 0 &&
+    (parseInt(state.expiration.hours) || 0) === 0 &&
+    (parseInt(state.expiration.minutes) || 0) === 0;
 
   return (
     <>
@@ -267,16 +264,17 @@ export function MakeOffer() {
               {state.expiration !== null && (
                 <div className='flex gap-2'>
                   <div className='relative'>
-                    <Input
+                    <IntegerInput
                       className='pr-12'
                       value={state.expiration.days}
                       placeholder='0'
-                      onChange={(e) => {
+                      min={0}
+                      onValueChange={(values) => {
                         if (state.expiration === null) return;
                         useOfferState.setState({
                           expiration: {
                             ...state.expiration,
-                            days: e.target.value,
+                            days: values.value,
                           },
                         });
                       }}
@@ -289,16 +287,17 @@ export function MakeOffer() {
                   </div>
 
                   <div className='relative'>
-                    <Input
+                    <IntegerInput
                       className='pr-12'
                       value={state.expiration.hours}
                       placeholder='0'
-                      onChange={(e) => {
+                      min={0}
+                      onValueChange={(values) => {
                         if (state.expiration === null) return;
                         useOfferState.setState({
                           expiration: {
                             ...state.expiration,
-                            hours: e.target.value,
+                            hours: values.value,
                           },
                         });
                       }}
@@ -311,16 +310,17 @@ export function MakeOffer() {
                   </div>
 
                   <div className='relative'>
-                    <Input
+                    <IntegerInput
                       className='pr-12'
                       value={state.expiration.minutes}
                       placeholder='0'
-                      onChange={(e) => {
+                      min={0}
+                      onValueChange={(values) => {
                         if (state.expiration === null) return;
                         useOfferState.setState({
                           expiration: {
                             ...state.expiration,
-                            minutes: e.target.value,
+                            minutes: values.value,
                           },
                         });
                       }}

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -66,13 +66,20 @@ export function MakeOffer() {
 
   useEffect(() => {
     if (expiry.enabled && state.expiration === null) {
-      useOfferState.setState({
-        expiration: {
-          days: expiry.days.toString(),
-          hours: expiry.hours.toString(),
-          minutes: expiry.minutes.toString(),
-        },
-      });
+      const isAllZero =
+        (parseInt(expiry.days) || 0) === 0 &&
+        (parseInt(expiry.hours) || 0) === 0 &&
+        (parseInt(expiry.minutes) || 0) === 0;
+
+      if (!isAllZero) {
+        useOfferState.setState({
+          expiration: {
+            days: expiry.days.toString(),
+            hours: expiry.hours.toString(),
+            minutes: expiry.minutes.toString(),
+          },
+        });
+      }
     }
   }, [expiry, state.expiration]);
 
@@ -129,7 +136,10 @@ export function MakeOffer() {
     state.expiration !== null &&
     (isNaN(Number(state.expiration.days)) ||
       isNaN(Number(state.expiration.hours)) ||
-      isNaN(Number(state.expiration.minutes)));
+      isNaN(Number(state.expiration.minutes)) ||
+      ((parseInt(state.expiration.days) || 0) === 0 &&
+        (parseInt(state.expiration.hours) || 0) === 0 &&
+        (parseInt(state.expiration.minutes) || 0) === 0));
 
   return (
     <>

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -53,7 +53,7 @@ export function MakeOffer() {
   const [config, setConfig] = useState<NetworkConfig | null>(null);
   const network = config?.network_id ?? 'mainnet';
 
-  const { expiry, getTotalSeconds } = useDefaultOfferExpiry();
+  const { expiry, getTotalSeconds, setExpiry } = useDefaultOfferExpiry();
 
   useEffect(() => {
     commands.networkConfig().then((config) => setConfig(config));
@@ -223,6 +223,10 @@ export function MakeOffer() {
                       });
                     } else {
                       useOfferState.setState({ expiration: null });
+                      if (expiry.enabled) {
+                        const tempExpiry = { ...expiry, enabled: false };
+                        setExpiry(tempExpiry);
+                      }
                     }
                   }}
                 />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { IntegerInput } from '@/components/ui/masked-input';
 import {
   Select,
   SelectContent,
@@ -132,14 +133,15 @@ function GlobalSettings() {
             {expiry.enabled && (
               <div className='flex gap-2'>
                 <div className='relative'>
-                  <Input
+                  <IntegerInput
                     className='pr-12'
                     value={expiry.days}
                     placeholder='0'
-                    onChange={(e) => {
+                    min={0}
+                    onValueChange={(values) => {
                       setExpiry({
                         ...expiry,
-                        days: e.target.value,
+                        days: values.value,
                       });
                     }}
                   />
@@ -151,14 +153,15 @@ function GlobalSettings() {
                 </div>
 
                 <div className='relative'>
-                  <Input
+                  <IntegerInput
                     className='pr-12'
                     value={expiry.hours}
                     placeholder='0'
-                    onChange={(e) => {
+                    min={0}
+                    onValueChange={(values) => {
                       setExpiry({
                         ...expiry,
-                        hours: e.target.value,
+                        hours: values.value,
                       });
                     }}
                   />
@@ -170,14 +173,15 @@ function GlobalSettings() {
                 </div>
 
                 <div className='relative'>
-                  <Input
+                  <IntegerInput
                     className='pr-12'
                     value={expiry.minutes}
                     placeholder='0'
-                    onChange={(e) => {
+                    min={0}
+                    onValueChange={(values) => {
                       setExpiry({
                         ...expiry,
-                        minutes: e.target.value,
+                        minutes: values.value,
                       });
                     }}
                   />


### PR DESCRIPTION
- fix a bug where offer expiry could not be disabled if the default was enabled
- put ui and final data validation logic in `makeOffer` to prevent offers with an expiration of 0 seconds
- only allow positive int input in offer inputs `IntegerInput`