### PR TITLE
Search debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you add or change queries run this command to generate new sqlx SQL files:
 cargo sqlx prepare --workspace
 ```
 
-Schema changes, including new indices, go into the `migrations` folder as SQL DDL scripts. 
+Schema changes, including new indices, go into the `migrations` folder as SQL DDL scripts.
 
 ### Testing
 

--- a/crates/sage-database/src/primitives/nfts.rs
+++ b/crates/sage-database/src/primitives/nfts.rs
@@ -833,137 +833,94 @@ async fn nfts_by_metadata_hash(
     .collect()
 }
 
-fn escape_fts_query(query: &str) -> String {
-    // First escape backslashes by doubling them
-    // Then escape quotes by doubling them
-    // Finally wrap in quotes to treat as literal string
-    let escaped = query.replace('\\', "\\\\").replace('"', "\"\"");
-    format!("\"{escaped}\"")
-}
-
 async fn search_nfts(
     conn: impl SqliteExecutor<'_>,
     params: NftSearchParams,
     limit: u32,
     offset: u32,
 ) -> Result<(Vec<NftRow>, u32)> {
-    let mut conditions = vec!["is_owned = 1"];
-
-    // Group filtering (Collection/DID)
-    match params.group {
-        Some(NftGroup::Collection(_)) => conditions.push("collection_id = ?"),
-        Some(NftGroup::NoCollection) => conditions.push("collection_id IS NULL"),
-        Some(NftGroup::MinterDid(_)) => conditions.push("minter_did = ?"),
-        Some(NftGroup::NoMinterDid) => conditions.push("minter_did IS NULL"),
-        Some(NftGroup::OwnerDid(_)) => conditions.push("owner_did = ?"),
-        Some(NftGroup::NoOwnerDid) => conditions.push("owner_did IS NULL"),
-        None => {}
-    }
-
-    // Visibility condition
-    if !params.include_hidden {
-        conditions.push("visible = 1");
-    }
-
-    // Build base conditions
-    let where_clause = conditions.join(" AND ");
-
-    // Common parts
-    let order_by = format!(
-        r"ORDER BY {visible_order}
-                 is_pending DESC,
-                 {sort_order},
-                 launcher_id ASC
-        LIMIT ? OFFSET ?",
-        visible_order = if params.include_hidden {
-            "visible DESC,"
-        } else {
-            ""
-        },
-        sort_order = match params.sort_mode {
-            NftSortMode::Recent => "created_height DESC",
-            NftSortMode::Name => "is_named DESC, name ASC",
-        }
+    let mut query = sqlx::QueryBuilder::new(
+        "SELECT launcher_id, 
+            coin_id, 
+            collection_id, 
+            minter_did, 
+            owner_did, 
+            visible, 
+            sensitive_content, 
+            name, 
+            is_owned, 
+            created_height, 
+            metadata_hash,
+            is_named,
+            is_pending,
+            COUNT(*) OVER() as total_count	
+        FROM nfts
+        WHERE 1=1 
+        AND is_owned = 1
+        "
     );
-
-    // Choose index based on sort mode and group type
-    let index = match (params.sort_mode, &params.group) {
-        // Collection grouping
-        (NftSortMode::Name, Some(NftGroup::Collection(_) | NftGroup::NoCollection)) => {
-            "nft_col_name"
+    
+    // Add visibility condition if not including hidden NFTs
+    if !params.include_hidden {
+        query.push(" AND visible = 1");
+    }
+    
+    // Add group filtering (Collection/DID)
+    if let Some(group) = &params.group {
+        match group {
+            NftGroup::Collection(id) => {
+                query.push(" AND collection_id = ");
+                query.push_bind(id.as_ref());
+            },
+            NftGroup::NoCollection => {
+                query.push(" AND collection_id IS NULL");
+            },
+            NftGroup::MinterDid(id) => {
+                query.push(" AND minter_did = ");
+                query.push_bind(id.as_ref());
+            },
+            NftGroup::NoMinterDid => {
+                query.push(" AND minter_did IS NULL");
+            },
+            NftGroup::OwnerDid(id) => {
+                query.push(" AND owner_did = ");
+                query.push_bind(id.as_ref());
+            },
+            NftGroup::NoOwnerDid => {
+                query.push(" AND owner_did IS NULL");
+            },
         }
-        (NftSortMode::Recent, Some(NftGroup::Collection(_) | NftGroup::NoCollection)) => {
-            "nft_col_recent"
-        }
-
-        // Minter DID grouping
-        (NftSortMode::Name, Some(NftGroup::MinterDid(_) | NftGroup::NoMinterDid)) => {
-            "nft_minter_did_name"
-        }
-        (NftSortMode::Recent, Some(NftGroup::MinterDid(_) | NftGroup::NoMinterDid)) => {
-            "nft_minter_did_recent"
-        }
-
-        // Owner DID grouping
-        (NftSortMode::Name, Some(NftGroup::OwnerDid(_) | NftGroup::NoOwnerDid)) => {
-            "nft_owner_did_name"
-        }
-        (NftSortMode::Recent, Some(NftGroup::OwnerDid(_) | NftGroup::NoOwnerDid)) => {
-            "nft_owner_did_recent"
-        }
-
-        // Global sorting
-        (NftSortMode::Name, None) => "nft_name",
-        (NftSortMode::Recent, None) => "nft_recent",
-    };
-
-    // Construct query based on whether we're doing a name search
-    let query = if params.name.is_some() {
-        format!(
-            r"
-            WITH matched_names AS (
-                SELECT launcher_id 
-                FROM nft_name_fts 
-                WHERE name MATCH ? || '*'
-                ORDER BY rank
-            )
-            SELECT nfts.*, COUNT(*) OVER() as total_count 
-            FROM nfts INDEXED BY {index}
-            INNER JOIN matched_names ON nfts.launcher_id = matched_names.launcher_id
-            WHERE {where_clause}
-            {order_by}
-            "
-        )
-    } else {
-        format!(
-            r"
-            SELECT *, COUNT(*) OVER() as total_count
-            FROM nfts INDEXED BY {index}
-            WHERE {where_clause}
-            {order_by}
-            "
-        )
-    };
-
-    // Execute query with bindings
-    let mut query = sqlx::query_as::<_, NftSearchRow>(&query);
-
-    // Bind name search if present
-    if let Some(name_search) = params.name {
-        query = query.bind(escape_fts_query(&name_search));
+    }
+    
+    // Add name search if present
+    if let Some(name_search) = &params.name {
+        query.push(" AND name LIKE ");
+        query.push_bind(format!("%{}%", name_search));
     }
 
-    // Bind group parameters if present
-    //if let Some(NftGroup::Collection(id) | NftGroup::MinterDid(id)) = &params.group {
-    if let Some(NftGroup::Collection(id) | NftGroup::MinterDid(id) | NftGroup::OwnerDid(id)) =
-        &params.group
-    {
-        query = query.bind(id.as_ref());
+    // Add ORDER BY clause based on sort_mode
+    query.push(" ORDER BY ");
+    
+    // Add visible DESC to sort order if including hidden NFTs
+    if params.include_hidden {
+        query.push("visible DESC, ");
+    }
+    
+    match params.sort_mode {
+        NftSortMode::Recent => {
+            query.push("is_pending DESC, created_height DESC, launcher_id ASC");
+        },
+        NftSortMode::Name => {
+            query.push("is_pending DESC, is_named DESC, name ASC, launcher_id ASC");
+        }
     }
 
-    // Limit and offset
-    query = query.bind(limit);
-    query = query.bind(offset);
+    query.push(" LIMIT ? OFFSET ?");
+    
+    let query = query.build_query_as::<NftSearchRow>();
+    
+    // Bind limit and offset
+    let query = query.bind(limit).bind(offset);
 
     let rows = query.fetch_all(conn).await?;
     let total_count = rows.first().map_or(0, |row| row.total_count as u32);

--- a/crates/sage-database/src/primitives/nfts.rs
+++ b/crates/sage-database/src/primitives/nfts.rs
@@ -857,41 +857,41 @@ async fn search_nfts(
         FROM nfts
         WHERE 1=1 
         AND is_owned = 1
-        "
+        ",
     );
-    
+
     // Add visibility condition if not including hidden NFTs
     if !params.include_hidden {
         query.push(" AND visible = 1");
     }
-    
+
     // Add group filtering (Collection/DID)
     if let Some(group) = &params.group {
         match group {
             NftGroup::Collection(id) => {
                 query.push(" AND collection_id = ");
                 query.push_bind(id.as_ref());
-            },
+            }
             NftGroup::NoCollection => {
                 query.push(" AND collection_id IS NULL");
-            },
+            }
             NftGroup::MinterDid(id) => {
                 query.push(" AND minter_did = ");
                 query.push_bind(id.as_ref());
-            },
+            }
             NftGroup::NoMinterDid => {
                 query.push(" AND minter_did IS NULL");
-            },
+            }
             NftGroup::OwnerDid(id) => {
                 query.push(" AND owner_did = ");
                 query.push_bind(id.as_ref());
-            },
+            }
             NftGroup::NoOwnerDid => {
                 query.push(" AND owner_did IS NULL");
-            },
+            }
         }
     }
-    
+
     // Add name search if present
     if let Some(name_search) = &params.name {
         query.push(" AND name LIKE ");
@@ -900,25 +900,25 @@ async fn search_nfts(
 
     // Add ORDER BY clause based on sort_mode
     query.push(" ORDER BY ");
-    
+
     // Add visible DESC to sort order if including hidden NFTs
     if params.include_hidden {
         query.push("visible DESC, ");
     }
-    
+
     match params.sort_mode {
         NftSortMode::Recent => {
             query.push("is_pending DESC, created_height DESC, launcher_id ASC");
-        },
+        }
         NftSortMode::Name => {
             query.push("is_pending DESC, is_named DESC, name ASC, launcher_id ASC");
         }
     }
 
     query.push(" LIMIT ? OFFSET ?");
-    
+
     let query = query.build_query_as::<NftSearchRow>();
-    
+
     // Bind limit and offset
     let query = query.bind(limit).bind(offset);
 

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -58,7 +58,7 @@ const optionsPaginationVariants = {
 
 export function NftOptions({
   isCollection,
-  params: { sort, group, showHidden, query, cardSize, page },
+  params: { sort, group, showHidden, query, cardSize },
   setParams,
   multiSelect,
   setMultiSelect,

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -34,8 +34,6 @@ import {
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { Input } from './ui/input';
-import { Pagination } from './Pagination';
-import { CardSizeToggle } from './CardSizeToggle';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useDebounce } from '@/hooks/useDebounce';
@@ -72,7 +70,7 @@ export function NftOptions({
   const isFilteredView = Boolean(collection_id || owner_did || minter_did);
   const allowSearch = group === NftGroupMode.None || isFilteredView;
   const [searchValue, setSearchValue] = useState(query ?? '');
-  const debouncedSearch = useDebounce(searchValue);
+  const debouncedSearch = useDebounce(searchValue, 400);
   const prevSearchRef = useRef(query);
 
   useEffect(() => {

--- a/src/components/NftOptions.tsx
+++ b/src/components/NftOptions.tsx
@@ -37,6 +37,8 @@ import { Input } from './ui/input';
 import { Pagination } from './Pagination';
 import { CardSizeToggle } from './CardSizeToggle';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useDebounce } from '@/hooks/useDebounce';
 
 export interface NftOptionsProps {
   isCollection?: boolean;
@@ -58,7 +60,7 @@ const optionsPaginationVariants = {
 
 export function NftOptions({
   isCollection,
-  params: { sort, group, showHidden, query, cardSize },
+  params: { sort, group, showHidden, query, cardSize, page },
   setParams,
   multiSelect,
   setMultiSelect,
@@ -69,6 +71,34 @@ export function NftOptions({
   const navigate = useNavigate();
   const isFilteredView = Boolean(collection_id || owner_did || minter_did);
   const allowSearch = group === NftGroupMode.None || isFilteredView;
+  const [searchValue, setSearchValue] = useState(query ?? '');
+  const debouncedSearch = useDebounce(searchValue);
+  const prevSearchRef = useRef(query);
+
+  useEffect(() => {
+    setSearchValue(query ?? '');
+  }, [query]);
+
+  useEffect(() => {
+    if (debouncedSearch !== query) {
+      const shouldResetPage = prevSearchRef.current !== debouncedSearch;
+      prevSearchRef.current = debouncedSearch;
+
+      setParams({
+        query: debouncedSearch || null,
+        ...(shouldResetPage && { page: 1 }),
+      });
+    }
+  }, [debouncedSearch, query, setParams]);
+
+  const handleInputChange = useCallback((value: string) => {
+    setSearchValue(value);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchValue('');
+  }, []);
+
   const handleBack = () => {
     if (collection_id) {
       setParams({ group: NftGroupMode.Collection, page: 1 });
@@ -107,24 +137,24 @@ export function NftOptions({
             aria-hidden='true'
           />
           <Input
-            value={query ?? ''}
+            value={searchValue}
             aria-label={t`Search NFTs...`}
             title={t`Search NFTs...`}
             placeholder={t`Search NFTs...`}
-            onChange={(e) => setParams({ query: e.target.value, page: 1 })}
+            onChange={(e) => handleInputChange(e.target.value)}
             className='w-full pl-8 pr-8'
             disabled={!allowSearch}
             aria-disabled={!allowSearch}
           />
         </div>
-        {query && (
+        {searchValue && (
           <Button
             variant='ghost'
             size='icon'
             title={t`Clear search`}
             aria-label={t`Clear search`}
             className='absolute right-0 top-0 h-full px-2 hover:bg-transparent'
-            onClick={() => setParams({ query: '', page: 1 })}
+            onClick={handleClearSearch}
             disabled={!allowSearch}
           >
             <XIcon className='h-4 w-4' aria-hidden='true' />

--- a/src/components/TokenOptions.tsx
+++ b/src/components/TokenOptions.tsx
@@ -20,6 +20,8 @@ import {
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 import { TokenSortMode } from '@/hooks/useTokenParams';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useState, useEffect } from 'react';
 
 interface TokenOptionsProps {
   query: string;
@@ -50,6 +52,28 @@ export function TokenOptions({
   setShowHiddenCats,
   className,
 }: TokenOptionsProps) {
+  const [searchValue, setSearchValue] = useState(query);
+  const debouncedSearch = useDebounce(searchValue);
+
+  useEffect(() => {
+    setSearchValue(query);
+  }, [query]);
+
+  useEffect(() => {
+    if (debouncedSearch !== query) {
+      setQuery(debouncedSearch);
+      handleSearch(debouncedSearch);
+    }
+  }, [debouncedSearch, query, setQuery, handleSearch]);
+
+  const handleInputChange = (value: string) => {
+    setSearchValue(value);
+  };
+
+  const handleClearSearch = () => {
+    handleInputChange('');
+  };
+
   return (
     <div
       className={`flex flex-col gap-4 ${className}`}
@@ -64,28 +88,22 @@ export function TokenOptions({
               aria-hidden='true'
             />
             <Input
-              value={query}
+              value={searchValue}
               aria-label={t`Search tokens...`}
               title={t`Search tokens...`}
               placeholder={t`Search tokens...`}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                handleSearch(e.target.value);
-              }}
+              onChange={(e) => handleInputChange(e.target.value)}
               className='w-full pl-8 pr-8'
             />
           </div>
-          {query && (
+          {searchValue && (
             <Button
               variant='ghost'
               size='icon'
               title={t`Clear search`}
               aria-label={t`Clear search`}
               className='absolute right-0 top-0 h-full px-2 hover:bg-transparent'
-              onClick={() => {
-                setQuery('');
-                handleSearch('');
-              }}
+              onClick={handleClearSearch}
             >
               <XIcon className='h-4 w-4' aria-hidden='true' />
             </Button>

--- a/src/components/TransactionOptions.tsx
+++ b/src/components/TransactionOptions.tsx
@@ -19,6 +19,8 @@ import {
   SetTransactionParams,
 } from '@/hooks/useTransactionsParams';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useState, useEffect } from 'react';
 
 const optionsPaginationVariants = {
   enter: { opacity: 1, y: 0 },
@@ -41,6 +43,18 @@ export function TransactionOptions({
   renderPagination,
 }: TransactionOptionsProps) {
   const { search, ascending } = params;
+  const [searchValue, setSearchValue] = useState(search);
+  const debouncedSearch = useDebounce(searchValue);
+
+  useEffect(() => {
+    setSearchValue(search);
+  }, [search]);
+
+  useEffect(() => {
+    if (debouncedSearch !== search) {
+      onParamsChange({ search: debouncedSearch, page: 1 });
+    }
+  }, [debouncedSearch, search, onParamsChange]);
 
   return (
     <div
@@ -55,22 +69,22 @@ export function TransactionOptions({
             aria-hidden='true'
           />
           <Input
-            value={search}
+            value={searchValue}
             aria-label={t`Search transactions...`}
             title={t`Search transactions...`}
             placeholder={t`Search transactions...`}
-            onChange={(e) => onParamsChange({ search: e.target.value })}
+            onChange={(e) => setSearchValue(e.target.value)}
             className='w-full pl-8 pr-8'
           />
         </div>
-        {search && (
+        {searchValue && (
           <Button
             variant='ghost'
             size='icon'
             title={t`Clear search`}
             aria-label={t`Clear search`}
             className='absolute right-0 top-0 h-full px-2 hover:bg-transparent'
-            onClick={() => onParamsChange({ search: '' })}
+            onClick={() => setSearchValue('')}
           >
             <XIcon className='h-4 w-4' aria-hidden='true' />
           </Button>

--- a/src/components/TransactionOptions.tsx
+++ b/src/components/TransactionOptions.tsx
@@ -44,7 +44,7 @@ export function TransactionOptions({
 }: TransactionOptionsProps) {
   const { search, ascending } = params;
   const [searchValue, setSearchValue] = useState(search);
-  const debouncedSearch = useDebounce(searchValue);
+  const debouncedSearch = useDebounce(searchValue, 400);
 
   useEffect(() => {
     setSearchValue(search);

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * A hook that debounces a value with a specified delay.
+ * @param value The value to debounce
+ * @param delay The delay in milliseconds (default: 300ms)
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay = 300): T {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+} 

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -6,18 +6,18 @@ import { useEffect, useState } from 'react';
  * @param delay The delay in milliseconds (default: 300ms)
  * @returns The debounced value
  */
-export function useDebounce<T>(value: T, delay = 300): T {
-    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setDebouncedValue(value);
-        }, delay);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
 
-        return () => {
-            clearTimeout(timer);
-        };
-    }, [value, delay]);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
 
-    return debouncedValue;
-} 
+  return debouncedValue;
+}

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -94,27 +94,33 @@ export function Transactions() {
     };
   }, [updateTransactions]);
 
-  const handlePageChange = useCallback((newPage: number, compact?: boolean) => {
-    setIsPaginationLoading(true);
-    setParams({ page: newPage });
-    if (compact) {
-      listRef.current?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    }
-  }, [setParams]);
-
-  const handlePageSizeChange = useCallback((newSize: number, compact?: boolean) => {
-    setIsPaginationLoading(true);
-    setParams({ pageSize: newSize, page: 1 });
-    if (compact) {
+  const handlePageChange = useCallback(
+    (newPage: number, compact?: boolean) => {
+      setIsPaginationLoading(true);
+      setParams({ page: newPage });
+      if (compact) {
         listRef.current?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    }
-  }, [setParams]);
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
+    },
+    [setParams],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (newSize: number, compact?: boolean) => {
+      setIsPaginationLoading(true);
+      setParams({ pageSize: newSize, page: 1 });
+      if (compact) {
+        listRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
+    },
+    [setParams],
+  );
 
   const renderPagination = useCallback(
     (compact: boolean = false) => (
@@ -129,7 +135,15 @@ export function Transactions() {
         isLoading={isLoading || isPaginationLoading}
       />
     ),
-    [page, pageSize, totalTransactions, isLoading, isPaginationLoading, handlePageChange, handlePageSizeChange],
+    [
+      page,
+      pageSize,
+      totalTransactions,
+      isLoading,
+      isPaginationLoading,
+      handlePageChange,
+      handlePageSizeChange,
+    ],
   );
 
   return (


### PR DESCRIPTION
Fix https://github.com/xch-dev/sage/issues/347

This PR adds a configurable debounce to token, NFT and transaction searches.

This also includes a re-write of the NFT search to use the `nfts` table directly instead of the FTS. The rationale being to simplify that search implementation and still achieve good results, even on very large wallets. The FTS can be added back in if results are not good enough.