### PR TITLE
Copy address from wallet login screen

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -61,9 +61,7 @@ import { useNavigate } from 'react-router-dom';
 import { commands, KeyInfo, SecretKeyInfo } from '../bindings';
 import Container from '../components/Container';
 import { useWallet } from '../contexts/WalletContext';
-import {
-  loginAndUpdateState,
-} from '../state';
+import { loginAndUpdateState } from '../state';
 import { toast } from 'react-toastify';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 
@@ -316,7 +314,6 @@ function WalletItem({
 
       if (sync?.receive_address) {
         writeText(sync.receive_address);
-        toast.success(sync.receive_address);
         toast.success(t`Address copied to clipboard`);
       } else {
         toast.error(t`No address found`);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -313,7 +313,7 @@ function WalletItem({
       const sync = await commands.getSyncStatus({});
 
       if (sync?.receive_address) {
-        writeText(sync.receive_address);
+        await writeText(sync.receive_address);
         toast.success(t`Address copied to clipboard`);
       } else {
         toast.error(t`No address found`);

--- a/src/pages/Token.tsx
+++ b/src/pages/Token.tsx
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { commands } from '../bindings';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 export default function Token() {
   const { asset_id: assetId } = useParams();
@@ -107,7 +108,12 @@ export default function Token() {
           <span>
             {asset ? (asset.name ?? t`Unknown asset`) : ''}{' '}
             {asset?.asset_id !== 'xch' && (
-              <CopyButton value={asset?.asset_id ?? ''} />
+              <CopyButton
+                value={asset?.asset_id ?? ''}
+                onCopy={() => {
+                  toast.success(t`Asset ID copied to clipboard`);
+                }}
+              />
             )}
           </span>
         }


### PR DESCRIPTION
Fix https://github.com/xch-dev/sage/issues/257

This copies the wallet address from the wallet login screen by doing a login, copy and logout in succession.

Note that it assumes that the wallet in question is either configured to correctly override the default network or is on the currently selected default network. 