### PR TITLE
Default fee

### DIFF
--- a/src/components/AssignNftDialog.tsx
+++ b/src/components/AssignNftDialog.tsx
@@ -25,7 +25,7 @@ import {
   FormLabel,
   FormMessage,
 } from './ui/form';
-import { TokenAmountInput } from './ui/masked-input';
+import { FeeAmountInput } from './ui/masked-input';
 import {
   Select,
   SelectContent,
@@ -61,10 +61,6 @@ export function AssignNftDialog({
 
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
-    defaultValues: {
-      profile: '',
-      fee: '0',
-    },
   });
 
   const handler = (values: z.infer<typeof schema>) => {
@@ -133,10 +129,7 @@ export function AssignNftDialog({
                     <Trans>Network Fee</Trans>
                   </FormLabel>
                   <FormControl>
-                    <TokenAmountInput
-                      {...field}
-                      aria-label={t`Network fee amount`}
-                    />
+                    <FeeAmountInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/components/CoinsCard.tsx
+++ b/src/components/CoinsCard.tsx
@@ -38,6 +38,7 @@ import {
   commands,
   TransactionResponse,
 } from '../bindings';
+import { FeeAmountInput } from './ui/masked-input';
 
 interface CoinsCardProps {
   precision: number;
@@ -204,9 +205,6 @@ export function CoinsCard({
 
   const combineForm = useForm<z.infer<typeof combineFormSchema>>({
     resolver: zodResolver(combineFormSchema),
-    defaultValues: {
-      combineFee: '0',
-    },
   });
 
   const onCombineSubmit = (values: z.infer<typeof combineFormSchema>) => {
@@ -255,7 +253,6 @@ export function CoinsCard({
     resolver: zodResolver(splitFormSchema),
     defaultValues: {
       outputCount: 2,
-      splitFee: '0',
     },
   });
 
@@ -307,7 +304,6 @@ export function CoinsCard({
   const autoCombineForm = useForm<z.infer<typeof autoCombineFormSchema>>({
     resolver: zodResolver(autoCombineFormSchema),
     defaultValues: {
-      autoCombineFee: '0',
       maxCoins: '100',
       maxCoinAmount: '',
     },
@@ -459,7 +455,7 @@ export function CoinsCard({
                       <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <FeeAmountInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -527,7 +523,7 @@ export function CoinsCard({
                       <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <FeeAmountInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -577,7 +573,7 @@ export function CoinsCard({
                       <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <FeeAmountInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/components/FeeOnlyDialog.tsx
+++ b/src/components/FeeOnlyDialog.tsx
@@ -24,8 +24,7 @@ import {
   FormLabel,
   FormMessage,
 } from './ui/form';
-import { TokenAmountInput } from './ui/masked-input';
-import { useDefaultFee } from '@/hooks/useDefaultFee';
+import { FeeAmountInput } from './ui/masked-input';
 
 export interface FeeOnlyDialogProps {
   title: string;
@@ -44,7 +43,6 @@ export function FeeOnlyDialog({
   children,
 }: PropsWithChildren<FeeOnlyDialogProps>) {
   const walletState = useWalletState();
-  const { fee: defaultFee } = useDefaultFee();
 
   const schema = z.object({
     fee: amount(walletState.sync.unit.decimals).refine(
@@ -55,9 +53,6 @@ export function FeeOnlyDialog({
 
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
-    defaultValues: {
-      fee: defaultFee,
-    },
   });
 
   const handler = (values: z.infer<typeof schema>) => {
@@ -82,11 +77,7 @@ export function FeeOnlyDialog({
                     <Trans>Network Fee</Trans>
                   </FormLabel>
                   <FormControl>
-                    <TokenAmountInput
-                      {...field}
-                      placeholder={t`Enter network fee`}
-                      aria-label={t`Network fee amount`}
-                    />
+                    <FeeAmountInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/components/FeeOnlyDialog.tsx
+++ b/src/components/FeeOnlyDialog.tsx
@@ -25,6 +25,7 @@ import {
   FormMessage,
 } from './ui/form';
 import { TokenAmountInput } from './ui/masked-input';
+import { useDefaultFee } from '@/hooks/useDefaultFee';
 
 export interface FeeOnlyDialogProps {
   title: string;
@@ -43,6 +44,7 @@ export function FeeOnlyDialog({
   children,
 }: PropsWithChildren<FeeOnlyDialogProps>) {
   const walletState = useWalletState();
+  const { fee: defaultFee } = useDefaultFee();
 
   const schema = z.object({
     fee: amount(walletState.sync.unit.decimals).refine(
@@ -54,7 +56,7 @@ export function FeeOnlyDialog({
   const form = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     defaultValues: {
-      fee: '0',
+      fee: defaultFee,
     },
   });
 

--- a/src/components/NftCard.tsx
+++ b/src/components/NftCard.tsx
@@ -65,7 +65,7 @@ import {
   FormMessage,
 } from './ui/form';
 import { Input } from './ui/input';
-import { TokenAmountInput } from './ui/masked-input';
+import { FeeAmountInput } from './ui/masked-input';
 import {
   Select,
   SelectContent,
@@ -200,7 +200,6 @@ export function NftCard({ nft, updateNfts, selectionState }: NftCardProps) {
     defaultValues: {
       url: '',
       kind: 'data',
-      fee: '0',
     },
   });
 
@@ -607,7 +606,7 @@ export function NftCard({ nft, updateNfts, selectionState }: NftCardProps) {
                       <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
-                      <TokenAmountInput {...field} />
+                      <FeeAmountInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/components/TransferDialog.tsx
+++ b/src/components/TransferDialog.tsx
@@ -23,7 +23,7 @@ import {
   FormMessage,
 } from './ui/form';
 import { Input } from './ui/input';
-import { TokenAmountInput } from './ui/masked-input';
+import { FeeAmountInput } from './ui/masked-input';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 
@@ -55,7 +55,6 @@ export function TransferDialog({
     resolver: zodResolver(schema),
     defaultValues: {
       address: '',
-      fee: '0',
     },
   });
 
@@ -96,10 +95,7 @@ export function TransferDialog({
                     <Trans>Network Fee</Trans>
                   </FormLabel>
                   <FormControl>
-                    <TokenAmountInput
-                      {...field}
-                      placeholder={t`Enter fee amount`}
-                    />
+                    <FeeAmountInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/hooks/useDefaultFee.ts
+++ b/src/hooks/useDefaultFee.ts
@@ -1,4 +1,5 @@
 import { useLocalStorage } from 'usehooks-ts';
+import * as React from 'react';
 
 export interface DefaultFee {
   fee: string;
@@ -24,9 +25,11 @@ export function useDefaultFee() {
   };
 
   // Ensure we always have a valid fee value
-  if (!isValidFee(defaultFee.fee)) {
-    setDefaultFee({ fee: DEFAULT_FEE });
-  }
+  React.useEffect(() => {
+    if (!isValidFee(defaultFee.fee)) {
+      setDefaultFee({ fee: DEFAULT_FEE });
+    }
+  }, [defaultFee.fee, setDefaultFee]);
 
   return {
     fee: isValidFee(defaultFee.fee) ? defaultFee.fee : DEFAULT_FEE,

--- a/src/hooks/useDefaultFee.ts
+++ b/src/hooks/useDefaultFee.ts
@@ -1,0 +1,32 @@
+import { useLocalStorage } from 'usehooks-ts';
+
+export interface DefaultFee {
+  fee: string;
+}
+
+const isValidFee = (value: string): boolean => {
+  const num = parseFloat(value);
+  return !isNaN(num) && num >= 0;
+};
+
+const DEFAULT_FEE = '0';
+
+export function useDefaultFee() {
+  const [defaultFee, setDefaultFee] = useLocalStorage<DefaultFee>('defaultFee', { fee: DEFAULT_FEE });
+
+  const setFee = (fee: string) => {
+    if (isValidFee(fee)) {
+      setDefaultFee({ fee });
+    }
+  };
+
+  // Ensure we always have a valid fee value
+  if (!isValidFee(defaultFee.fee)) {
+    setDefaultFee({ fee: DEFAULT_FEE });
+  }
+
+  return {
+    fee: isValidFee(defaultFee.fee) ? defaultFee.fee : DEFAULT_FEE,
+    setFee,
+  };
+}

--- a/src/hooks/useDefaultFee.ts
+++ b/src/hooks/useDefaultFee.ts
@@ -12,7 +12,10 @@ const isValidFee = (value: string): boolean => {
 const DEFAULT_FEE = '0';
 
 export function useDefaultFee() {
-  const [defaultFee, setDefaultFee] = useLocalStorage<DefaultFee>('defaultFee', { fee: DEFAULT_FEE });
+  const [defaultFee, setDefaultFee] = useLocalStorage<DefaultFee>(
+    'defaultFee',
+    { fee: DEFAULT_FEE },
+  );
 
   const setFee = (fee: string) => {
     if (isValidFee(fee)) {

--- a/src/pages/CreateProfile.tsx
+++ b/src/pages/CreateProfile.tsx
@@ -21,7 +21,7 @@ import * as z from 'zod';
 import { commands, TransactionResponse } from '../bindings';
 import Container from '../components/Container';
 import { useWalletState } from '../state';
-import { TokenAmountInput } from '@/components/ui/masked-input';
+import { FeeAmountInput } from '@/components/ui/masked-input';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { CreateProfileConfirmation } from '@/components/confirmations/CreateProfileConfirmation';
@@ -88,12 +88,7 @@ export default function CreateProfile() {
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>
-                        <TokenAmountInput {...field} className='pr-12' />
-                        <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
-                          <span className='text-gray-500 text-sm'>
-                            {walletState.sync.unit.ticker}
-                          </span>
-                        </div>
+                        <FeeAmountInput {...field} className='pr-12' />
                       </div>
                     </FormControl>
                     <FormMessage />

--- a/src/pages/IssueToken.tsx
+++ b/src/pages/IssueToken.tsx
@@ -127,7 +127,7 @@ export default function IssueToken() {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>
-                      <Trans>Fee</Trans>
+                      <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>

--- a/src/pages/IssueToken.tsx
+++ b/src/pages/IssueToken.tsx
@@ -21,7 +21,7 @@ import * as z from 'zod';
 import { commands, TransactionResponse } from '../bindings';
 import Container from '../components/Container';
 import { useWalletState } from '../state';
-import { TokenAmountInput } from '@/components/ui/masked-input';
+import { TokenAmountInput, FeeAmountInput } from '@/components/ui/masked-input';
 import { Trans } from '@lingui/react/macro';
 import { t } from '@lingui/core/macro';
 import { TokenConfirmation } from '@/components/confirmations/TokenConfirmation';
@@ -131,12 +131,7 @@ export default function IssueToken() {
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>
-                        <TokenAmountInput {...field} className='pr-12' />
-                        <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
-                          <span className='text-gray-500 text-sm'>
-                            {walletState.sync.unit.ticker}
-                          </span>
-                        </div>
+                        <FeeAmountInput {...field} className='pr-12' />
                       </div>
                     </FormControl>
                     <FormMessage />

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -138,7 +138,7 @@ export function MakeOffer() {
       ),
       expires_at_second: expiresAtSecond,
     });
-    console.log(`state ${state.fee}`);
+
     setState(null);
     setOffer(data.offer);
     setPending(false);
@@ -210,7 +210,6 @@ export function MakeOffer() {
                   id='fee'
                   className='pr-12'
                   onValueChange={(values: { value: string }) => {
-                    console.log(`values ${values.value}`);
                     setState({
                       fee: values.value,
                     });

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -16,7 +16,11 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { IntegerInput, TokenAmountInput } from '@/components/ui/masked-input';
+import {
+  IntegerInput,
+  TokenAmountInput,
+  FeeAmountInput,
+} from '@/components/ui/masked-input';
 import { Switch } from '@/components/ui/switch';
 import {
   Tooltip,
@@ -134,7 +138,7 @@ export function MakeOffer() {
       ),
       expires_at_second: expiresAtSecond,
     });
-
+    console.log(`state ${state.fee}`);
     setState(null);
     setOffer(data.offer);
     setPending(false);
@@ -202,13 +206,11 @@ export function MakeOffer() {
                 <Trans>Network Fee</Trans>
               </Label>
               <div className='relative'>
-                <TokenAmountInput
+                <FeeAmountInput
                   id='fee'
-                  type='text'
-                  placeholder={'0.00'}
                   className='pr-12'
-                  value={state.fee}
-                  onValueChange={(values) => {
+                  onValueChange={(values: { value: string }) => {
+                    console.log(`values ${values.value}`);
                     setState({
                       fee: values.value,
                     });

--- a/src/pages/MintNft.tsx
+++ b/src/pages/MintNft.tsx
@@ -34,6 +34,7 @@ import * as z from 'zod';
 import { commands, TransactionResponse } from '../bindings';
 import Container from '../components/Container';
 import { useWalletState } from '../state';
+import { FeeAmountInput } from '@/components/ui/masked-input';
 
 export default function MintNft() {
   const navigate = useNavigate();
@@ -272,17 +273,7 @@ export default function MintNft() {
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>
-                        <Input
-                          type='text'
-                          placeholder={'0.00'}
-                          {...field}
-                          className='pr-12'
-                        />
-                        <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
-                          <span className='text-gray-500 text-sm'>
-                            {walletState.sync.unit.ticker}
-                          </span>
-                        </div>
+                        <FeeAmountInput {...field} className='pr-12' />
                       </div>
                     </FormControl>
                     <FormMessage />

--- a/src/pages/Offers.tsx
+++ b/src/pages/Offers.tsx
@@ -37,7 +37,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import { TokenAmountInput } from '@/components/ui/masked-input';
+import { FeeAmountInput } from '@/components/ui/masked-input';
 import { Textarea } from '@/components/ui/textarea';
 import { useErrors } from '@/hooks/useErrors';
 import { useScannerOrClipboard } from '@/hooks/useScannerOrClipboard';
@@ -309,9 +309,6 @@ function Offer({ record, refresh }: OfferProps) {
 
   const cancelForm = useForm<z.infer<typeof cancelSchema>>({
     resolver: zodResolver(cancelSchema),
-    defaultValues: {
-      fee: '0',
-    },
   });
 
   const [response, setResponse] = useState<TransactionResponse | null>(null);
@@ -537,7 +534,7 @@ function Offer({ record, refresh }: OfferProps) {
                       <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
-                      <TokenAmountInput {...field} />
+                      <FeeAmountInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -336,19 +336,11 @@ export default function Send() {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>
-                      <Trans>Fee</Trans>
+                      <Trans>Network Fee</Trans>
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>
                         <FeeAmountInput {...field} className='pr-12' />
-                        <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
-                          <span
-                            className='text-gray-500 text-sm'
-                            id='price-currency'
-                          >
-                            {walletState.sync.unit.ticker}
-                          </span>
-                        </div>
                       </div>
                     </FormControl>
                     <FormMessage />

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -13,7 +13,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
-import { TokenAmountInput } from '@/components/ui/masked-input';
+import { FeeAmountInput, TokenAmountInput } from '@/components/ui/masked-input';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { useErrors } from '@/hooks/useErrors';
@@ -41,6 +41,7 @@ import {
 } from '@/components/ui/tooltip';
 import { ArrowUpToLine } from 'lucide-react';
 import { TokenConfirmation } from '@/components/confirmations/TokenConfirmation';
+import { useDefaultFee } from '@/hooks/useDefaultFee';
 
 function stringToUint8Array(str: string): Uint8Array {
   return new TextEncoder().encode(str);
@@ -52,6 +53,7 @@ export default function Send() {
   const navigate = useNavigate();
   const walletState = useWalletState();
   const { addError } = useErrors();
+  const { fee: defaultFee } = useDefaultFee();
 
   const [asset, setAsset] = useState<(CatRecord & { decimals: number }) | null>(
     null,
@@ -338,7 +340,7 @@ export default function Send() {
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>
-                        <TokenAmountInput {...field} className='pr-12' />
+                        <FeeAmountInput {...field} className='pr-12' />
                         <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
                           <span
                             className='text-gray-500 text-sm'

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { IntegerInput } from '@/components/ui/masked-input';
+import { IntegerInput, TokenAmountInput } from '@/components/ui/masked-input';
 import {
   Select,
   SelectContent,
@@ -54,6 +54,8 @@ import { z } from 'zod';
 import { commands, Network, NetworkConfig, Wallet } from '../bindings';
 import { DarkModeContext } from '../contexts/DarkModeContext';
 import { isValidU32 } from '../validation';
+import { useLocalStorage } from 'usehooks-ts';
+import { useDefaultFee } from '@/hooks/useDefaultFee';
 
 export default function Settings() {
   const { wallet } = useWallet();
@@ -230,6 +232,7 @@ function GlobalSettings() {
   const { locale, changeLanguage } = useLanguage();
   const { expiry, setExpiry } = useDefaultOfferExpiry();
   const { enabled, available, enableIfAvailable, disable } = useBiometric();
+  const { fee, setFee } = useDefaultFee();
 
   const isMobile = platform() === 'ios' || platform() === 'android';
 
@@ -248,7 +251,6 @@ function GlobalSettings() {
         description={t`Switch between light and dark theme`}
         control={<Switch checked={dark} onCheckedChange={setDark} />}
       />
-
       {isMobile && (
         <SettingItem
           label={t`Biometric Authentication`}
@@ -262,7 +264,6 @@ function GlobalSettings() {
           }
         />
       )}
-
       <SettingItem
         label={t`Language`}
         description={t`Choose your preferred language`}
@@ -280,7 +281,16 @@ function GlobalSettings() {
           </Select>
         }
       />
-
+      <SettingItem
+        label={t`Default Fee (in XCH)`}
+        description={t`The default fee (in XCH) to use for transactions`}
+        control={
+          <TokenAmountInput
+            value={fee}
+            onChange={(e) => setFee(e.target.value)}
+          />
+        }
+      />
       <SettingItem
         label={t`Default Offer Expiry`}
         description={t`Set a default expiration time for new offers`}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { IntegerInput, TokenAmountInput } from '@/components/ui/masked-input';
+import { FeeAmountInput, IntegerInput, TokenAmountInput } from '@/components/ui/masked-input';
 import {
   Select,
   SelectContent,
@@ -282,12 +282,11 @@ function GlobalSettings() {
         }
       />
       <SettingItem
-        label={t`Default Fee (in XCH)`}
-        description={t`The default fee (in XCH) to use for transactions`}
+        label={t`Default Fee`}
+        description={t`The default fee to use for transactions`}
         control={
-          <TokenAmountInput
-            value={fee}
-            onChange={(e) => setFee(e.target.value)}
+          <FeeAmountInput
+            onValueChange={(values) => setFee(values.value)}
           />
         }
       />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -286,7 +286,7 @@ function GlobalSettings() {
         description={t`The default fee to use for transactions`}
         control={
           <FeeAmountInput
-            onValueChange={(values) => setFee(values.value)}
+            onValueChange={(values) => setFee(values.value === '' ? '0' : values.value)}
           />
         }
       />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -22,7 +22,11 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { FeeAmountInput, IntegerInput, TokenAmountInput } from '@/components/ui/masked-input';
+import {
+  FeeAmountInput,
+  IntegerInput,
+  TokenAmountInput,
+} from '@/components/ui/masked-input';
 import {
   Select,
   SelectContent,
@@ -286,7 +290,9 @@ function GlobalSettings() {
         description={t`The default fee to use for transactions`}
         control={
           <FeeAmountInput
-            onValueChange={(values) => setFee(values.value === '' ? '0' : values.value)}
+            onValueChange={(values) =>
+              setFee(values.value === '' ? '0' : values.value)
+            }
           />
         }
       />

--- a/src/pages/ViewOffer.tsx
+++ b/src/pages/ViewOffer.tsx
@@ -6,8 +6,8 @@ import Header from '@/components/Header';
 import { Loading } from '@/components/Loading';
 import { OfferCard } from '@/components/OfferCard';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { FeeAmountInput } from '@/components/ui/masked-input';
 import { CustomError } from '@/contexts/ErrorContext';
 import { useErrors } from '@/hooks/useErrors';
 import { resolveOfferData } from '@/lib/offerData';
@@ -95,13 +95,10 @@ export function ViewOffer() {
                   <Label htmlFor='fee'>
                     <Trans>Network Fee</Trans>
                   </Label>
-                  <Input
+                  <FeeAmountInput
                     id='fee'
-                    type='text'
-                    placeholder='0.00'
                     className='pr-12'
-                    value={fee}
-                    onChange={(e) => setFee(e.target.value)}
+                    onValueChange={(values) => setFee(values.value)}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter') {
                         event.preventDefault();


### PR DESCRIPTION
This PR adds a default fee that will be used anywhere the UI asks for a fee. 

The implementation consists of:

- a `useDefaultFee` hook that stores the default in local storage
- a default fee setting under General Preferences (the default default is 0.0)
- A `FeeAmountInput` component that handles populating the default when mounted. It also makes fee input consistent, ensuring the fee is >=0 and displays the fee token
- Anywhere a fee is requested form the user has had the input controls replaced with `FeeAmountInput`

![image](https://github.com/user-attachments/assets/d66caf9f-3a67-43d3-b32b-867fc92a4dae)
