### PR TITLE
add get_version to rpc

### DIFF
--- a/crates/sage-api/endpoints.json
+++ b/crates/sage-api/endpoints.json
@@ -10,7 +10,7 @@
   "get_secret_key": false,
   "get_keys": false,
   "get_sync_status": true,
-  "get_version": true,
+  "get_version": false,
   "check_address": true,
   "get_derivations": true,
   "get_are_coins_spendable": true,

--- a/crates/sage-api/endpoints.json
+++ b/crates/sage-api/endpoints.json
@@ -10,6 +10,7 @@
   "get_secret_key": false,
   "get_keys": false,
   "get_sync_status": true,
+  "get_version": true,
   "check_address": true,
   "get_derivations": true,
   "get_are_coins_spendable": true,

--- a/crates/sage-api/src/requests/data.rs
+++ b/crates/sage-api/src/requests/data.rs
@@ -55,6 +55,16 @@ pub struct GetSyncStatusResponse {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "tauri", derive(specta::Type))]
+pub struct GetVersion {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "tauri", derive(specta::Type))]
+pub struct GetVersionResponse {
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "tauri", derive(specta::Type))]
 #[serde(rename_all = "snake_case")]
 pub enum CoinSortMode {
     CoinId,

--- a/crates/sage/src/endpoints/data.rs
+++ b/crates/sage/src/endpoints/data.rs
@@ -34,7 +34,7 @@ use sage_wallet::WalletError;
 use sqlx::{sqlite::SqliteRow, Row};
 
 impl Sage {
-    pub async fn get_version(&self, _req: GetVersion) -> Result<GetVersionResponse> {
+    pub fn get_version(&self, _req: GetVersion) -> Result<GetVersionResponse> {
         Ok(GetVersionResponse {
             version: env!("CARGO_PKG_VERSION").to_string(),
         })

--- a/crates/sage/src/endpoints/data.rs
+++ b/crates/sage/src/endpoints/data.rs
@@ -25,15 +25,21 @@ use sage_api::{
     GetNftResponse, GetNftThumbnail, GetNftThumbnailResponse, GetNfts, GetNftsResponse,
     GetPendingTransactions, GetPendingTransactionsResponse, GetSpendableCoinCount,
     GetSpendableCoinCountResponse, GetSyncStatus, GetSyncStatusResponse, GetTransactions,
-    GetTransactionsResponse, GetXchCoins, GetXchCoinsResponse, NftCollectionRecord, NftData,
-    NftRecord, NftSortMode as ApiNftSortMode, PendingTransactionRecord, TransactionCoin,
-    TransactionRecord,
+    GetTransactionsResponse, GetVersion, GetVersionResponse, GetXchCoins, GetXchCoinsResponse,
+    NftCollectionRecord, NftData, NftRecord, NftSortMode as ApiNftSortMode,
+    PendingTransactionRecord, TransactionCoin, TransactionRecord,
 };
 use sage_database::{CoinKind, CoinSortMode, NftGroup, NftRow, NftSearchParams, NftSortMode};
 use sage_wallet::WalletError;
 use sqlx::{sqlite::SqliteRow, Row};
 
 impl Sage {
+    pub async fn get_version(&self, _req: GetVersion) -> Result<GetVersionResponse> {
+        Ok(GetVersionResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        })
+    }
+
     pub async fn get_sync_status(&self, _req: GetSyncStatus) -> Result<GetSyncStatusResponse> {
         let wallet = self.wallet()?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
             commands::view_coin_spends,
             commands::submit_transaction,
             commands::get_sync_status,
+            commands::get_version,
             commands::check_address,
             commands::get_derivations,
             commands::get_are_coins_spendable,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -104,6 +104,9 @@ async submitTransaction(req: SubmitTransaction) : Promise<SubmitTransactionRespo
 async getSyncStatus(req: GetSyncStatus) : Promise<GetSyncStatusResponse> {
     return await TAURI_INVOKE("get_sync_status", { req });
 },
+async getVersion(req: GetVersion) : Promise<GetVersionResponse> {
+    return await TAURI_INVOKE("get_version", { req });
+},
 async checkAddress(req: CheckAddress) : Promise<CheckAddressResponse> {
     return await TAURI_INVOKE("check_address", { req });
 },
@@ -429,6 +432,8 @@ export type GetSyncStatus = Record<string, never>
 export type GetSyncStatusResponse = { balance: Amount; unit: Unit; synced_coins: number; total_coins: number; receive_address: string; burn_address: string; unhardened_derivation_index: number; hardened_derivation_index: number; checked_uris: number; total_uris: number; database_size: number }
 export type GetTransactions = { offset: number; limit: number; ascending: boolean; find_value: string | null }
 export type GetTransactionsResponse = { transactions: TransactionRecord[]; total: number }
+export type GetVersion = Record<string, never>
+export type GetVersionResponse = { version: string }
 export type GetXchCoins = { offset: number; limit: number; sort_mode?: CoinSortMode; ascending?: boolean; include_spent_coins?: boolean }
 export type GetXchCoinsResponse = { coins: CoinRecord[]; total: number }
 export type ImportKey = { name: string; key: string; derivation_index?: number; save_secrets?: boolean; login?: boolean }


### PR DESCRIPTION
FIX https://github.com/xch-dev/sage/issues/398

```
% ./sage rpc get_version '{}'    
{
  "version": "0.10.3"
}
```

adding `get_version` to things is my chia legacy.
https://github.com/Chia-Network/chia-blockchain/pull/8710