### PR TITLE
enforce a maximum royalty percent of 655.36

### DIFF
--- a/src/pages/MintNft.tsx
+++ b/src/pages/MintNft.tsx
@@ -34,8 +34,7 @@ import * as z from 'zod';
 import { commands, TransactionResponse } from '../bindings';
 import Container from '../components/Container';
 import { useWalletState } from '../state';
-import { FeeAmountInput } from '@/components/ui/masked-input';
-import { Switch } from '@/components/ui/switch';
+import { FeeAmountInput, MaskedInput } from '@/components/ui/masked-input';
 import { IntegerInput } from '@/components/ui/masked-input';
 
 export default function MintNft() {
@@ -264,9 +263,16 @@ export default function MintNft() {
                     </FormLabel>
                     <FormControl>
                       <div className='relative'>
-                        <Input
-                          type='text'
+                        <MaskedInput
+                          title={t`The maximum royalty percent is 655.36%`}
                           placeholder={t`Enter percent`}
+                          allowLeadingZeros={true}
+                          allowNegative={false}
+                          decimalScale={2}
+                          isAllowed={(values) => {
+                            const { floatValue } = values;
+                            return !floatValue || floatValue <= 655.36;
+                          }}
                           {...field}
                           className='pr-12'
                         />


### PR DESCRIPTION
FIX https://github.com/xch-dev/sage/issues/457

royalty percent (in thousandths) is stored as a u16, so the maximum allowed is 65536 or 655.36%. This is now enforced in the UI. 

UI also now prevents negative or text entry, and only allows 2 decimal digits.