### PR TITLE
Seed phrase stuff

### DIFF
--- a/src/pages/CreateWallet.tsx
+++ b/src/pages/CreateWallet.tsx
@@ -4,6 +4,13 @@ import SafeAreaView from '@/components/SafeAreaView';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -119,155 +126,175 @@ function CreateForm(props: {
   };
 
   return (
-    <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(confirmAndSubmit)}
-        className='space-y-4 max-w-xl mx-auto py-0'
-      >
-        <FormField
-          control={form.control}
-          name='walletName'
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <Trans>Wallet Name</Trans>
-              </FormLabel>
-              <FormControl>
-                <Input placeholder='' required {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+    <>
+      <Card className='mx-8'>
+        <CardHeader className='text-center'>
+          <CardTitle>
+            <Trans>New Wallet</Trans>
+          </CardTitle>
+          <CardDescription>
+            <Trans>
+              Unless you create it as a cold wallet, your seed phrase will be
+              viewable from the wallet card on the login screen.
+            </Trans>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(confirmAndSubmit)}
+              className='space-y-4 max-w-xl mx-auto py-0'
+            >
+              <FormField
+                control={form.control}
+                name='walletName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <Trans>Wallet Name</Trans>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder='' required {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-        <FormField
-          control={form.control}
-          name='emoji'
-          render={({ field }) => (
-            <FormItem>
-              <label htmlFor='emoji' className='space-y-0.5'>
-                <FormLabel>
-                  <Trans>Wallet Emoji (Optional)</Trans>
-                </FormLabel>
-                <FormControl>
-                  <div className='flex items-center gap-2'>
-                    <EmojiPicker
-                      value={field.value}
-                      onChange={field.onChange}
-                      placeholder={t`Choose an emoji`}
-                    />
+              <FormField
+                control={form.control}
+                name='emoji'
+                render={({ field }) => (
+                  <FormItem>
+                    <label htmlFor='emoji' className='space-y-0.5'>
+                      <FormLabel>
+                        <Trans>Wallet Emoji (Optional)</Trans>
+                      </FormLabel>
+                      <FormControl>
+                        <div className='flex items-center gap-2'>
+                          <EmojiPicker
+                            value={field.value}
+                            onChange={field.onChange}
+                            placeholder={t`Choose an emoji`}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormDescription>
+                        <Trans>
+                          Choose an emoji to easily identify your wallet
+                        </Trans>
+                      </FormDescription>
+                    </label>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='use24Words'
+                defaultValue={true}
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4 gap-2'>
+                    <label htmlFor='use24Words' className='space-y-0.5'>
+                      <FormLabel>
+                        <Trans>Use 24 words</Trans>
+                      </FormLabel>
+                      <FormDescription>
+                        <Trans>
+                          While 12 word mnemonics are sufficiently hard to
+                          crack, you can choose to use 24 instead to increase
+                          security.
+                        </Trans>
+                      </FormDescription>
+                    </label>
+                    <FormControl>
+                      <Switch
+                        id='use24Words'
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='saveMnemonic'
+                defaultValue={true}
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4 gap-2'>
+                    <label htmlFor='saveMnemonic' className='space-y-0.5'>
+                      <FormLabel>
+                        <Trans>Save mnemonic</Trans>
+                      </FormLabel>
+                      <FormDescription>
+                        <Trans>
+                          By disabling this you are creating a cold wallet, with
+                          no ability to sign transactions. The mnemonic will
+                          need to be saved elsewhere.
+                        </Trans>
+                      </FormDescription>
+                    </label>
+                    <FormControl>
+                      <Switch
+                        id='saveMnemonic'
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <div className='mt-3'>
+                <div className='flex justify-between items-center mb-2'>
+                  <Label>
+                    <Trans>Mnemonic</Trans>
+                  </Label>
+                  <div>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={loadMnemonic}
+                    >
+                      <RefreshCwIcon className='h-4 w-4' />
+                    </Button>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={copyMnemonic}
+                    >
+                      <CopyIcon className='h-4 w-4' />
+                    </Button>
                   </div>
-                </FormControl>
-                <FormDescription>
-                  <Trans>Choose an emoji to easily identify your wallet</Trans>
-                </FormDescription>
-              </label>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+                </div>
+                <div className='flex flex-wrap'>
+                  {form
+                    .watch('mnemonic')
+                    ?.split(' ')
+                    .map((word) => (
+                      <Badge
+                        key={word}
+                        variant='outline'
+                        className='py-1.5 px-2.5 m-0.5 rounded-lg font-medium'
+                      >
+                        {word}
+                      </Badge>
+                    ))}
+                </div>
+              </div>
 
-        <FormField
-          control={form.control}
-          name='use24Words'
-          defaultValue={true}
-          render={({ field }) => (
-            <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4 gap-2'>
-              <label htmlFor='use24Words' className='space-y-0.5'>
-                <FormLabel>
-                  <Trans>Use 24 words</Trans>
-                </FormLabel>
-                <FormDescription>
-                  <Trans>
-                    While 12 word mnemonics are sufficiently hard to crack, you
-                    can choose to use 24 instead to increase security.
-                  </Trans>
-                </FormDescription>
-              </label>
-              <FormControl>
-                <Switch
-                  id='use24Words'
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name='saveMnemonic'
-          defaultValue={true}
-          render={({ field }) => (
-            <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4 gap-2'>
-              <label htmlFor='saveMnemonic' className='space-y-0.5'>
-                <FormLabel>
-                  <Trans>Save mnemonic</Trans>
-                </FormLabel>
-                <FormDescription>
-                  <Trans>
-                    By disabling this you are creating a cold wallet, with no
-                    ability to sign transactions. The mnemonic will need to be
-                    saved elsewhere.
-                  </Trans>
-                </FormDescription>
-              </label>
-              <FormControl>
-                <Switch
-                  id='saveMnemonic'
-                  checked={field.value}
-                  onCheckedChange={field.onChange}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-
-        <div className='mt-3'>
-          <div className='flex justify-between items-center mb-2'>
-            <Label>
-              <Trans>Mnemonic</Trans>
-            </Label>
-            <div>
-              <Button
-                type='button'
-                variant='ghost'
-                size='sm'
-                onClick={loadMnemonic}
-              >
-                <RefreshCwIcon className='h-4 w-4' />
+              <Button type='submit'>
+                <Trans>Submit</Trans>
               </Button>
-              <Button
-                type='button'
-                variant='ghost'
-                size='sm'
-                onClick={copyMnemonic}
-              >
-                <CopyIcon className='h-4 w-4' />
-              </Button>
-            </div>
-          </div>
-          <div className='flex flex-wrap'>
-            {form
-              .watch('mnemonic')
-              ?.split(' ')
-              .map((word) => (
-                <Badge
-                  key={word}
-                  variant='outline'
-                  className='py-1.5 px-2.5 m-0.5 rounded-lg font-medium'
-                >
-                  {word}
-                </Badge>
-              ))}
-          </div>
-        </div>
-
-        <Button type='submit'>
-          <Trans>Submit</Trans>
-        </Button>
-      </form>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
       <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
         <DialogContent>
           <DialogHeader>
@@ -282,6 +309,7 @@ function CreateForm(props: {
               </Trans>
             </DialogDescription>
           </DialogHeader>
+
           <DialogFooter>
             <Button variant='outline' onClick={() => setIsConfirmOpen(false)}>
               <Trans>Cancel</Trans>
@@ -297,6 +325,6 @@ function CreateForm(props: {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </Form>
+    </>
   );
 }

--- a/src/pages/ImportWallet.tsx
+++ b/src/pages/ImportWallet.tsx
@@ -69,13 +69,23 @@ export default function ImportWallet() {
     },
   });
 
+  function cleanKey(key: string) {
+    return key
+      .trim()
+      .replace(/[^a-z]/gi, ' ')
+      .split(/\s+/)
+      .filter((item) => item.length > 0)
+      .join(' ')
+      .toLowerCase();
+  }
+
   const submit = (values: z.infer<typeof formSchema>) => {
     setPending(true);
 
     commands
       .importKey({
         name: values.name,
-        key: values.key,
+        key: cleanKey(values.key),
         derivation_index: parseInt(values.addresses),
         hardened,
         unhardened,

--- a/src/pages/ImportWallet.tsx
+++ b/src/pages/ImportWallet.tsx
@@ -2,6 +2,13 @@ import { EmojiPicker } from '@/components/EmojiPicker';
 import Header from '@/components/Header';
 import SafeAreaView from '@/components/SafeAreaView';
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
   Form,
   FormControl,
   FormDescription,
@@ -89,109 +96,87 @@ export default function ImportWallet() {
     <SafeAreaView>
       <Header title={t`Import Wallet`} back={() => navigate('/')} />
       <Container>
-        <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(submit)}
-            className='space-y-4 max-w-xl mx-auto py-4'
-          >
-            <FormField
-              control={form.control}
-              name='name'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    <Trans>Wallet Name</Trans>
-                  </FormLabel>
-                  <FormControl>
-                    <Input required {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='emoji'
-              render={({ field }) => (
-                <FormItem>
-                  <label htmlFor='emoji' className='space-y-0.5'>
-                    <FormLabel>
-                      <Trans>Wallet Emoji (Optional)</Trans>
-                    </FormLabel>
-                    <FormControl>
-                      <div className='flex items-center gap-2'>
-                        <EmojiPicker
-                          value={field.value}
-                          onChange={field.onChange}
-                          placeholder={t`Choose an emoji`}
-                        />
-                      </div>
-                    </FormControl>
-                    <FormDescription>
-                      <Trans>
-                        Choose an emoji to easily identify your wallet
-                      </Trans>
-                    </FormDescription>
-                  </label>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name='key'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    <Trans>Wallet Key</Trans>
-                  </FormLabel>
-                  <FormControl>
-                    <Textarea className='resize-none h-20' {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    <Trans>
-                      Enter your mnemonic, private key, or public key above. If
-                      it&apos;s a public key, it will be imported as a read-only
-                      cold wallet.
-                    </Trans>
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className='flex items-center gap-2 my-4'>
-              <label htmlFor='advanced'>
-                <Trans>Advanced options</Trans>
-              </label>
-              <Switch
-                id='advanced'
-                checked={advanced}
-                onCheckedChange={(value) => setAdvanced(value)}
-              />
-            </div>
-
-            {advanced && (
-              <>
+        {' '}
+        <Card className='mx-8'>
+          <CardHeader className='text-center'>
+            <CardTitle>
+              <Trans>Import Existing Wallet</Trans>
+            </CardTitle>
+            <CardDescription>
+              <Trans>
+                Unless you import it as a cold wallet, your seed phrase and/or
+                secret key will be viewable from the wallet card on the login
+                screen.
+              </Trans>
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(submit)}
+                className='space-y-4 max-w-xl mx-auto py-4'
+              >
                 <FormField
                   control={form.control}
-                  name='addresses'
+                  name='name'
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>
-                        <Trans>Initial Addresses</Trans>
+                        <Trans>Wallet Name</Trans>
                       </FormLabel>
                       <FormControl>
                         <Input required {...field} />
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='emoji'
+                  render={({ field }) => (
+                    <FormItem>
+                      <label htmlFor='emoji' className='space-y-0.5'>
+                        <FormLabel>
+                          <Trans>Wallet Emoji (Optional)</Trans>
+                        </FormLabel>
+                        <FormControl>
+                          <div className='flex items-center gap-2'>
+                            <EmojiPicker
+                              value={field.value}
+                              onChange={field.onChange}
+                              placeholder={t`Choose an emoji`}
+                            />
+                          </div>
+                        </FormControl>
+                        <FormDescription>
+                          <Trans>
+                            Choose an emoji to easily identify your wallet
+                          </Trans>
+                        </FormDescription>
+                      </label>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name='key'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        <Trans>Wallet Key</Trans>
+                      </FormLabel>
+                      <FormControl>
+                        <Textarea className='resize-none h-20' {...field} />
+                      </FormControl>
                       <FormDescription>
                         <Trans>
-                          The initial derivation index to sync to (both hardened
-                          and unhardened keys). This is primarily applicable to
-                          legacy wallets with either hardened keys or gaps in
-                          addresses used.
+                          Enter your mnemonic, private key, or public key above.
+                          If it&apos;s a public key, it will be imported as a
+                          read-only cold wallet.
                         </Trans>
                       </FormDescription>
                       <FormMessage />
@@ -200,45 +185,84 @@ export default function ImportWallet() {
                 />
 
                 <div className='flex items-center gap-2 my-4'>
-                  <label
-                    htmlFor='unhardened'
-                    className='text-sm text-muted-foreground'
-                  >
-                    <Trans>Unhardened Keys</Trans>
+                  <label htmlFor='advanced'>
+                    <Trans>Advanced options</Trans>
                   </label>
                   <Switch
-                    id='unhardened'
-                    checked={unhardened}
-                    onCheckedChange={(value) => setUnhardened(value)}
+                    id='advanced'
+                    checked={advanced}
+                    onCheckedChange={(value) => setAdvanced(value)}
                   />
                 </div>
 
-                <div className='flex items-center gap-2 my-4'>
-                  <label
-                    htmlFor='hardened'
-                    className='text-sm text-muted-foreground'
-                  >
-                    <Trans>Hardened Keys</Trans>
-                  </label>
-                  <Switch
-                    id='hardened'
-                    checked={hardened}
-                    onCheckedChange={(value) => setHardened(value)}
-                  />
-                </div>
-              </>
-            )}
+                {advanced && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name='addresses'
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            <Trans>Initial Addresses</Trans>
+                          </FormLabel>
+                          <FormControl>
+                            <Input required {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            <Trans>
+                              The initial derivation index to sync to (both
+                              hardened and unhardened keys). This is primarily
+                              applicable to legacy wallets with either hardened
+                              keys or gaps in addresses used.
+                            </Trans>
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
 
-            <LoadingButton
-              type='submit'
-              loading={pending}
-              loadingText={t`Importing`}
-              disabled={!form.formState.isValid}
-            >
-              <Trans>Import</Trans>
-            </LoadingButton>
-          </form>
-        </Form>
+                    <div className='flex items-center gap-2 my-4'>
+                      <label
+                        htmlFor='unhardened'
+                        className='text-sm text-muted-foreground'
+                      >
+                        <Trans>Unhardened Keys</Trans>
+                      </label>
+                      <Switch
+                        id='unhardened'
+                        checked={unhardened}
+                        onCheckedChange={(value) => setUnhardened(value)}
+                      />
+                    </div>
+
+                    <div className='flex items-center gap-2 my-4'>
+                      <label
+                        htmlFor='hardened'
+                        className='text-sm text-muted-foreground'
+                      >
+                        <Trans>Hardened Keys</Trans>
+                      </label>
+                      <Switch
+                        id='hardened'
+                        checked={hardened}
+                        onCheckedChange={(value) => setHardened(value)}
+                      />
+                    </div>
+                  </>
+                )}
+
+                <LoadingButton
+                  type='submit'
+                  loading={pending}
+                  loadingText={t`Importing`}
+                  disabled={!form.formState.isValid}
+                >
+                  <Trans>Import</Trans>
+                </LoadingButton>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
       </Container>
     </SafeAreaView>
   );


### PR DESCRIPTION
fix #681 by adding a note on the create and import screens - also add card to these screens
fix #567 clean seed phrase on import 

split on anything that isn't [a-zA-Z]
```
  function cleanKey(key: string) {
    return key
      .trim()
      .replace(/[^a-z]/gi, ' ')
      .split(/\s+/)
      .filter((item) => item.length > 0)
      .join(' ')
      .toLowerCase();
  }
  ```