### PR TITLE
fix bug with classname on estimated balance value label

### DIFF
--- a/src/pages/TokenList.tsx
+++ b/src/pages/TokenList.tsx
@@ -258,7 +258,7 @@ export function TokenList() {
                   </Tooltip>
                 </TooltipProvider>
               </div>
-              <span className='text-primary-foreground'>
+              <span className='foreground'>
                 <NumberFormat
                   value={totalUsdBalance}
                   style='currency'


### PR DESCRIPTION
The actual balance isn't visible in the light theme.