### PR TITLE
Fix tab order: remove send full balance button from tab sequence

### DIFF
--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -312,6 +312,7 @@ export default function Send() {
                                 variant='outline'
                                 size='icon'
                                 type='button'
+                                tabIndex={-1}
                                 className='!border-l-0 !rounded-l-none flex-shrink-0'
                                 onClick={() => {
                                   if (asset) {


### PR DESCRIPTION
The send full balance button was interrupting tab navigation between the amount and fee fields. Added tabIndex={-1} to exclude it from the tab order while keeping it accessible via mouse click.