### PR TITLE
fix #719

### DIFF
--- a/crates/sage-database/src/tables/assets/asset.rs
+++ b/crates/sage-database/src/tables/assets/asset.rs
@@ -183,10 +183,10 @@ async fn insert_asset(conn: impl SqliteExecutor<'_>, asset: Asset) -> Result<()>
         )
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(hash) DO UPDATE SET
-            name = COALESCE(name, excluded.name),
-            ticker = COALESCE(ticker, excluded.ticker),
-            icon_url = COALESCE(icon_url, excluded.icon_url),
-            description = COALESCE(description, excluded.description),
+            name = COALESCE(excluded.name, name),
+            ticker = COALESCE(excluded.ticker, ticker),
+            icon_url = COALESCE(excluded.icon_url, icon_url),
+            description = COALESCE(excluded.description, description),
             is_sensitive_content = is_sensitive_content OR excluded.is_sensitive_content
         ",
         hash,


### PR DESCRIPTION
Fix https://github.com/xch-dev/sage/issues/719

When a asset record is created but not submitted to the mempool, the next createion may use the same coin and then there is a conflict between the next asset record and the cancelled one. Current COALESCE in the insert clause prefers the first record rather than the latest. 

fix is to reverse that. prefer the latest record on conflict.

```sql
INSERT INTO assets (
    hash, kind, name, ticker, precision, icon_url, description,
    is_sensitive_content, is_visible, hidden_puzzle_hash
)
VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
ON CONFLICT(hash) DO UPDATE SET
    name = COALESCE(excluded.name, name),
    ticker = COALESCE(excluded.ticker, ticker),
    icon_url = COALESCE(excluded.icon_url, icon_url),
    description = COALESCE(excluded.description, description),
    is_sensitive_content = is_sensitive_content OR excluded.is_sensitive_content
```