### PR TITLE
Fix #691: display ∞ for NFT edition_total=0

### DIFF
--- a/src/components/NftCard.tsx
+++ b/src/components/NftCard.tsx
@@ -317,12 +317,12 @@ export function NftCard({ nft, updateNfts, selectionState }: NftCardProps) {
               <TooltipContent>
                 <p>
                   {nftName}
-                  {nft.edition_total != null && nft.edition_total > 1 && (
+                  {nft.edition_total != null && (nft.edition_total === 0 || nft.edition_total > 1) && (
                     <span>
                       {' '}
                       (
                       <Trans>
-                        {nft.edition_number} of {nft.edition_total}
+                        {nft.edition_number} of {nft.edition_total === 0 ? '∞' : nft.edition_total}
                       </Trans>
                       )
                     </span>

--- a/src/pages/Nft.tsx
+++ b/src/pages/Nft.tsx
@@ -272,10 +272,10 @@ export default function Nft() {
                   address={nft?.launcher_id ?? ''}
                 />
 
-                {nft?.edition_total != null && nft?.edition_total > 1 && (
+                {nft?.edition_total != null && (nft?.edition_total === 0 || nft?.edition_total > 1) && (
                   <LabeledItem
                     label={t`Edition`}
-                    content={`${nft.edition_number} of ${nft.edition_total}`}
+                    content={`${nft.edition_number} of ${nft.edition_total === 0 ? '∞' : nft.edition_total}`}
                   />
                 )}
 


### PR DESCRIPTION
## Summary

- MintGarden convention: `edition_total=0` means unlimited editions
- Previously hidden because condition only checked `> 1`
- Now shows "X of ∞" when `edition_total` is 0

## Changes

| File | Change |
|------|--------|
| `src/components/NftCard.tsx` | Condition includes `=== 0`, renders ∞ in tooltip |
| `src/pages/Nft.tsx` | Same pattern on NFT detail page |

## Test plan

- [ ] Verify NFTs with `edition_total=0` show "X of ∞" in card tooltip and detail page
- [ ] Verify NFTs with `edition_total > 1` still show "X of Y" as before
- [ ] Verify NFTs with `edition_total === 1` still hide edition info

🤖 Generated with [Claude Code](https://claude.com/claude-code)