### PR TITLE
Fix #390: make dialogs scrollable when viewport is constrained

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -64,7 +64,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-[50%] top-[50%] z-50 grid w-full md:max-w-lg max-w-sm translate-x-[-50%] translate-y-[-50%] gap-4 border bg-card p-6 text-card-foreground shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg',
+          'fixed left-[50%] top-[50%] z-50 grid w-full md:max-w-lg max-w-sm translate-x-[-50%] translate-y-[-50%] gap-4 border bg-card p-6 text-card-foreground shadow-lg duration-200 max-h-[85vh] overflow-y-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg',
           className,
         )}
         style={mergedStyles}


### PR DESCRIPTION
## Summary

- iPad landscape + virtual keyboard covers the fee dialog
- Added `max-h-[85vh] overflow-y-auto` to DialogContent
- Only activates when content exceeds 85vh — no visual change on desktop

## Changes

| File | Change |
|------|--------|
| `src/components/ui/dialog.tsx` | Add `max-h-[85vh] overflow-y-auto` to DialogContent |

## Test plan

- [ ] Open a dialog on iPad landscape with virtual keyboard — content should scroll
- [ ] Desktop dialogs should look unchanged (content doesn't exceed 85vh)
- [ ] Test FeeOnlyDialog, TransferDialog, and AssignNftDialog with keyboard active

🤖 Generated with [Claude Code](https://claude.com/claude-code)