### PR TITLE
Fix #726: improve mnemonic import error messages

### DIFF
--- a/crates/sage/src/endpoints/keys.rs
+++ b/crates/sage/src/endpoints/keys.rs
@@ -148,7 +148,30 @@ impl Sage {
                 return Err(Error::InvalidKey);
             }
         } else {
-            let mnemonic = Mnemonic::from_str(&req.key)?;
+            let words: Vec<&str> = req.key.split_whitespace().collect();
+            let word_count = words.len();
+
+            if word_count != 12 && word_count != 24 {
+                return Err(Error::InvalidMnemonic(format!(
+                    "Expected 12 or 24 words, but got {word_count}."
+                )));
+            }
+
+            let mnemonic = Mnemonic::from_str(&req.key).map_err(|e| match e {
+                bip39::Error::BadWordCount(count) => Error::InvalidMnemonic(format!(
+                    "Expected 12 or 24 words, but got {count}."
+                )),
+                bip39::Error::UnknownWord(idx) => Error::InvalidMnemonic(format!(
+                    "Word #{} ({}) is not a valid BIP39 word.",
+                    idx + 1,
+                    words.get(idx).copied().unwrap_or("unknown"),
+                )),
+                bip39::Error::InvalidChecksum => Error::InvalidMnemonic(
+                    "Invalid checksum. Please verify all words are correct and in the right order."
+                        .to_string(),
+                ),
+                _ => Error::InvalidMnemonic(format!("Invalid mnemonic: {e}")),
+            })?;
             let master_sk = SecretKey::from_seed(&mnemonic.to_seed(""));
             let master_pk = master_sk.public_key();
             let fingerprint = if req.save_secrets {

--- a/crates/sage/src/error.rs
+++ b/crates/sage/src/error.rs
@@ -122,6 +122,9 @@ pub enum Error {
     #[error("Invalid key")]
     InvalidKey,
 
+    #[error("{0}")]
+    InvalidMnemonic(String),
+
     #[error("Wrong address prefix: {0}")]
     AddressPrefix(String),
 
@@ -279,6 +282,7 @@ impl Error {
             Self::Bls(..)
             | Self::Hex(..)
             | Self::InvalidKey
+            | Self::InvalidMnemonic(..)
             | Self::TryFromSlice(..)
             | Self::TryFromInt(..)
             | Self::ParseInt(..)

--- a/src/pages/ImportWallet.tsx
+++ b/src/pages/ImportWallet.tsx
@@ -183,9 +183,10 @@ export default function ImportWallet() {
                       </FormControl>
                       <FormDescription>
                         <Trans>
-                          Enter your mnemonic, private key, or public key above.
-                          If it&apos;s a public key, it will be imported as a
-                          read-only cold wallet.
+                          Enter your 12 or 24-word mnemonic seed phrase, private
+                          key, or public key. Words should be separated by
+                          spaces. If it&apos;s a public key, it will be imported
+                          as a read-only cold wallet.
                         </Trans>
                       </FormDescription>
                       <FormMessage />


### PR DESCRIPTION
## Summary

- Replace cryptic "BIP39 error: mnemonic contains an unknown word (word 0)" with specific messages
- Pre-validate word count (must be 12 or 24)
- Map bip39 errors to user-friendly messages identifying the invalid word, wrong count, or checksum failure
- Improve helper text on import page

## Changes

| File | Change |
|------|--------|
| `crates/sage/src/error.rs` | Add `InvalidMnemonic(String)` variant |
| `crates/sage/src/endpoints/keys.rs` | Pre-validate word count, map bip39 errors to friendly messages |
| `src/pages/ImportWallet.tsx` | Improve helper text ("12 or 24-word mnemonic seed phrase") |

## Example error messages

- Wrong word count: "Expected 12 or 24 words, but got 13."
- Invalid word: "Word #5 (banan) is not a valid BIP39 word."
- Bad checksum: "Invalid checksum. Please verify all words are correct and in the right order."

## Test plan

- [ ] Import mnemonic with wrong word count → "Expected 12 or 24 words, but got N"
- [ ] Import mnemonic with a typo → "Word #N (word) is not a valid BIP39 word"
- [ ] Import mnemonic with wrong word order → checksum error message
- [ ] Import valid 12-word and 24-word mnemonics → works as before
- [ ] `cargo clippy -p sage` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)