### PR TITLE
Fix #723: validate request-only offers require a network fee

### DIFF
--- a/crates/sage/src/endpoints/offers.rs
+++ b/crates/sage/src/endpoints/offers.rs
@@ -81,6 +81,17 @@ impl Sage {
             }
         }
 
+        let has_offered_assets = offered.xch > 0
+            || !offered.cats.is_empty()
+            || !offered.nfts.is_empty()
+            || !offered.options.is_empty();
+
+        if !has_offered_assets && offered.fee == 0 {
+            return Err(Error::InvalidAmount(
+                "A request-only offer requires a network fee.".to_string(),
+            ));
+        }
+
         let mut requested = Requested::default();
         let mut peer = None;
 

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -86,6 +86,20 @@ export function MakeOffer() {
       });
       return;
     }
+
+    if (
+      !hasOfferedTokens &&
+      !hasOfferedNfts &&
+      !hasOfferedOptions &&
+      parseFloat(state.fee || '0') === 0
+    ) {
+      addError({
+        kind: 'invalid',
+        reason: t`A request-only offer requires a network fee.`,
+      });
+      return;
+    }
+
     setIsConfirmDialogOpen(true);
   };
 


### PR DESCRIPTION
## Summary

- Creating an offer with only requested assets and zero fee crashes because there are no coins to spend
- Added validation on both backend and frontend to catch this case with a clear error message

## Changes

| File | Change |
|------|--------|
| `crates/sage/src/endpoints/offers.rs` | Backend guard: no offered assets + zero fee = clear error |
| `src/pages/MakeOffer.tsx` | Frontend guard: same validation before opening confirmation dialog |

## Test plan

- [ ] Create offer with only requested assets and zero fee → "A request-only offer requires a network fee"
- [ ] Create offer with only requested assets and nonzero fee → proceeds normally
- [ ] Create normal offer (both sides) with zero fee → proceeds normally
- [ ] `cargo clippy -p sage` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)