### PR TITLE
Add a hint to the send action

### DIFF
--- a/crates/sage/src/endpoints/action_system.rs
+++ b/crates/sage/src/endpoints/action_system.rs
@@ -47,6 +47,8 @@ impl Sage {
                         &mut ctx,
                         if let Some(clawback) = clawback {
                             Hint::Clawback(clawback)
+                        } else if hinted {
+                            Hint::P2PuzzleHash(receiver_puzzle_hash)
                         } else {
                             Hint::None
                         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to memo/hint selection for send transactions; no changes to spend construction beyond adding a memo entry.
> 
> **Overview**
> Adds an automatic `Hint::P2PuzzleHash(receiver_puzzle_hash)` when building `Send` actions for non-XCH assets, so CAT sends include a receiver puzzle-hash memo hint even without clawback.
> 
> This only affects memo calculation for sends; clawback handling and puzzle-hash selection remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ff9b1d3ce7e695a4ed313d230449b80f998030d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->