### PR TITLE
update theme-o-rama to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tauri-plugin-safe-area-insets": "^0.1.0",
     "tauri-plugin-sage": "file:tauri-plugin-sage",
-    "theme-o-rama": "0.2.0",
+    "theme-o-rama": "0.2.4",
     "usehooks-ts": "^3.1.1",
     "zod": "^3.25.76",
     "zustand": "^4.5.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: file:tauri-plugin-sage
         version: tauri-plugin-sage-api@file:tauri-plugin-sage
       theme-o-rama:
-        specifier: 0.2.0
-        version: 0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.2.4
+        version: 0.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@18.3.1)
@@ -3531,8 +3531,8 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
-  theme-o-rama@0.2.0:
-    resolution: {integrity: sha512-oq+GyazY3OXnF88Aew1bzPRqXyzfdfNtpgnHlBcwXbK1rXG7PaZfUZqR3fg0YCQJtwV4tLdGP2+IvJDbiRAz0w==}
+  theme-o-rama@0.2.4:
+    resolution: {integrity: sha512-6WyTnr2NdzzeW4p6vMdp4nk913+SH3EFa2egNlBodckup3KaF+puNcDww/pDHc1My/q3JHd+m+yrWvUO18fRlA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -7436,7 +7436,7 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  theme-o-rama@0.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  theme-o-rama@0.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
the corrects cutton style attributes not being cleared when switching themes. this shows up as things like button shimmer sticking around when it shouldn.t

the fix is in the theme-o-ramam package so `pnpm install` is needed to test