### PR TITLE
Coin selection unit tests

### DIFF
--- a/crates/sage-wallet/src/wallet/offer.rs
+++ b/crates/sage-wallet/src/wallet/offer.rs
@@ -623,7 +623,12 @@ mod tests {
 
         let offer = alice
             .wallet
-            .sign_transaction(unsigned_offer, &alice.agg_sig, alice.master_sk.clone(), true)
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
             .await?;
 
         // Take offer
@@ -698,7 +703,12 @@ mod tests {
 
         let offer = alice
             .wallet
-            .sign_transaction(unsigned_offer, &alice.agg_sig, alice.master_sk.clone(), true)
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
             .await?;
 
         // Take offer
@@ -765,7 +775,12 @@ mod tests {
 
         let offer = alice
             .wallet
-            .sign_transaction(unsigned_offer, &alice.agg_sig, alice.master_sk.clone(), true)
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
             .await?;
 
         // Take offer
@@ -968,17 +983,14 @@ mod tests {
         Ok(())
     }
 
-    /// Reproduces a bug where make_offer with coin_ids selects additional
-    /// maker coins beyond the ones explicitly specified, even when the
-    /// selected coin has enough value to cover the offer amount + fee.
+    /// When the selected coin covers the full offer amount + fee, no
+    /// additional coins should be auto-selected.
     #[test(tokio::test)]
-    async fn test_offer_selected_coin_should_not_add_extra_inputs() -> anyhow::Result<()> {
-        // Alice starts with 2000 mojos
+    async fn test_offer_selected_coin_covers_amount_plus_fee_no_extra() -> anyhow::Result<()> {
         let mut alice = TestWallet::new(2000).await?;
         let mut bob = alice.next(1000).await?;
 
-        // Split Alice's XCH into multiple coins so the auto-selector has
-        // candidates it could grab if the guard condition fails.
+        // Split into 4 coins (~500 each) so auto-selector has candidates
         let coins = alice.wallet.db.selectable_xch_coins().await?;
         let coin_spends = alice
             .wallet
@@ -989,27 +1001,23 @@ mod tests {
 
         let coins = alice.wallet.db.selectable_xch_coins().await?;
         assert_eq!(coins.len(), 4);
-        // Each coin is ~500 mojos
 
-        // Issue a CAT for Bob so we have something to request
         let (coin_spends, asset_id) = bob.wallet.issue_cat(1000, 0, None).await?;
         bob.transact(coin_spends).await?;
         bob.wait_for_coins().await;
 
-        // Pick the largest coin to use as the selected maker coin.
-        // Offer 300 XCH + 100 fee = 400 total. The coin (~500) has ~25% headroom.
+        // Pick the largest coin. Offer 300 + fee 100 = 400 total.
+        // Coin (~500) has headroom above amount + fee.
         let selected_coin = coins.iter().max_by_key(|c| c.amount).copied().unwrap();
         let offer_amount = 300u64;
         let fee_amount = 100u64;
         assert!(
             selected_coin.amount >= offer_amount + fee_amount,
-            "Selected coin ({}) should cover offer + fee ({})",
+            "Selected coin ({}) must cover offer + fee ({})",
             selected_coin.amount,
             offer_amount + fee_amount
         );
 
-        // Collect all XCH coin IDs before the offer so we can check which
-        // ones end up in the spend bundle.
         let all_xch_coin_ids: std::collections::HashSet<Bytes32> =
             coins.iter().map(|c| c.coin_id()).collect();
 
@@ -1035,73 +1043,60 @@ mod tests {
             )
             .await?;
 
-        // Count how many of Alice's XCH coins appear in the offer's coin spends.
         let xch_spends_in_offer: Vec<_> = unsigned_offer
             .coin_spends
             .iter()
             .filter(|cs| all_xch_coin_ids.contains(&cs.coin.coin_id()))
             .collect();
 
-        // BUG: The offer should only contain the single selected coin as a
-        // maker XCH input. If this assertion fails, the coin selector is
-        // pulling in extra coins despite the caller explicitly specifying
-        // which coin(s) to use.
         assert_eq!(
             xch_spends_in_offer.len(),
             1,
-            "Expected exactly 1 XCH coin spend (the selected coin), but found {}. \
-             coin_ids should be a hard constraint, not a hint. \
-             Spent XCH coins: {:?}",
+            "When selected coin covers amount + fee, no extra coins should be added. \
+             Found {} XCH spends: {:?}",
             xch_spends_in_offer.len(),
             xch_spends_in_offer
                 .iter()
                 .map(|cs| (cs.coin.coin_id(), cs.coin.amount))
                 .collect::<Vec<_>>()
         );
-
-        // And it must be the coin we selected
         assert_eq!(
             xch_spends_in_offer[0].coin.coin_id(),
             selected_coin.coin_id(),
-            "The XCH spend should be the coin we selected"
         );
 
-        // Verify the offer is still valid end-to-end
+        // Verify end-to-end: offer can be taken successfully
         let offer = alice
             .wallet
-            .sign_transaction(unsigned_offer, &alice.agg_sig, alice.master_sk.clone(), true)
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
             .await?;
-
         let offer = bob.wallet.take_offer(offer, 0).await?;
         let spend_bundle = bob
             .wallet
             .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
             .await?;
         bob.push_bundle(spend_bundle).await?;
-
         bob.wait_for_coins().await;
         alice.wait_for_puzzles().await;
-
         assert_eq!(alice.wallet.db.cat_balance(asset_id).await?, 1000);
 
         Ok(())
     }
 
-    /// Reproduces the reported bug: the selected coin has ~10% headroom above
-    /// the XCH offer amount, but the fee pushes the total beyond the coin's
-    /// value. select_spends then silently auto-selects additional coins from
-    /// the wallet, resulting in 2 maker inputs instead of 1.
-    ///
-    /// The user's expectation when providing coin_ids is that ONLY those coins
-    /// are used. If they're insufficient, the call should fail rather than
-    /// silently grabbing more coins from the wallet.
+    /// When the selected coin does NOT cover the offer amount + fee,
+    /// it is ok for the wallet to auto-select additional coins to
+    /// make up the difference.
     #[test(tokio::test)]
-    async fn test_offer_selected_coin_with_fee_should_not_add_extra_inputs() -> anyhow::Result<()> {
-        // Alice starts with 5000 mojos
+    async fn test_offer_selected_coin_insufficient_allows_extra() -> anyhow::Result<()> {
         let mut alice = TestWallet::new(5000).await?;
-        let bob = alice.next(1000).await?;
+        let mut bob = alice.next(1000).await?;
 
-        // Split Alice's XCH into multiple coins so auto-selector has candidates
+        // Split into 5 coins (~1000 each)
         let coins = alice.wallet.db.selectable_xch_coins().await?;
         let coin_spends = alice
             .wallet
@@ -1112,33 +1107,25 @@ mod tests {
 
         let coins = alice.wallet.db.selectable_xch_coins().await?;
         assert_eq!(coins.len(), 5);
-        // Each coin is ~1000 mojos
 
-        // Issue a CAT for Bob
         let (coin_spends, asset_id) = bob.wallet.issue_cat(500, 0, None).await?;
-        // Bob needs to be mutable for transact
-        let mut bob = bob;
         bob.transact(coin_spends).await?;
         bob.wait_for_coins().await;
 
-        // Pick one coin (~1000 mojos). Offer 900 XCH + 200 fee = 1100 total.
-        // The coin has ~11% headroom above the offer amount (900) but NOT
-        // enough for offer + fee (1100). This is the "10% headroom" scenario
-        // from the bug report.
+        // Pick one coin (~1000). Offer 900 + fee 200 = 1100 total.
+        // The coin has headroom above the offer amount but NOT above amount + fee.
         let selected_coin = coins.iter().max_by_key(|c| c.amount).copied().unwrap();
         let offer_amount = (selected_coin.amount as f64 * 0.9) as u64;
         let fee_amount = (selected_coin.amount as f64 * 0.2) as u64;
-        // Verify setup: coin covers xch but NOT xch + fee
         assert!(
             selected_coin.amount >= offer_amount,
-            "Coin should cover the offer amount"
+            "Coin should cover the offer amount alone"
         );
         assert!(
             selected_coin.amount < offer_amount + fee_amount,
-            "Coin should NOT cover offer + fee (this is the bug trigger)"
+            "Coin should NOT cover offer + fee"
         );
 
-        // Collect all XCH coin IDs
         let all_xch_coin_ids: std::collections::HashSet<Bytes32> =
             coins.iter().map(|c| c.coin_id()).collect();
 
@@ -1164,33 +1151,250 @@ mod tests {
             )
             .await?;
 
-        // Count XCH coins used in the offer
         let xch_spends_in_offer: Vec<_> = unsigned_offer
             .coin_spends
             .iter()
             .filter(|cs| all_xch_coin_ids.contains(&cs.coin.coin_id()))
             .collect();
 
-        // BUG: When coin_ids are provided, only those coins should be used.
-        // This assertion documents the DESIRED behavior and will FAIL with
-        // the current code because select_spends auto-selects additional
-        // coins to cover the shortfall (xch + fee - coin_amount).
-        assert_eq!(
-            xch_spends_in_offer.len(),
-            1,
-            "BUG: Expected exactly 1 XCH coin spend (the selected coin), but found {}. \
-             select_spends silently added extra coins beyond what was specified in coin_ids. \
-             Selected coin: {} mojos, offer: {}, fee: {}, total needed: {}. \
-             Spent XCH coins: {:?}",
-            xch_spends_in_offer.len(),
-            selected_coin.amount,
-            offer_amount,
-            fee_amount,
-            offer_amount + fee_amount,
+        // Extra coins are expected when the selected coin is insufficient
+        assert!(
+            xch_spends_in_offer.len() > 1,
+            "When selected coin doesn't cover amount + fee, additional coins \
+             should be auto-selected. Found only {} XCH spend(s).",
+            xch_spends_in_offer.len()
+        );
+
+        // The originally selected coin must still be among them
+        assert!(
             xch_spends_in_offer
+                .iter()
+                .any(|cs| cs.coin.coin_id() == selected_coin.coin_id()),
+            "The selected coin must be included in the offer"
+        );
+
+        // Verify end-to-end: offer can be taken successfully
+        let offer = alice
+            .wallet
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
+            .await?;
+        let offer = bob.wallet.take_offer(offer, 0).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+        bob.wait_for_coins().await;
+        alice.wait_for_puzzles().await;
+        assert_eq!(alice.wallet.db.cat_balance(asset_id).await?, 500);
+
+        Ok(())
+    }
+
+    /// When the selected CAT coin covers the full offered CAT amount,
+    /// no additional CAT coins should be auto-selected.
+    #[test(tokio::test)]
+    async fn test_offer_selected_cat_covers_amount_no_extra() -> anyhow::Result<()> {
+        let mut alice = TestWallet::new(2000).await?;
+        let mut bob = alice.next(1000).await?;
+
+        // Issue CAT for Alice and split into multiple coins
+        let (coin_spends, asset_id) = alice.wallet.issue_cat(2000, 0, None).await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let cats = alice.wallet.db.selectable_cat_coins(asset_id).await?;
+        assert_eq!(cats.len(), 1);
+        let coin_spends = alice
+            .wallet
+            .split(vec![cats[0].coin.coin_id()], 4, 0)
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let cats = alice.wallet.db.selectable_cat_coins(asset_id).await?;
+        assert_eq!(cats.len(), 4);
+        // Each CAT coin is ~500
+
+        // Pick the largest CAT coin. Offer 300 CATs — coin (~500) has headroom.
+        let selected_cat = cats.iter().max_by_key(|c| c.coin.amount).unwrap();
+        let offer_amount = 300u64;
+        assert!(
+            selected_cat.coin.amount >= offer_amount,
+            "Selected CAT coin ({}) must cover the offered amount ({})",
+            selected_cat.coin.amount,
+            offer_amount
+        );
+
+        let all_cat_coin_ids: std::collections::HashSet<Bytes32> =
+            cats.iter().map(|c| c.coin.coin_id()).collect();
+
+        let unsigned_offer = alice
+            .wallet
+            .make_offer(
+                Offered {
+                    cats: indexmap! { asset_id => offer_amount },
+                    selected_coin_ids: vec![selected_cat.coin.coin_id()],
+                    ..Default::default()
+                },
+                Requested {
+                    xch: 500,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+
+        let cat_spends_in_offer: Vec<_> = unsigned_offer
+            .coin_spends
+            .iter()
+            .filter(|cs| all_cat_coin_ids.contains(&cs.coin.coin_id()))
+            .collect();
+
+        assert_eq!(
+            cat_spends_in_offer.len(),
+            1,
+            "When selected CAT coin covers the offered amount, no extra CAT coins \
+             should be added. Found {} CAT spends: {:?}",
+            cat_spends_in_offer.len(),
+            cat_spends_in_offer
                 .iter()
                 .map(|cs| (cs.coin.coin_id(), cs.coin.amount))
                 .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            cat_spends_in_offer[0].coin.coin_id(),
+            selected_cat.coin.coin_id(),
+        );
+
+        // Verify end-to-end
+        let offer = alice
+            .wallet
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
+            .await?;
+        let offer = bob.wallet.take_offer(offer, 0).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+        bob.wait_for_coins().await;
+        alice.wait_for_puzzles().await;
+        assert_eq!(
+            bob.wallet.db.cat_balance(asset_id).await?,
+            offer_amount as u128
+        );
+
+        Ok(())
+    }
+
+    /// When the selected CAT coin does NOT cover the full offered CAT amount,
+    /// it is ok for the wallet to auto-select additional CAT coins.
+    #[test(tokio::test)]
+    async fn test_offer_selected_cat_insufficient_allows_extra() -> anyhow::Result<()> {
+        let mut alice = TestWallet::new(2000).await?;
+        let mut bob = alice.next(1000).await?;
+
+        // Issue CAT for Alice and split into multiple coins
+        let (coin_spends, asset_id) = alice.wallet.issue_cat(2000, 0, None).await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let cats = alice.wallet.db.selectable_cat_coins(asset_id).await?;
+        assert_eq!(cats.len(), 1);
+        let coin_spends = alice
+            .wallet
+            .split(vec![cats[0].coin.coin_id()], 4, 0)
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let cats = alice.wallet.db.selectable_cat_coins(asset_id).await?;
+        assert_eq!(cats.len(), 4);
+        // Each CAT coin is ~500
+
+        // Pick one CAT coin (~500). Offer 800 CATs — coin is insufficient.
+        let selected_cat = cats.iter().max_by_key(|c| c.coin.amount).unwrap();
+        let offer_amount = 800u64;
+        assert!(
+            selected_cat.coin.amount < offer_amount,
+            "Selected CAT coin ({}) should NOT cover the offered amount ({})",
+            selected_cat.coin.amount,
+            offer_amount
+        );
+
+        let all_cat_coin_ids: std::collections::HashSet<Bytes32> =
+            cats.iter().map(|c| c.coin.coin_id()).collect();
+
+        let unsigned_offer = alice
+            .wallet
+            .make_offer(
+                Offered {
+                    cats: indexmap! { asset_id => offer_amount },
+                    selected_coin_ids: vec![selected_cat.coin.coin_id()],
+                    ..Default::default()
+                },
+                Requested {
+                    xch: 500,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+
+        let cat_spends_in_offer: Vec<_> = unsigned_offer
+            .coin_spends
+            .iter()
+            .filter(|cs| all_cat_coin_ids.contains(&cs.coin.coin_id()))
+            .collect();
+
+        // Extra CAT coins are expected when the selected coin is insufficient
+        assert!(
+            cat_spends_in_offer.len() > 1,
+            "When selected CAT coin doesn't cover the offered amount, additional \
+             CAT coins should be auto-selected. Found only {} CAT spend(s).",
+            cat_spends_in_offer.len()
+        );
+
+        // The originally selected coin must still be among them
+        assert!(
+            cat_spends_in_offer
+                .iter()
+                .any(|cs| cs.coin.coin_id() == selected_cat.coin.coin_id()),
+            "The selected CAT coin must be included in the offer"
+        );
+
+        // Verify end-to-end
+        let offer = alice
+            .wallet
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
+            .await?;
+        let offer = bob.wallet.take_offer(offer, 0).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+        bob.wait_for_coins().await;
+        alice.wait_for_puzzles().await;
+        assert_eq!(
+            bob.wallet.db.cat_balance(asset_id).await?,
+            offer_amount as u128
         );
 
         Ok(())

--- a/crates/sage-wallet/src/wallet/offer.rs
+++ b/crates/sage-wallet/src/wallet/offer.rs
@@ -1399,4 +1399,247 @@ mod tests {
 
         Ok(())
     }
+
+    /// When multiple pre-selected XCH coins together cover amount + fee (but
+    /// neither alone does), no additional coins should be auto-selected.
+    #[test(tokio::test)]
+    async fn test_offer_multiple_selected_xch_coins_cover_amount_plus_fee_no_extra()
+    -> anyhow::Result<()> {
+        let mut alice = TestWallet::new(2000).await?;
+        let mut bob = alice.next(1000).await?;
+
+        // Split into 4 coins (~500 each)
+        let coins = alice.wallet.db.selectable_xch_coins().await?;
+        let coin_spends = alice
+            .wallet
+            .split(coins.iter().map(Coin::coin_id).collect(), 4, 0)
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let coins = alice.wallet.db.selectable_xch_coins().await?;
+        assert_eq!(coins.len(), 4);
+
+        let (coin_spends, asset_id) = bob.wallet.issue_cat(1000, 0, None).await?;
+        bob.transact(coin_spends).await?;
+        bob.wait_for_coins().await;
+
+        // Pick two smallest coins. Each is ~500; together ~1000.
+        // Offer 700 + fee 200 = 900. Neither coin alone covers 900, but together they do.
+        let mut sorted = coins.clone();
+        sorted.sort_by_key(|c| c.amount);
+        let coin_a = sorted[0];
+        let coin_b = sorted[1];
+        let offer_amount = 700u64;
+        let fee_amount = 200u64;
+        let required = offer_amount + fee_amount;
+        assert!(
+            coin_a.amount < required,
+            "coin_a ({}) should not cover amount + fee ({}) alone",
+            coin_a.amount,
+            required
+        );
+        assert!(
+            coin_b.amount < required,
+            "coin_b ({}) should not cover amount + fee ({}) alone",
+            coin_b.amount,
+            required
+        );
+        assert!(
+            coin_a.amount + coin_b.amount >= required,
+            "coin_a + coin_b ({}) must cover amount + fee ({})",
+            coin_a.amount + coin_b.amount,
+            required
+        );
+
+        let all_xch_coin_ids: std::collections::HashSet<Bytes32> =
+            coins.iter().map(|c| c.coin_id()).collect();
+
+        let unsigned_offer = alice
+            .wallet
+            .make_offer(
+                Offered {
+                    xch: offer_amount,
+                    fee: fee_amount,
+                    selected_coin_ids: vec![coin_a.coin_id(), coin_b.coin_id()],
+                    ..Default::default()
+                },
+                Requested {
+                    cats: indexmap! {
+                        asset_id => RequestedCat {
+                            amount: 1000,
+                            hidden_puzzle_hash: None,
+                        }
+                    },
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+
+        let xch_spends_in_offer: Vec<_> = unsigned_offer
+            .coin_spends
+            .iter()
+            .filter(|cs| all_xch_coin_ids.contains(&cs.coin.coin_id()))
+            .collect();
+
+        assert_eq!(
+            xch_spends_in_offer.len(),
+            2,
+            "Only the two pre-selected XCH coins should be spent, found {}: {:?}",
+            xch_spends_in_offer.len(),
+            xch_spends_in_offer
+                .iter()
+                .map(|cs| (cs.coin.coin_id(), cs.coin.amount))
+                .collect::<Vec<_>>()
+        );
+
+        let spent_ids: std::collections::HashSet<Bytes32> = xch_spends_in_offer
+            .iter()
+            .map(|cs| cs.coin.coin_id())
+            .collect();
+        assert!(spent_ids.contains(&coin_a.coin_id()));
+        assert!(spent_ids.contains(&coin_b.coin_id()));
+
+        // Verify end-to-end
+        let offer = alice
+            .wallet
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
+            .await?;
+        let offer = bob.wallet.take_offer(offer, 0).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+        bob.wait_for_coins().await;
+        alice.wait_for_puzzles().await;
+        assert_eq!(alice.wallet.db.cat_balance(asset_id).await?, 1000);
+
+        Ok(())
+    }
+
+    /// When multiple pre-selected CAT coins together cover the offered CAT amount
+    /// (but neither alone does), no additional CAT coins should be auto-selected.
+    #[test(tokio::test)]
+    async fn test_offer_multiple_selected_cat_coins_cover_amount_no_extra() -> anyhow::Result<()> {
+        let mut alice = TestWallet::new(2000).await?;
+        let mut bob = alice.next(1000).await?;
+
+        // Issue CAT for Alice and split into 4 coins (~500 each)
+        let (coin_spends, asset_id) = alice.wallet.issue_cat(2000, 0, None).await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let cats = alice.wallet.db.selectable_cat_coins(asset_id).await?;
+        assert_eq!(cats.len(), 1);
+        let coin_spends = alice
+            .wallet
+            .split(vec![cats[0].coin.coin_id()], 4, 0)
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let cats = alice.wallet.db.selectable_cat_coins(asset_id).await?;
+        assert_eq!(cats.len(), 4);
+
+        // Pick two smallest CAT coins. Each is ~500; together ~1000.
+        // Offer 700 CATs — neither coin alone covers 700, but together they do.
+        let mut sorted = cats.clone();
+        sorted.sort_by_key(|c| c.coin.amount);
+        let cat_a = sorted[0].clone();
+        let cat_b = sorted[1].clone();
+        let offer_amount = 700u64;
+        assert!(
+            cat_a.coin.amount < offer_amount,
+            "cat_a ({}) should not cover the offered amount ({}) alone",
+            cat_a.coin.amount,
+            offer_amount
+        );
+        assert!(
+            cat_b.coin.amount < offer_amount,
+            "cat_b ({}) should not cover the offered amount ({}) alone",
+            cat_b.coin.amount,
+            offer_amount
+        );
+        assert!(
+            cat_a.coin.amount + cat_b.coin.amount >= offer_amount,
+            "cat_a + cat_b ({}) must cover the offered amount ({})",
+            cat_a.coin.amount + cat_b.coin.amount,
+            offer_amount
+        );
+
+        let all_cat_coin_ids: std::collections::HashSet<Bytes32> =
+            cats.iter().map(|c| c.coin.coin_id()).collect();
+
+        let unsigned_offer = alice
+            .wallet
+            .make_offer(
+                Offered {
+                    cats: indexmap! { asset_id => offer_amount },
+                    selected_coin_ids: vec![cat_a.coin.coin_id(), cat_b.coin.coin_id()],
+                    ..Default::default()
+                },
+                Requested {
+                    xch: 500,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+
+        let cat_spends_in_offer: Vec<_> = unsigned_offer
+            .coin_spends
+            .iter()
+            .filter(|cs| all_cat_coin_ids.contains(&cs.coin.coin_id()))
+            .collect();
+
+        assert_eq!(
+            cat_spends_in_offer.len(),
+            2,
+            "Only the two pre-selected CAT coins should be spent, found {}: {:?}",
+            cat_spends_in_offer.len(),
+            cat_spends_in_offer
+                .iter()
+                .map(|cs| (cs.coin.coin_id(), cs.coin.amount))
+                .collect::<Vec<_>>()
+        );
+
+        let spent_ids: std::collections::HashSet<Bytes32> = cat_spends_in_offer
+            .iter()
+            .map(|cs| cs.coin.coin_id())
+            .collect();
+        assert!(spent_ids.contains(&cat_a.coin.coin_id()));
+        assert!(spent_ids.contains(&cat_b.coin.coin_id()));
+
+        // Verify end-to-end
+        let offer = alice
+            .wallet
+            .sign_transaction(
+                unsigned_offer,
+                &alice.agg_sig,
+                alice.master_sk.clone(),
+                true,
+            )
+            .await?;
+        let offer = bob.wallet.take_offer(offer, 0).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+        bob.wait_for_coins().await;
+        alice.wait_for_puzzles().await;
+        assert_eq!(
+            bob.wallet.db.cat_balance(asset_id).await?,
+            offer_amount as u128
+        );
+
+        Ok(())
+    }
 }

--- a/crates/sage-wallet/src/wallet/offer.rs
+++ b/crates/sage-wallet/src/wallet/offer.rs
@@ -967,4 +967,232 @@ mod tests {
 
         Ok(())
     }
+
+    /// Reproduces a bug where make_offer with coin_ids selects additional
+    /// maker coins beyond the ones explicitly specified, even when the
+    /// selected coin has enough value to cover the offer amount + fee.
+    #[test(tokio::test)]
+    async fn test_offer_selected_coin_should_not_add_extra_inputs() -> anyhow::Result<()> {
+        // Alice starts with 2000 mojos
+        let mut alice = TestWallet::new(2000).await?;
+        let mut bob = alice.next(1000).await?;
+
+        // Split Alice's XCH into multiple coins so the auto-selector has
+        // candidates it could grab if the guard condition fails.
+        let coins = alice.wallet.db.selectable_xch_coins().await?;
+        let coin_spends = alice
+            .wallet
+            .split(coins.iter().map(Coin::coin_id).collect(), 4, 0)
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let coins = alice.wallet.db.selectable_xch_coins().await?;
+        assert_eq!(coins.len(), 4);
+        // Each coin is ~500 mojos
+
+        // Issue a CAT for Bob so we have something to request
+        let (coin_spends, asset_id) = bob.wallet.issue_cat(1000, 0, None).await?;
+        bob.transact(coin_spends).await?;
+        bob.wait_for_coins().await;
+
+        // Pick the largest coin to use as the selected maker coin.
+        // Offer 300 XCH + 100 fee = 400 total. The coin (~500) has ~25% headroom.
+        let selected_coin = coins.iter().max_by_key(|c| c.amount).copied().unwrap();
+        let offer_amount = 300u64;
+        let fee_amount = 100u64;
+        assert!(
+            selected_coin.amount >= offer_amount + fee_amount,
+            "Selected coin ({}) should cover offer + fee ({})",
+            selected_coin.amount,
+            offer_amount + fee_amount
+        );
+
+        // Collect all XCH coin IDs before the offer so we can check which
+        // ones end up in the spend bundle.
+        let all_xch_coin_ids: std::collections::HashSet<Bytes32> =
+            coins.iter().map(|c| c.coin_id()).collect();
+
+        let unsigned_offer = alice
+            .wallet
+            .make_offer(
+                Offered {
+                    xch: offer_amount,
+                    fee: fee_amount,
+                    selected_coin_ids: vec![selected_coin.coin_id()],
+                    ..Default::default()
+                },
+                Requested {
+                    cats: indexmap! {
+                        asset_id => RequestedCat {
+                            amount: 1000,
+                            hidden_puzzle_hash: None,
+                        }
+                    },
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+
+        // Count how many of Alice's XCH coins appear in the offer's coin spends.
+        let xch_spends_in_offer: Vec<_> = unsigned_offer
+            .coin_spends
+            .iter()
+            .filter(|cs| all_xch_coin_ids.contains(&cs.coin.coin_id()))
+            .collect();
+
+        // BUG: The offer should only contain the single selected coin as a
+        // maker XCH input. If this assertion fails, the coin selector is
+        // pulling in extra coins despite the caller explicitly specifying
+        // which coin(s) to use.
+        assert_eq!(
+            xch_spends_in_offer.len(),
+            1,
+            "Expected exactly 1 XCH coin spend (the selected coin), but found {}. \
+             coin_ids should be a hard constraint, not a hint. \
+             Spent XCH coins: {:?}",
+            xch_spends_in_offer.len(),
+            xch_spends_in_offer
+                .iter()
+                .map(|cs| (cs.coin.coin_id(), cs.coin.amount))
+                .collect::<Vec<_>>()
+        );
+
+        // And it must be the coin we selected
+        assert_eq!(
+            xch_spends_in_offer[0].coin.coin_id(),
+            selected_coin.coin_id(),
+            "The XCH spend should be the coin we selected"
+        );
+
+        // Verify the offer is still valid end-to-end
+        let offer = alice
+            .wallet
+            .sign_transaction(unsigned_offer, &alice.agg_sig, alice.master_sk.clone(), true)
+            .await?;
+
+        let offer = bob.wallet.take_offer(offer, 0).await?;
+        let spend_bundle = bob
+            .wallet
+            .sign_transaction(offer, &bob.agg_sig, bob.master_sk.clone(), true)
+            .await?;
+        bob.push_bundle(spend_bundle).await?;
+
+        bob.wait_for_coins().await;
+        alice.wait_for_puzzles().await;
+
+        assert_eq!(alice.wallet.db.cat_balance(asset_id).await?, 1000);
+
+        Ok(())
+    }
+
+    /// Reproduces the reported bug: the selected coin has ~10% headroom above
+    /// the XCH offer amount, but the fee pushes the total beyond the coin's
+    /// value. select_spends then silently auto-selects additional coins from
+    /// the wallet, resulting in 2 maker inputs instead of 1.
+    ///
+    /// The user's expectation when providing coin_ids is that ONLY those coins
+    /// are used. If they're insufficient, the call should fail rather than
+    /// silently grabbing more coins from the wallet.
+    #[test(tokio::test)]
+    async fn test_offer_selected_coin_with_fee_should_not_add_extra_inputs() -> anyhow::Result<()> {
+        // Alice starts with 5000 mojos
+        let mut alice = TestWallet::new(5000).await?;
+        let bob = alice.next(1000).await?;
+
+        // Split Alice's XCH into multiple coins so auto-selector has candidates
+        let coins = alice.wallet.db.selectable_xch_coins().await?;
+        let coin_spends = alice
+            .wallet
+            .split(coins.iter().map(Coin::coin_id).collect(), 5, 0)
+            .await?;
+        alice.transact(coin_spends).await?;
+        alice.wait_for_coins().await;
+
+        let coins = alice.wallet.db.selectable_xch_coins().await?;
+        assert_eq!(coins.len(), 5);
+        // Each coin is ~1000 mojos
+
+        // Issue a CAT for Bob
+        let (coin_spends, asset_id) = bob.wallet.issue_cat(500, 0, None).await?;
+        // Bob needs to be mutable for transact
+        let mut bob = bob;
+        bob.transact(coin_spends).await?;
+        bob.wait_for_coins().await;
+
+        // Pick one coin (~1000 mojos). Offer 900 XCH + 200 fee = 1100 total.
+        // The coin has ~11% headroom above the offer amount (900) but NOT
+        // enough for offer + fee (1100). This is the "10% headroom" scenario
+        // from the bug report.
+        let selected_coin = coins.iter().max_by_key(|c| c.amount).copied().unwrap();
+        let offer_amount = (selected_coin.amount as f64 * 0.9) as u64;
+        let fee_amount = (selected_coin.amount as f64 * 0.2) as u64;
+        // Verify setup: coin covers xch but NOT xch + fee
+        assert!(
+            selected_coin.amount >= offer_amount,
+            "Coin should cover the offer amount"
+        );
+        assert!(
+            selected_coin.amount < offer_amount + fee_amount,
+            "Coin should NOT cover offer + fee (this is the bug trigger)"
+        );
+
+        // Collect all XCH coin IDs
+        let all_xch_coin_ids: std::collections::HashSet<Bytes32> =
+            coins.iter().map(|c| c.coin_id()).collect();
+
+        let unsigned_offer = alice
+            .wallet
+            .make_offer(
+                Offered {
+                    xch: offer_amount,
+                    fee: fee_amount,
+                    selected_coin_ids: vec![selected_coin.coin_id()],
+                    ..Default::default()
+                },
+                Requested {
+                    cats: indexmap! {
+                        asset_id => RequestedCat {
+                            amount: 500,
+                            hidden_puzzle_hash: None,
+                        }
+                    },
+                    ..Default::default()
+                },
+                None,
+            )
+            .await?;
+
+        // Count XCH coins used in the offer
+        let xch_spends_in_offer: Vec<_> = unsigned_offer
+            .coin_spends
+            .iter()
+            .filter(|cs| all_xch_coin_ids.contains(&cs.coin.coin_id()))
+            .collect();
+
+        // BUG: When coin_ids are provided, only those coins should be used.
+        // This assertion documents the DESIRED behavior and will FAIL with
+        // the current code because select_spends auto-selects additional
+        // coins to cover the shortfall (xch + fee - coin_amount).
+        assert_eq!(
+            xch_spends_in_offer.len(),
+            1,
+            "BUG: Expected exactly 1 XCH coin spend (the selected coin), but found {}. \
+             select_spends silently added extra coins beyond what was specified in coin_ids. \
+             Selected coin: {} mojos, offer: {}, fee: {}, total needed: {}. \
+             Spent XCH coins: {:?}",
+            xch_spends_in_offer.len(),
+            selected_coin.amount,
+            offer_amount,
+            fee_amount,
+            offer_amount + fee_amount,
+            xch_spends_in_offer
+                .iter()
+                .map(|cs| (cs.coin.coin_id(), cs.coin.amount))
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
unit tests for https://github.com/xch-dev/sage/issues/762

Test that coin selection in `make_offer` is not overly eager when pre-selected coins cover the offer amount.