### PR TITLE
Add hardened key option to getPublicKeys

### DIFF
--- a/src/walletconnect/commands.ts
+++ b/src/walletconnect/commands.ts
@@ -88,6 +88,7 @@ export const walletConnectCommands = {
       .object({
         limit: z.number().optional(),
         offset: z.number().optional(),
+        hardened: z.boolean().optional(),
       })
       .optional(),
     returnType: z.array(z.string()),

--- a/src/walletconnect/commands/chip0002.ts
+++ b/src/walletconnect/commands/chip0002.ts
@@ -20,6 +20,7 @@ export async function handleGetPublicKeys(
   const data = await commands.getDerivations({
     limit: params?.limit ?? 10,
     offset: params?.offset ?? 0,
+    hardened: params?.hardened ?? false,
   });
 
   return data.derivations.map((derivation) => derivation.public_key);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds an optional boolean parameter to a WalletConnect command and threads it through to an existing `getDerivations` call, with a safe default of `false`. Main risk is minor compatibility issues if callers or backend expect different param shapes.
> 
> **Overview**
> Adds an optional `hardened` flag to the WalletConnect `chip0002_getPublicKeys` command schema and forwards it to `commands.getDerivations` (defaulting to `false`). This lets callers request public keys derived from hardened paths without changing the command’s return shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 551444f0f12195a4572a57c7cf10171a4ee12284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->