### PR TITLE
Duplicate offer

### DIFF
--- a/src/components/OfferRowCard.tsx
+++ b/src/components/OfferRowCard.tsx
@@ -2,6 +2,7 @@ import { commands, OfferRecord, TransactionResponse } from '@/bindings';
 import ConfirmationDialog from '@/components/ConfirmationDialog';
 import { CancelOfferDialog } from '@/components/dialogs/CancelOfferDialog';
 import { DeleteOfferDialog } from '@/components/dialogs/DeleteOfferDialog';
+import { DuplicateOfferDialog } from '@/components/dialogs/DuplicateOfferDialog';
 import { OfferSummaryCard } from '@/components/OfferSummaryCard';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,6 +25,7 @@ import BigNumber from 'bignumber.js';
 import {
   CircleOff,
   CopyIcon,
+  CopyPlus,
   MoreVertical,
   Tags,
   TrashIcon,
@@ -44,6 +46,11 @@ export function OfferRowCard({ record, refresh }: OfferRowCardProps) {
   const { addError } = useErrors();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isCancelOpen, setIsCancelOpen] = useState(false);
+  const [isDuplicateOpen, setIsDuplicateOpen] = useState(false);
+
+  const isTokenOnlyOffer = record.summary.maker.every(
+    (a) => a.asset.kind === 'token',
+  );
 
   const cancelSchema = z.object({
     fee: amount(walletState.sync.unit.precision).refine(
@@ -144,6 +151,22 @@ export function OfferRowCard({ record, refresh }: OfferRowCardProps) {
                       <Trans>Copy ID</Trans>
                     </span>
                   </DropdownMenuItem>
+
+                  <DropdownMenuSeparator />
+
+                  <DropdownMenuItem
+                    className='cursor-pointer'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setIsDuplicateOpen(true);
+                    }}
+                    disabled={!isTokenOnlyOffer}
+                  >
+                    <CopyPlus className='mr-2 h-4 w-4' aria-hidden='true' />
+                    <span>
+                      <Trans>Duplicate</Trans>
+                    </span>
+                  </DropdownMenuItem>
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -180,6 +203,13 @@ export function OfferRowCard({ record, refresh }: OfferRowCardProps) {
           title: t`Cancel Offer`,
           content: response && <CancelOfferConfirmation offers={[record]} />,
         }}
+      />
+
+      <DuplicateOfferDialog
+        open={isDuplicateOpen}
+        onOpenChange={setIsDuplicateOpen}
+        record={record}
+        onDone={refresh}
       />
     </>
   );

--- a/src/components/dialogs/DuplicateOfferDialog.tsx
+++ b/src/components/dialogs/DuplicateOfferDialog.tsx
@@ -225,6 +225,8 @@ export function DuplicateOfferDialog({
               kind: 'upload',
               reason: t`Failed to upload offer ${oi + 1} to ${marketplace.name}: ${error instanceof Error ? error.message : String(error)}`,
             });
+            // Break inner loop only — consistent with OfferCreationProgressDialog behavior.
+            // Typically if one offer fails, the rest will too.
             break;
           }
         }
@@ -285,7 +287,9 @@ export function DuplicateOfferDialog({
               <DialogDescription>
                 <Trans>
                   Create identical copies of this offer. All copies will use
-                  the same assets, amounts, and expiry as the original.
+                  the same assets and amounts as the original. Timestamp-based
+                  expiry is preserved; block-height expiry is not supported and
+                  will be omitted.
                 </Trans>
               </DialogDescription>
             </DialogHeader>

--- a/src/components/dialogs/DuplicateOfferDialog.tsx
+++ b/src/components/dialogs/DuplicateOfferDialog.tsx
@@ -152,14 +152,14 @@ export function DuplicateOfferDialog({
   }, [copies, open, record.summary, walletState.sync.selectable_balance]);
 
   const handleDuplicate = async () => {
+    // Check biometric before transitioning to progress phase
+    if (!(await promptIfEnabled())) {
+      return;
+    }
+
     setPhase('progress');
     setIsCreating(true);
     setCurrentStep('creating');
-
-    if (!(await promptIfEnabled())) {
-      onOpenChange(false);
-      return;
-    }
 
     const offeredAssets: OfferAmount[] = record.summary.maker.map((a) => ({
       asset_id: a.asset.asset_id,

--- a/src/components/dialogs/DuplicateOfferDialog.tsx
+++ b/src/components/dialogs/DuplicateOfferDialog.tsx
@@ -149,7 +149,7 @@ export function DuplicateOfferDialog({
     };
 
     validate();
-  }, [copies, open, record.summary, walletState.sync.selectable_balance]);
+  }, [copies, open, record.offer_id, walletState.sync.selectable_balance]);
 
   const handleDuplicate = async () => {
     // Check biometric before transitioning to progress phase
@@ -189,7 +189,9 @@ export function DuplicateOfferDialog({
       addError({
         kind: 'invalid',
         reason:
-          error instanceof Error ? error.message : t`Failed to create offer`,
+          error instanceof Error
+            ? t`Failed on copy ${createdOffers.length + 1} of ${copies}: ${error.message}`
+            : t`Failed to create offer`,
       });
       onOpenChange(false);
       return;
@@ -221,7 +223,7 @@ export function DuplicateOfferDialog({
           } catch (error) {
             addError({
               kind: 'upload',
-              reason: t`Failed to upload offer ${oi + 1} to ${marketplace.name}: ${error as string}`,
+              reason: t`Failed to upload offer ${oi + 1} to ${marketplace.name}: ${error instanceof Error ? error.message : String(error)}`,
             });
             break;
           }
@@ -265,7 +267,15 @@ export function DuplicateOfferDialog({
         if (!isInProgress) onOpenChange(isOpen);
       }}
     >
-      <DialogContent className='sm:max-w-md'>
+      <DialogContent
+        className='sm:max-w-md'
+        onInteractOutside={(e) => {
+          if (isInProgress) e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (isInProgress) e.preventDefault();
+        }}
+      >
         {phase === 'config' ? (
           <>
             <DialogHeader>

--- a/src/components/dialogs/DuplicateOfferDialog.tsx
+++ b/src/components/dialogs/DuplicateOfferDialog.tsx
@@ -149,7 +149,13 @@ export function DuplicateOfferDialog({
     };
 
     validate();
-  }, [copies, open, record.offer_id, walletState.sync.selectable_balance]);
+  }, [
+    copies,
+    open,
+    record.summary.fee,
+    record.summary.maker,
+    walletState.sync.selectable_balance,
+  ]);
 
   const handleDuplicate = async () => {
     // Check biometric before transitioning to progress phase
@@ -213,10 +219,7 @@ export function DuplicateOfferDialog({
         for (const [oi, offer] of createdOffers.entries()) {
           setCurrentOfferIndex(oi);
           try {
-            await marketplace.uploadToMarketplace(
-              offer,
-              network === 'testnet',
-            );
+            await marketplace.uploadToMarketplace(offer, network === 'testnet');
             if (oi < createdOffers.length - 1) {
               await delay(500);
             }
@@ -286,8 +289,8 @@ export function DuplicateOfferDialog({
               </DialogTitle>
               <DialogDescription>
                 <Trans>
-                  Create identical copies of this offer. All copies will use
-                  the same assets and amounts as the original. Timestamp-based
+                  Create identical copies of this offer. All copies will use the
+                  same assets and amounts as the original. Timestamp-based
                   expiry is preserved; block-height expiry is not supported and
                   will be omitted.
                 </Trans>
@@ -323,7 +326,9 @@ export function DuplicateOfferDialog({
                   </Button>
                 </div>
                 {balanceError && (
-                  <p className='text-sm text-destructive mt-1'>{balanceError}</p>
+                  <p className='text-sm text-destructive mt-1'>
+                    {balanceError}
+                  </p>
                 )}
               </div>
 

--- a/src/components/dialogs/DuplicateOfferDialog.tsx
+++ b/src/components/dialogs/DuplicateOfferDialog.tsx
@@ -1,0 +1,427 @@
+import { commands, NetworkKind, OfferAmount, OfferRecord } from '@/bindings';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { useErrors } from '@/hooks/useErrors';
+import { useBiometric } from '@/hooks/useBiometric';
+import { marketplaces } from '@/lib/marketplaces';
+import { fromMojos, getAssetDisplayName } from '@/lib/utils';
+import { useWalletState } from '@/state';
+import { t } from '@lingui/core/macro';
+import { Trans } from '@lingui/react/macro';
+import BigNumber from 'bignumber.js';
+import { LoaderCircleIcon, Minus, Plus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface DuplicateOfferDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  record: OfferRecord;
+  onDone: () => void;
+}
+
+type Phase = 'config' | 'progress';
+
+export function DuplicateOfferDialog({
+  open,
+  onOpenChange,
+  record,
+  onDone,
+}: DuplicateOfferDialogProps) {
+  const walletState = useWalletState();
+  const { addError } = useErrors();
+  const { promptIfEnabled } = useBiometric();
+
+  const [copies, setCopies] = useState(1);
+  const [phase, setPhase] = useState<Phase>('config');
+  const [enabledMarketplaces, setEnabledMarketplaces] = useState<
+    Record<string, boolean>
+  >({});
+  const [balanceError, setBalanceError] = useState<string | null>(null);
+  const [network, setNetwork] = useState<NetworkKind | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [currentStep, setCurrentStep] = useState<'creating' | 'uploading'>(
+    'creating',
+  );
+  const [currentOfferIndex, setCurrentOfferIndex] = useState(0);
+  const [currentMarketplaceIndex, setCurrentMarketplaceIndex] = useState(0);
+  const [isDone, setIsDone] = useState(false);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setCopies(1);
+      setPhase('config');
+      setIsCreating(false);
+      setIsUploading(false);
+      setIsDone(false);
+      setCurrentOfferIndex(0);
+      setCurrentMarketplaceIndex(0);
+      setCurrentStep('creating');
+      setBalanceError(null);
+      setEnabledMarketplaces({});
+    }
+  }, [open]);
+
+  // Fetch network once
+  useEffect(() => {
+    if (open) {
+      commands.getNetwork({}).then((data) => setNetwork(data.kind));
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const validate = async () => {
+      // XCH check: (fee + any XCH offered) × copies ≤ selectable_balance (mojos)
+      const xchAsset = record.summary.maker.find(
+        (a) => a.asset.asset_id === null,
+      );
+      const feeMojos = BigNumber(record.summary.fee.toString());
+      const xchOfferedMojos = xchAsset
+        ? BigNumber(xchAsset.amount.toString())
+        : BigNumber(0);
+      const totalXchNeeded = feeMojos
+        .plus(xchOfferedMojos)
+        .multipliedBy(copies);
+      const xchBalance = BigNumber(walletState.sync.selectable_balance);
+
+      if (totalXchNeeded.gt(xchBalance)) {
+        const needed = fromMojos(totalXchNeeded.toString(), 12).toString();
+        const have = fromMojos(xchBalance.toString(), 12).toString();
+        setBalanceError(
+          t`Insufficient XCH balance: need ${needed} XCH for ${copies} copies, have ${have}`,
+        );
+        return;
+      }
+
+      // Per-CAT check
+      for (const asset of record.summary.maker.filter(
+        (a) => a.asset.kind === 'token' && a.asset.asset_id !== null,
+      )) {
+        const neededMojos = BigNumber(asset.amount.toString()).multipliedBy(
+          copies,
+        );
+        try {
+          const resp = await commands.getToken({
+            asset_id: asset.asset.asset_id,
+          });
+          if (resp.token) {
+            const haveMojos = BigNumber(resp.token.selectable_balance);
+            if (neededMojos.gt(haveMojos)) {
+              const displayName = getAssetDisplayName(
+                resp.token.name,
+                resp.token.ticker,
+                'token',
+              );
+              const needed = fromMojos(
+                neededMojos.toString(),
+                resp.token.precision,
+              ).toString();
+              const have = fromMojos(
+                haveMojos.toString(),
+                resp.token.precision,
+              ).toString();
+              setBalanceError(
+                t`Insufficient balance: need ${needed} ${displayName} for ${copies} copies, have ${have}`,
+              );
+              return;
+            }
+          }
+        } catch {
+          // skip check if fetch fails
+        }
+      }
+
+      setBalanceError(null);
+    };
+
+    validate();
+  }, [copies, open, record.summary, walletState.sync.selectable_balance]);
+
+  const handleDuplicate = async () => {
+    setPhase('progress');
+    setIsCreating(true);
+    setCurrentStep('creating');
+
+    if (!(await promptIfEnabled())) {
+      onOpenChange(false);
+      return;
+    }
+
+    const offeredAssets: OfferAmount[] = record.summary.maker.map((a) => ({
+      asset_id: a.asset.asset_id,
+      amount: a.amount,
+    }));
+    const requestedAssets: OfferAmount[] = record.summary.taker.map((a) => ({
+      asset_id: a.asset.asset_id,
+      amount: a.amount,
+    }));
+    const fee = record.summary.fee;
+    const expiresAtSecond = record.summary.expiration_timestamp ?? null;
+
+    const createdOffers: string[] = [];
+
+    try {
+      for (let i = 0; i < copies; i++) {
+        setCurrentOfferIndex(i);
+        const data = await commands.makeOffer({
+          offered_assets: offeredAssets,
+          requested_assets: requestedAssets,
+          fee,
+          expires_at_second: expiresAtSecond,
+        });
+        createdOffers.push(data.offer);
+      }
+    } catch (error) {
+      addError({
+        kind: 'invalid',
+        reason:
+          error instanceof Error ? error.message : t`Failed to create offer`,
+      });
+      onOpenChange(false);
+      return;
+    }
+
+    setIsCreating(false);
+
+    // Upload to marketplaces
+    const enabledConfigs = marketplaces.filter(
+      (m) => enabledMarketplaces[m.id],
+    );
+
+    if (enabledConfigs.length > 0 && network) {
+      setIsUploading(true);
+      setCurrentStep('uploading');
+
+      for (const [mi, marketplace] of enabledConfigs.entries()) {
+        setCurrentMarketplaceIndex(mi);
+        for (const [oi, offer] of createdOffers.entries()) {
+          setCurrentOfferIndex(oi);
+          try {
+            await marketplace.uploadToMarketplace(
+              offer,
+              network === 'testnet',
+            );
+            if (oi < createdOffers.length - 1) {
+              await delay(500);
+            }
+          } catch (error) {
+            addError({
+              kind: 'upload',
+              reason: t`Failed to upload offer ${oi + 1} to ${marketplace.name}: ${error as string}`,
+            });
+            break;
+          }
+        }
+      }
+
+      setIsUploading(false);
+    }
+
+    setIsDone(true);
+  };
+
+  const isInProgress = isCreating || isUploading;
+  const supportedMarketplaces = marketplaces.filter((m) =>
+    m.isSupported(record.summary, false),
+  );
+
+  const getProgressMessage = () => {
+    if (currentStep === 'creating') {
+      return (
+        <Trans>
+          Creating offer {currentOfferIndex + 1} of {copies}...
+        </Trans>
+      );
+    }
+    const currentMarketplace = supportedMarketplaces.filter(
+      (m) => enabledMarketplaces[m.id],
+    )[currentMarketplaceIndex];
+    return (
+      <Trans>
+        Uploading offer {currentOfferIndex + 1} of {copies} to{' '}
+        {currentMarketplace?.name}...
+      </Trans>
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isInProgress) onOpenChange(isOpen);
+      }}
+    >
+      <DialogContent className='sm:max-w-md'>
+        {phase === 'config' ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                <Trans>Duplicate Offer</Trans>
+              </DialogTitle>
+              <DialogDescription>
+                <Trans>
+                  Create identical copies of this offer. All copies will use
+                  the same assets, amounts, and expiry as the original.
+                </Trans>
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className='space-y-4 py-4'>
+              <div>
+                <h3 className='text-md font-semibold mb-1'>
+                  <Trans>Number of Copies</Trans>
+                </h3>
+                <div className='flex items-center gap-2'>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    className='h-8 w-8'
+                    onClick={() => setCopies(Math.max(1, copies - 1))}
+                    disabled={copies <= 1}
+                    type='button'
+                  >
+                    <Minus className='h-4 w-4' />
+                  </Button>
+                  <span className='w-8 text-center font-mono'>{copies}</span>
+                  <Button
+                    variant='outline'
+                    size='icon'
+                    className='h-8 w-8'
+                    onClick={() => setCopies(Math.min(10, copies + 1))}
+                    disabled={copies >= 10}
+                    type='button'
+                  >
+                    <Plus className='h-4 w-4' />
+                  </Button>
+                </div>
+                {balanceError && (
+                  <p className='text-sm text-destructive mt-1'>{balanceError}</p>
+                )}
+              </div>
+
+              {supportedMarketplaces.length > 0 && (
+                <div className='flex flex-col gap-4 pt-2'>
+                  {supportedMarketplaces.map((marketplace) => (
+                    <div
+                      key={marketplace.id}
+                      className='flex items-center space-x-2'
+                    >
+                      <Switch
+                        id={`dup-upload-${marketplace.id}`}
+                        checked={enabledMarketplaces[marketplace.id] || false}
+                        onCheckedChange={(checked) =>
+                          setEnabledMarketplaces({
+                            ...enabledMarketplaces,
+                            [marketplace.id]: checked,
+                          })
+                        }
+                      />
+                      <Label
+                        htmlFor={`dup-upload-${marketplace.id}`}
+                        className='flex flex-col'
+                      >
+                        <span>
+                          <Trans>Upload to {marketplace.name}</Trans>
+                        </span>
+                        {enabledMarketplaces[marketplace.id] && (
+                          <span className='text-xs text-muted-foreground'>
+                            <Trans>
+                              This will make your offer(s) immediately public
+                              and takeable on {marketplace.name}.
+                            </Trans>
+                          </span>
+                        )}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant='outline' onClick={() => onOpenChange(false)}>
+                <Trans>Cancel</Trans>
+              </Button>
+              <Button onClick={handleDuplicate} disabled={!!balanceError}>
+                <Trans>Duplicate</Trans>
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>
+                {isInProgress ? (
+                  <div className='flex items-center gap-2'>
+                    <LoaderCircleIcon
+                      className='h-4 w-4 animate-spin'
+                      aria-hidden='true'
+                    />
+                    {currentStep === 'creating' ? (
+                      <Trans>Creating Offers</Trans>
+                    ) : (
+                      <Trans>Uploading Offers</Trans>
+                    )}
+                  </div>
+                ) : (
+                  <Trans>Offers Created</Trans>
+                )}
+              </DialogTitle>
+              <DialogDescription>
+                {isInProgress ? (
+                  <div className='space-y-2'>
+                    <p>
+                      <Trans>
+                        Please wait while your offers are being{' '}
+                        {currentStep === 'creating' ? 'created' : 'uploaded'}
+                        ...
+                      </Trans>
+                    </p>
+                    <p className='text-sm text-muted-foreground'>
+                      {getProgressMessage()}
+                    </p>
+                  </div>
+                ) : (
+                  <Trans>
+                    {copies} offer{copies > 1 ? 's have' : ' has'} been created
+                    successfully
+                    {Object.values(enabledMarketplaces).some(Boolean)
+                      ? ' and uploaded to the selected marketplaces'
+                      : ''}
+                    .
+                  </Trans>
+                )}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              {isDone && (
+                <Button
+                  onClick={() => {
+                    onOpenChange(false);
+                    onDone();
+                  }}
+                >
+                  <Trans>Done</Trans>
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dialogs/MakeOfferConfirmationDialog.tsx
+++ b/src/components/dialogs/MakeOfferConfirmationDialog.tsx
@@ -12,12 +12,13 @@ import {
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { marketplaces } from '@/lib/marketplaces';
-import { emptyNftRecord, getAssetDisplayName } from '@/lib/utils';
+import { emptyNftRecord, fromMojos, getAssetDisplayName, toMojos } from '@/lib/utils';
 import { Assets, OfferState, TokenAmount } from '@/state';
+import { useWalletState } from '@/state';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import BigNumber from 'bignumber.js';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Minus, Plus } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { NumberFormat } from '../NumberFormat';
 import { ScrollArea } from '../ui/scroll-area';
@@ -31,6 +32,8 @@ interface MakeOfferConfirmationDialogProps {
   fee: string;
   enabledMarketplaces?: Record<string, boolean>;
   setEnabledMarketplaces?: (marketplaces: Record<string, boolean>) => void;
+  copies: number;
+  onCopiesChange: (copies: number) => void;
 }
 interface TokenWithName extends TokenAmount {
   displayName?: string;
@@ -371,8 +374,75 @@ export function MakeOfferConfirmationDialog({
   fee,
   enabledMarketplaces,
   setEnabledMarketplaces,
+  copies,
+  onCopiesChange,
 }: MakeOfferConfirmationDialogProps) {
   const [xchToken, setXchToken] = useState<TokenRecord | null>(null);
+  const walletState = useWalletState();
+  const [balanceError, setBalanceError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || copies <= 1) {
+      setBalanceError(null);
+      return;
+    }
+
+    const validate = async () => {
+      // XCH check: (fee + any XCH offered) × copies ≤ selectable_balance (mojos)
+      const xchToken = offerState.offered.tokens.find(
+        (t) => t.asset_id === null,
+      );
+      const xchOfferedMojos = xchToken
+        ? BigNumber(toMojos(xchToken.amount?.toString() || '0', 12))
+        : BigNumber(0);
+      const feeMojos = BigNumber(toMojos(fee || '0', 12));
+      const totalXchNeeded = xchOfferedMojos.plus(feeMojos).multipliedBy(copies);
+      const xchBalance = BigNumber(walletState.sync.selectable_balance);
+
+      if (totalXchNeeded.gt(xchBalance)) {
+        const needed = fromMojos(totalXchNeeded.toString(), 12);
+        const have = fromMojos(xchBalance.toString(), 12);
+        setBalanceError(
+          t`Insufficient XCH balance: need ${needed} XCH for ${copies} copies, have ${have}`,
+        );
+        return;
+      }
+
+      // Per-CAT check: cat_amount × copies ≤ cat.selectable_balance (mojos)
+      for (const token of offerState.offered.tokens.filter(
+        (t) => t.asset_id !== null,
+      )) {
+        const neededMojos = BigNumber(
+          toMojos(token.amount?.toString() || '0', 3),
+        ).multipliedBy(copies);
+        try {
+          const resp = await commands.getToken({ asset_id: token.asset_id });
+          if (resp.token) {
+            const haveMojos = BigNumber(resp.token.selectable_balance);
+            if (neededMojos.gt(haveMojos)) {
+              const displayName = getAssetDisplayName(
+                resp.token.name,
+                resp.token.ticker,
+                'token',
+              );
+              const needed = fromMojos(neededMojos.toString(), resp.token.precision);
+              const have = fromMojos(haveMojos.toString(), resp.token.precision);
+              setBalanceError(
+                t`Insufficient balance: need ${needed} ${displayName} for ${copies} copies, have ${have}`,
+              );
+              return;
+            }
+          }
+        } catch {
+          // skip check if fetch fails
+        }
+      }
+
+      setBalanceError(null);
+    };
+
+    validate();
+  }, [copies, open, offerState.offered.tokens, fee, walletState.sync.selectable_balance]);
 
   useEffect(() => {
     const fetchXchToken = async () => {
@@ -434,6 +504,13 @@ export function MakeOfferConfirmationDialog({
                   <span className='font-bold'>{numberOfOffers}</span> individual
                   offers. Each offer will request the same assets and offer one
                   of the selected NFTs.
+                </Trans>
+              </p>
+            ) : copies > 1 ? (
+              <p className='text-sm'>
+                <Trans>
+                  You are about to create{' '}
+                  <span className='font-bold'>{copies}</span> identical offers.
                 </Trans>
               </p>
             ) : (
@@ -533,21 +610,42 @@ export function MakeOfferConfirmationDialog({
                   </p>
                 </>
               ) : (
-                <p className='text-sm'>
-                  <Trans>Network Fee:</Trans>{' '}
-                  <NumberFormat
-                    value={feePerOffer}
-                    minimumFractionDigits={2}
-                    maximumFractionDigits={xchToken?.precision ?? 12}
-                  />{' '}
-                  {xchToken
-                    ? getAssetDisplayName(
-                        xchToken.name,
-                        xchToken.ticker,
-                        'token',
-                      )
-                    : 'XCH'}
-                </p>
+                <>
+                  <p className='text-sm'>
+                    <Trans>Network Fee:</Trans>{' '}
+                    <NumberFormat
+                      value={feePerOffer}
+                      minimumFractionDigits={2}
+                      maximumFractionDigits={xchToken?.precision ?? 12}
+                    />{' '}
+                    {xchToken
+                      ? getAssetDisplayName(
+                          xchToken.name,
+                          xchToken.ticker,
+                          'token',
+                        )
+                      : 'XCH'}
+                  </p>
+                  {!isSplitting && copies > 1 && (
+                    <p className='text-sm'>
+                      <Trans>Total fees for {copies} copies:</Trans>{' '}
+                      <NumberFormat
+                        value={new BigNumber(feePerOffer)
+                          .multipliedBy(copies)
+                          .toString()}
+                        minimumFractionDigits={2}
+                        maximumFractionDigits={xchToken?.precision ?? 12}
+                      />{' '}
+                      {xchToken
+                        ? getAssetDisplayName(
+                            xchToken.name,
+                            xchToken.ticker,
+                            'token',
+                          )
+                        : 'XCH'}
+                    </p>
+                  )}
+                </>
               )}
               {(fee || '0') === '0' && (
                 <p className='text-xs text-muted-foreground'>
@@ -555,6 +653,40 @@ export function MakeOfferConfirmationDialog({
                     (Plus any blockchain royalties for offered assets)
                   </Trans>
                 </p>
+              )}
+            </div>
+          )}
+
+          {!isSplitting && (
+            <div>
+              <h3 className='text-md font-semibold mb-1'>
+                <Trans>Number of Copies</Trans>
+              </h3>
+              <div className='flex items-center gap-2'>
+                <Button
+                  variant='outline'
+                  size='icon'
+                  className='h-8 w-8'
+                  onClick={() => onCopiesChange(Math.max(1, copies - 1))}
+                  disabled={copies <= 1}
+                  type='button'
+                >
+                  <Minus className='h-4 w-4' />
+                </Button>
+                <span className='w-8 text-center font-mono'>{copies}</span>
+                <Button
+                  variant='outline'
+                  size='icon'
+                  className='h-8 w-8'
+                  onClick={() => onCopiesChange(Math.min(10, copies + 1))}
+                  disabled={copies >= 10}
+                  type='button'
+                >
+                  <Plus className='h-4 w-4' />
+                </Button>
+              </div>
+              {balanceError && (
+                <p className='text-sm text-destructive mt-1'>{balanceError}</p>
               )}
             </div>
           )}
@@ -610,7 +742,7 @@ export function MakeOfferConfirmationDialog({
           <Button variant='outline' onClick={() => onOpenChange(false)}>
             <Trans>Cancel</Trans>
           </Button>
-          <Button onClick={handleConfirm}>
+          <Button onClick={handleConfirm} disabled={!!balanceError}>
             <Trans>Confirm & Create</Trans>
           </Button>
         </DialogFooter>

--- a/src/components/dialogs/MakeOfferConfirmationDialog.tsx
+++ b/src/components/dialogs/MakeOfferConfirmationDialog.tsx
@@ -420,12 +420,15 @@ export function MakeOfferConfirmationDialog({
       for (const token of offerState.offered.tokens.filter(
         (t) => t.asset_id !== null,
       )) {
-        const neededMojos = BigNumber(
-          toMojos(token.amount?.toString() || '0', 3),
-        ).multipliedBy(copies);
         try {
           const resp = await commands.getToken({ asset_id: token.asset_id });
           if (resp.token) {
+            const neededMojos = BigNumber(
+              toMojos(
+                token.amount?.toString() || '0',
+                resp.token.precision,
+              ),
+            ).multipliedBy(copies);
             const haveMojos = BigNumber(resp.token.selectable_balance);
             if (neededMojos.gt(haveMojos)) {
               const displayName = getAssetDisplayName(

--- a/src/components/dialogs/MakeOfferConfirmationDialog.tsx
+++ b/src/components/dialogs/MakeOfferConfirmationDialog.tsx
@@ -12,7 +12,12 @@ import {
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { marketplaces } from '@/lib/marketplaces';
-import { emptyNftRecord, fromMojos, getAssetDisplayName, toMojos } from '@/lib/utils';
+import {
+  emptyNftRecord,
+  fromMojos,
+  getAssetDisplayName,
+  toMojos,
+} from '@/lib/utils';
 import { Assets, OfferState, TokenAmount, useWalletState } from '@/state';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
@@ -397,7 +402,9 @@ export function MakeOfferConfirmationDialog({
         ? BigNumber(toMojos(xchToken.amount?.toString() || '0', 12))
         : BigNumber(0);
       const feeMojos = BigNumber(toMojos(fee || '0', 12));
-      const totalXchNeeded = xchOfferedMojos.plus(feeMojos).multipliedBy(copies);
+      const totalXchNeeded = xchOfferedMojos
+        .plus(feeMojos)
+        .multipliedBy(copies);
       const xchBalance = BigNumber(walletState.sync.selectable_balance);
 
       if (totalXchNeeded.gt(xchBalance)) {
@@ -426,8 +433,14 @@ export function MakeOfferConfirmationDialog({
                 resp.token.ticker,
                 'token',
               );
-              const needed = fromMojos(neededMojos.toString(), resp.token.precision).toString();
-              const have = fromMojos(haveMojos.toString(), resp.token.precision).toString();
+              const needed = fromMojos(
+                neededMojos.toString(),
+                resp.token.precision,
+              ).toString();
+              const have = fromMojos(
+                haveMojos.toString(),
+                resp.token.precision,
+              ).toString();
               setBalanceError(
                 t`Insufficient balance: need ${needed} ${displayName} for ${copies} copies, have ${have}`,
               );
@@ -443,7 +456,13 @@ export function MakeOfferConfirmationDialog({
     };
 
     validate();
-  }, [copies, open, offerState.offered.tokens, fee, walletState.sync.selectable_balance]);
+  }, [
+    copies,
+    open,
+    offerState.offered.tokens,
+    fee,
+    walletState.sync.selectable_balance,
+  ]);
 
   useEffect(() => {
     const fetchXchToken = async () => {

--- a/src/components/dialogs/MakeOfferConfirmationDialog.tsx
+++ b/src/components/dialogs/MakeOfferConfirmationDialog.tsx
@@ -13,8 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { marketplaces } from '@/lib/marketplaces';
 import { emptyNftRecord, fromMojos, getAssetDisplayName, toMojos } from '@/lib/utils';
-import { Assets, OfferState, TokenAmount } from '@/state';
-import { useWalletState } from '@/state';
+import { Assets, OfferState, TokenAmount, useWalletState } from '@/state';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import BigNumber from 'bignumber.js';
@@ -400,8 +399,8 @@ export function MakeOfferConfirmationDialog({
       const xchBalance = BigNumber(walletState.sync.selectable_balance);
 
       if (totalXchNeeded.gt(xchBalance)) {
-        const needed = fromMojos(totalXchNeeded.toString(), 12);
-        const have = fromMojos(xchBalance.toString(), 12);
+        const needed = fromMojos(totalXchNeeded.toString(), 12).toString();
+        const have = fromMojos(xchBalance.toString(), 12).toString();
         setBalanceError(
           t`Insufficient XCH balance: need ${needed} XCH for ${copies} copies, have ${have}`,
         );
@@ -425,8 +424,8 @@ export function MakeOfferConfirmationDialog({
                 resp.token.ticker,
                 'token',
               );
-              const needed = fromMojos(neededMojos.toString(), resp.token.precision);
-              const have = fromMojos(haveMojos.toString(), resp.token.precision);
+              const needed = fromMojos(neededMojos.toString(), resp.token.precision).toString();
+              const have = fromMojos(haveMojos.toString(), resp.token.precision).toString();
               setBalanceError(
                 t`Insufficient balance: need ${needed} ${displayName} for ${copies} copies, have ${have}`,
               );

--- a/src/components/dialogs/MakeOfferConfirmationDialog.tsx
+++ b/src/components/dialogs/MakeOfferConfirmationDialog.tsx
@@ -32,7 +32,7 @@ interface MakeOfferConfirmationDialogProps {
   enabledMarketplaces?: Record<string, boolean>;
   setEnabledMarketplaces?: (marketplaces: Record<string, boolean>) => void;
   copies: number;
-  onCopiesChange: (copies: number) => void;
+  onCopiesChange?: (copies: number) => void;
 }
 interface TokenWithName extends TokenAmount {
   displayName?: string;
@@ -381,6 +381,8 @@ export function MakeOfferConfirmationDialog({
   const [balanceError, setBalanceError] = useState<string | null>(null);
 
   useEffect(() => {
+    // Balance validation only runs when copies > 1 — single-copy offers
+    // rely on the blockchain to reject insufficient balance at signing time.
     if (!open || copies <= 1) {
       setBalanceError(null);
       return;
@@ -656,7 +658,7 @@ export function MakeOfferConfirmationDialog({
             </div>
           )}
 
-          {!isSplitting && (
+          {!isSplitting && onCopiesChange != null && (
             <div>
               <h3 className='text-md font-semibold mb-1'>
                 <Trans>Number of Copies</Trans>

--- a/src/components/dialogs/OfferCreationProgressDialog.tsx
+++ b/src/components/dialogs/OfferCreationProgressDialog.tsx
@@ -274,7 +274,10 @@ export function OfferCreationProgressDialog({
                 <p>
                   <Trans>
                     Please wait while{' '}
-                    {splitNftOffers || copies > 1 ? 'your offers are' : 'your offer is'} being
+                    {splitNftOffers || copies > 1
+                      ? 'your offers are'
+                      : 'your offer is'}{' '}
+                    being
                     {currentStep === 'creating' ? ' created' : ' uploaded'}
                     {currentStep === 'creating' &&
                     Object.values(enabledMarketplaces ?? {}).some(Boolean)

--- a/src/components/dialogs/OfferCreationProgressDialog.tsx
+++ b/src/components/dialogs/OfferCreationProgressDialog.tsx
@@ -28,6 +28,7 @@ interface OfferCreationProgressDialogProps {
   enabledMarketplaces?: Record<string, boolean>;
   clearOfferState: (offers: string[]) => void;
   isSwap?: boolean;
+  copies?: number;
 }
 
 export function OfferCreationProgressDialog({
@@ -38,6 +39,7 @@ export function OfferCreationProgressDialog({
   enabledMarketplaces,
   clearOfferState,
   isSwap,
+  copies = 1,
 }: OfferCreationProgressDialogProps) {
   const { addError } = useErrors();
   const [network, setNetwork] = useState<NetworkKind | null>(null);
@@ -51,7 +53,7 @@ export function OfferCreationProgressDialog({
   const [currentOfferIndex, setCurrentOfferIndex] = useState(0);
   const totalOffers = splitNftOffers
     ? offerState.offered.nfts.filter((n) => n).length
-    : 1;
+    : copies;
 
   const {
     createdOffers,
@@ -62,6 +64,7 @@ export function OfferCreationProgressDialog({
   } = useOfferProcessor({
     offerState,
     splitNftOffers,
+    copies,
     onProcessingEnd: () => {
       // Don't auto-close on success
     },
@@ -248,12 +251,12 @@ export function OfferCreationProgressDialog({
                   aria-hidden='true'
                 />
                 {currentStep === 'creating' ? (
-                  splitNftOffers ? (
+                  splitNftOffers || copies > 1 ? (
                     <Trans>Creating Offers</Trans>
                   ) : (
                     <Trans>Creating Offer</Trans>
                   )
-                ) : splitNftOffers ? (
+                ) : splitNftOffers || copies > 1 ? (
                   <Trans>Uploading Offers</Trans>
                 ) : (
                   <Trans>Uploading Offer</Trans>
@@ -271,7 +274,7 @@ export function OfferCreationProgressDialog({
                 <p>
                   <Trans>
                     Please wait while{' '}
-                    {splitNftOffers ? 'your offers are' : 'your offer is'} being
+                    {splitNftOffers || copies > 1 ? 'your offers are' : 'your offer is'} being
                     {currentStep === 'creating' ? ' created' : ' uploaded'}
                     {currentStep === 'creating' &&
                     Object.values(enabledMarketplaces ?? {}).some(Boolean)

--- a/src/hooks/useOfferProcessor.ts
+++ b/src/hooks/useOfferProcessor.ts
@@ -8,6 +8,7 @@ import { useCallback, useRef, useState } from 'react';
 interface UseOfferProcessorProps {
   offerState: OfferState;
   splitNftOffers: boolean;
+  copies?: number; // NEW — default 1
   onProcessingEnd?: () => void; // Callback for when offer processing (success or fail) is done
   onProgress?: (index: number) => void; // Callback for progress updates
 }
@@ -23,6 +24,7 @@ interface UseOfferProcessorReturn {
 export function useOfferProcessor({
   offerState,
   splitNftOffers,
+  copies = 1, // NEW
   onProcessingEnd,
   onProgress,
 }: UseOfferProcessorProps): UseOfferProcessorReturn {
@@ -127,43 +129,54 @@ export function useOfferProcessor({
           setCreatedOffers(newOffers);
         }
       } else {
-        onProgress?.(0);
+        const newOffers: string[] = [];
 
-        const offeredAssets: OfferAmount[] = [
-          ...offeredTokens,
-          ...offerState.offered.nfts.map((nft) => ({
-            asset_id: nft,
-            amount: 1,
-          })),
-          ...offerState.offered.options.map((option) => ({
-            asset_id: option,
-            amount: 1,
-          })),
-        ];
+        for (let copyIndex = 0; copyIndex < copies; copyIndex++) {
+          if (isCancelled.current) break;
 
-        const requestedAssets: OfferAmount[] = [
-          ...requestedTokens,
-          ...offerState.requested.nfts.map((nft) => ({
-            asset_id: nft,
-            amount: 1,
-          })),
-          ...offerState.requested.options.map((option) => ({
-            asset_id: option,
-            amount: 1,
-          })),
-        ];
+          onProgress?.(copyIndex);
 
-        const data = await commands.makeOffer({
-          offered_assets: offeredAssets,
-          requested_assets: requestedAssets,
-          fee: toMojos(
-            (offerState.fee || '0').toString(),
-            walletState.sync.unit.precision,
-          ),
-          expires_at_second: expiresAtSecond,
-        });
+          const offeredAssets: OfferAmount[] = [
+            ...offeredTokens,
+            ...offerState.offered.nfts.map((nft) => ({
+              asset_id: nft,
+              amount: 1,
+            })),
+            ...offerState.offered.options.map((option) => ({
+              asset_id: option,
+              amount: 1,
+            })),
+          ];
+
+          const requestedAssets: OfferAmount[] = [
+            ...requestedTokens,
+            ...offerState.requested.nfts.map((nft) => ({
+              asset_id: nft,
+              amount: 1,
+            })),
+            ...offerState.requested.options.map((option) => ({
+              asset_id: option,
+              amount: 1,
+            })),
+          ];
+
+          const data = await commands.makeOffer({
+            offered_assets: offeredAssets,
+            requested_assets: requestedAssets,
+            fee: toMojos(
+              (offerState.fee || '0').toString(),
+              walletState.sync.unit.precision,
+            ),
+            expires_at_second: expiresAtSecond,
+          });
+
+          if (!isCancelled.current) {
+            newOffers.push(data.offer);
+          }
+        }
+
         if (!isCancelled.current) {
-          setCreatedOffers([data.offer]);
+          setCreatedOffers(newOffers);
         }
       }
     } catch (err) {
@@ -179,6 +192,7 @@ export function useOfferProcessor({
   }, [
     offerState,
     splitNftOffers,
+    copies,
     walletState.sync.unit.precision,
     promptIfEnabled,
     onProcessingEnd,

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -315,7 +315,10 @@ export function MakeOffer() {
 
         <MakeOfferConfirmationDialog
           open={isConfirmDialogOpen}
-          onOpenChange={setIsConfirmDialogOpen}
+          onOpenChange={(open) => {
+            setIsConfirmDialogOpen(open);
+            if (!open) setCopies(1);
+          }}
           onConfirm={handleConfirm}
           offerState={state}
           splitNftOffers={splitNftOffers}

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -15,7 +15,7 @@ import { useWalletState } from '@/state';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { HandCoins, Handshake } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 export function MakeOffer() {
@@ -34,6 +34,7 @@ export function MakeOffer() {
     Record<string, boolean>
   >({});
   const [copies, setCopies] = useState(1);
+  const confirmedRef = useRef(false);
 
   const makeAction = () => {
     if (state.expiration !== null) {
@@ -105,6 +106,7 @@ export function MakeOffer() {
   };
 
   const handleConfirm = () => {
+    confirmedRef.current = true;
     setIsProgressDialogOpen(true);
   };
 
@@ -317,7 +319,8 @@ export function MakeOffer() {
           open={isConfirmDialogOpen}
           onOpenChange={(open) => {
             setIsConfirmDialogOpen(open);
-            if (!open) setCopies(1);
+            if (!open && !confirmedRef.current) setCopies(1);
+            confirmedRef.current = false;
           }}
           onConfirm={handleConfirm}
           offerState={state}

--- a/src/pages/MakeOffer.tsx
+++ b/src/pages/MakeOffer.tsx
@@ -33,6 +33,7 @@ export function MakeOffer() {
   const [enabledMarketplaces, setEnabledMarketplaces] = useState<
     Record<string, boolean>
   >({});
+  const [copies, setCopies] = useState(1);
 
   const makeAction = () => {
     if (state.expiration !== null) {
@@ -321,6 +322,8 @@ export function MakeOffer() {
           fee={state.fee || '0'}
           enabledMarketplaces={enabledMarketplaces}
           setEnabledMarketplaces={setEnabledMarketplaces}
+          copies={copies}
+          onCopiesChange={setCopies}
         />
 
         <OfferCreationProgressDialog
@@ -329,6 +332,7 @@ export function MakeOffer() {
           offerState={state}
           splitNftOffers={splitNftOffers}
           enabledMarketplaces={enabledMarketplaces}
+          copies={copies}
           clearOfferState={() => {
             setState(null);
             navigate('/offers', { replace: true });

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -341,7 +341,6 @@ export function Swap() {
           splitNftOffers={false}
           fee={fee || '0'}
           copies={1}
-          onCopiesChange={() => {}}
         />
 
         <OfferCreationProgressDialog

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -340,6 +340,8 @@ export function Swap() {
           offerState={offerState}
           splitNftOffers={false}
           fee={fee || '0'}
+          copies={1}
+          onCopiesChange={() => {}}
         />
 
         <OfferCreationProgressDialog


### PR DESCRIPTION
Adds the ability to duplicate token for token offers.

Offers will be copied identically: offered, requested, fee, expiration timestamp.

Also adds the ability to create multiple copies during the make offer action.

Offers that have nft's or options on either side cannot be duplicated.