### PR TITLE
Fix CHIP-0002 precision

### DIFF
--- a/crates/sage-api/src/requests/wallet_connect.rs
+++ b/crates/sage-api/src/requests/wallet_connect.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::Amount;
+
 /// Filter unlocked coins from a list
 #[cfg_attr(
     feature = "openapi",
@@ -109,7 +111,7 @@ pub struct Coin {
     /// Puzzle hash
     pub puzzle_hash: String,
     /// Amount in mojos
-    pub amount: u64,
+    pub amount: Amount,
 }
 
 /// Lineage proof for CAT coins
@@ -127,7 +129,7 @@ pub struct LineageProof {
     pub inner_puzzle_hash: Option<String>,
     /// Amount
     #[cfg_attr(feature = "openapi", schema(nullable = true))]
-    pub amount: Option<u64>,
+    pub amount: Option<Amount>,
 }
 
 /// Sign a message with a public key

--- a/crates/sage/src/endpoints/wallet_connect.rs
+++ b/crates/sage/src/endpoints/wallet_connect.rs
@@ -8,11 +8,14 @@ use chia_wallet_sdk::{
     driver::P2DelegatedConditionsLayer,
     prelude::*,
 };
-use sage_api::wallet_connect::{
-    self, AssetCoinType, FilterUnlockedCoins, FilterUnlockedCoinsResponse, GetAssetCoins,
-    GetAssetCoinsResponse, LineageProof, SendTransactionImmediately,
-    SendTransactionImmediatelyResponse, SignMessageByAddress, SignMessageByAddressResponse,
-    SignMessageWithPublicKey, SignMessageWithPublicKeyResponse, SpendableCoin,
+use sage_api::{
+    Amount,
+    wallet_connect::{
+        self, AssetCoinType, FilterUnlockedCoins, FilterUnlockedCoinsResponse, GetAssetCoins,
+        GetAssetCoinsResponse, LineageProof, SendTransactionImmediately,
+        SendTransactionImmediatelyResponse, SignMessageByAddress, SignMessageByAddressResponse,
+        SignMessageWithPublicKey, SignMessageWithPublicKeyResponse, SpendableCoin,
+    },
 };
 use sage_database::{AssetFilter, CoinFilterMode, CoinSortMode, DeserializePrimitive, P2Puzzle};
 use sage_wallet::{Status, SyncCommand, Transaction, insert_transaction, submit_to_peers};
@@ -141,7 +144,7 @@ impl Sage {
                 coin: wallet_connect::Coin {
                     parent_coin_info: hex::encode(row.coin.parent_coin_info),
                     puzzle_hash: hex::encode(row.coin.puzzle_hash),
-                    amount: row.coin.amount,
+                    amount: Amount::u64(row.coin.amount),
                 },
                 coin_name: hex::encode(row.coin.coin_id()),
                 puzzle: hex::encode(ctx.serialize(&puzzle)?),
@@ -152,12 +155,12 @@ impl Sage {
                     Some(Proof::Eve(proof)) => Some(LineageProof {
                         parent_name: Some(hex::encode(proof.parent_parent_coin_info)),
                         inner_puzzle_hash: None,
-                        amount: Some(proof.parent_amount),
+                        amount: Some(Amount::u64(proof.parent_amount)),
                     }),
                     Some(Proof::Lineage(proof)) => Some(LineageProof {
                         parent_name: Some(hex::encode(proof.parent_parent_coin_info)),
                         inner_puzzle_hash: Some(hex::encode(proof.parent_inner_puzzle_hash)),
-                        amount: Some(proof.parent_amount),
+                        amount: Some(Amount::u64(proof.parent_amount)),
                     }),
                 },
             });
@@ -329,6 +332,9 @@ fn rust_coin(coin: wallet_connect::Coin) -> Result<Coin> {
     Ok(Coin {
         parent_coin_info: parse_coin_id(coin.parent_coin_info)?,
         puzzle_hash: parse_hash(coin.puzzle_hash)?,
-        amount: coin.amount,
+        amount: coin
+            .amount
+            .to_u64()
+            .ok_or(Error::InvalidCoinAmount(coin.amount.to_string()))?,
     })
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -668,7 +668,7 @@ puzzle_hash: string;
 /**
  * Amount in mojos
  */
-amount: number }
+amount: Amount }
 export type CoinFilterMode = "all" | "selectable" | "owned" | "spent" | "clawback"
 export type CoinJson = { parent_coin_info: string; puzzle_hash: string; amount: Amount }
 export type CoinRecord = { coin_id: string; address: string; amount: Amount; transaction_id: string | null; offer_id: string | null; clawback_timestamp: number | null; created_height: number | null; spent_height: number | null; spent_timestamp: number | null; created_timestamp: number | null }
@@ -1751,7 +1751,7 @@ innerPuzzleHash: string | null;
 /**
  * Amount
  */
-amount: number | null }
+amount: Amount | null }
 export type LogFile = { name: string; text: string }
 /**
  * Login to a wallet using a fingerprint

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -3084,7 +3084,7 @@ msgstr "Port"
 msgid "Port:"
 msgstr "Port:"
 
-#: src/pages/QrScanner.tsx:74
+#: src/pages/QrScanner.tsx:91
 msgid "Position the QR code within the frame"
 msgstr ""
 
@@ -3413,7 +3413,7 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: src/pages/QrScanner.tsx:63
+#: src/pages/QrScanner.tsx:80
 msgid "Scan QR Code"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -3084,7 +3084,7 @@ msgstr "Port"
 msgid "Port:"
 msgstr "Port:"
 
-#: src/pages/QrScanner.tsx:74
+#: src/pages/QrScanner.tsx:91
 msgid "Position the QR code within the frame"
 msgstr "Position the QR code within the frame"
 
@@ -3413,7 +3413,7 @@ msgstr "Save Theme"
 msgid "Saving..."
 msgstr "Saving..."
 
-#: src/pages/QrScanner.tsx:63
+#: src/pages/QrScanner.tsx:80
 msgid "Scan QR Code"
 msgstr "Scan QR Code"
 

--- a/src/locales/es-MX/messages.po
+++ b/src/locales/es-MX/messages.po
@@ -3084,7 +3084,7 @@ msgstr "Puerto"
 msgid "Port:"
 msgstr "Puerto:"
 
-#: src/pages/QrScanner.tsx:74
+#: src/pages/QrScanner.tsx:91
 msgid "Position the QR code within the frame"
 msgstr "Posiciona el código QR dentro del marco"
 
@@ -3413,7 +3413,7 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: src/pages/QrScanner.tsx:63
+#: src/pages/QrScanner.tsx:80
 msgid "Scan QR Code"
 msgstr "Escanea el código QR"
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -3084,7 +3084,7 @@ msgstr "端口"
 msgid "Port:"
 msgstr "端口:"
 
-#: src/pages/QrScanner.tsx:74
+#: src/pages/QrScanner.tsx:91
 msgid "Position the QR code within the frame"
 msgstr ""
 
@@ -3413,7 +3413,7 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
-#: src/pages/QrScanner.tsx:63
+#: src/pages/QrScanner.tsx:80
 msgid "Scan QR Code"
 msgstr ""
 

--- a/src/walletconnect/commands.ts
+++ b/src/walletconnect/commands.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
+const safeAmount = z.number().or(z.string());
+
 const coinType = z.object({
   parent_coin_info: z.string(),
   puzzle_hash: z.string(),
-  amount: z.number(),
+  amount: safeAmount,
 });
 
 const coinSpendType = z.object({
@@ -16,8 +18,6 @@ const spendBundleType = z.object({
   coin_spends: z.array(coinSpendType),
   aggregated_signature: z.string(),
 });
-
-const safeAmount = z.number().or(z.string());
 
 const assetAmount = z.object({
   assetId: z.string(),
@@ -118,7 +118,7 @@ export const walletConnectCommands = {
           .object({
             parentName: z.string().nullable(),
             innerPuzzleHash: z.string().nullable(),
-            amount: z.number().nullable(),
+            amount: safeAmount.nullable(),
           })
           .nullable(),
       }),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the WalletConnect API contract for coin/lineage amounts from `u64`/`number` to an `Amount` (number-or-string) representation, which can impact external clients and parsing of incoming spend bundles.
> 
> **Overview**
> **Fixes CHIP-0002 precision issues** by switching WalletConnect coin amounts to the shared `Amount` type (string-or-number) instead of plain `u64`/JS `number`.
> 
> Backend endpoints now *emit* amounts via `Amount::u64(...)` and *consume* them by converting `Amount` back to `u64` with validation/erroring on invalid values. Frontend bindings and WalletConnect command Zod schemas were updated to accept `amount` as `number | string`, and locale message source line references were refreshed due to unrelated file shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385ec855af65ce8411268e9c0cc71dbe7b51b726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->