### PR TITLE
Fix import screen

### DIFF
--- a/src/pages/ImportWallet.tsx
+++ b/src/pages/ImportWallet.tsx
@@ -72,7 +72,7 @@ export default function ImportWallet() {
   function cleanKey(key: string) {
     return key
       .trim()
-      .replace(/[^a-z]/gi, ' ')
+      .replace(/[^a-z0-9]/gi, ' ')
       .split(/\s+/)
       .filter((item) => item.length > 0)
       .join(' ')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line input sanitization change on the import form with no auth or persistence logic touched.
> 
> **Overview**
> Fixes wallet import normalization on the import screen by updating **`cleanKey`** so pasted keys keep **digits** instead of treating them as invalid characters.
> 
> Previously, `cleanKey` replaced any non-letter character with a space before splitting and lowercasing the key sent to **`importKey`**. Keys that legitimately include numbers could be mangled and fail import; the regex now allows **`a–z`** and **`0–9`** (still lowercased and whitespace-normalized).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4fc5878030d23311da09388abbeeee78c6e084e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->