### PR TITLE
Show NFT portfolio value using MintGarden floor prices

### DIFF
--- a/.sqlx/query-7e240f953af6c94ef19615f73e71290193ff2460812f44cf2f95194ddb2842c3.json
+++ b/.sqlx/query-7e240f953af6c94ef19615f73e71290193ff2460812f44cf2f95194ddb2842c3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT id, hash, uuid, minter_hash, name, icon_url, banner_url, description, is_visible \n        FROM collections\n        WHERE hash = ?",
+  "query": "SELECT id, hash, uuid, minter_hash, name, icon_url, banner_url, description, is_visible,\n        (SELECT COUNT(*) FROM owned_nfts WHERE owned_nfts.collection_id = collections.id AND asset_is_visible = 1) AS \"nft_count!: i64\"\n        FROM collections\n        WHERE hash = ?",
   "describe": {
     "columns": [
       {
@@ -47,6 +47,11 @@
         "name": "is_visible",
         "ordinal": 8,
         "type_info": "Bool"
+      },
+      {
+        "name": "nft_count!: i64",
+        "ordinal": 9,
+        "type_info": "Null"
       }
     ],
     "parameters": {
@@ -61,8 +66,9 @@
       true,
       true,
       true,
-      false
+      false,
+      null
     ]
   },
-  "hash": "cb3a74b912417fef1b29f55002d74edc7c55bb39fc5169c252d92bdc57f5a3af"
+  "hash": "7e240f953af6c94ef19615f73e71290193ff2460812f44cf2f95194ddb2842c3"
 }

--- a/.sqlx/query-c7bba08e8c10517792d5ded81ce94bc235c8904c43837a81b8aa258b279e41b8.json
+++ b/.sqlx/query-c7bba08e8c10517792d5ded81ce94bc235c8904c43837a81b8aa258b279e41b8.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT collections.hash, uuid, collections.minter_hash, collections.name, collections.icon_url, \n        collections.banner_url, collections.description, collections.is_visible, COUNT(*) OVER() as total_count\n        FROM collections\n        WHERE 1=1\n        AND EXISTS (SELECT 1 FROM owned_nfts WHERE owned_nfts.collection_id = collections.id)\n        AND (? OR is_visible = 1)\n        ORDER BY CASE WHEN collections.id = 0 THEN 1 ELSE 0 END, name ASC\n        LIMIT ?\n        OFFSET ?",
+  "query": "SELECT collections.hash, uuid, collections.minter_hash, collections.name, collections.icon_url,\n        collections.banner_url, collections.description, collections.is_visible, COUNT(*) OVER() as total_count,\n        (SELECT COUNT(*) FROM owned_nfts WHERE owned_nfts.collection_id = collections.id AND asset_is_visible = 1) AS \"nft_count!: i64\"\n        FROM collections\n        WHERE 1=1\n        AND EXISTS (SELECT 1 FROM owned_nfts WHERE owned_nfts.collection_id = collections.id)\n        AND (? OR is_visible = 1)\n        ORDER BY CASE WHEN collections.id = 0 THEN 1 ELSE 0 END, name ASC\n        LIMIT ?\n        OFFSET ?",
   "describe": {
     "columns": [
       {
@@ -47,6 +47,11 @@
         "name": "total_count",
         "ordinal": 8,
         "type_info": "Integer"
+      },
+      {
+        "name": "nft_count!: i64",
+        "ordinal": 9,
+        "type_info": "Integer"
       }
     ],
     "parameters": {
@@ -61,8 +66,9 @@
       true,
       true,
       false,
+      false,
       false
     ]
   },
-  "hash": "5e740e307bf332541fc073cf20f72297912073527728adb5afd1391300b8ed0c"
+  "hash": "c7bba08e8c10517792d5ded81ce94bc235c8904c43837a81b8aa258b279e41b8"
 }

--- a/crates/sage-api/src/records/nft_collection.rs
+++ b/crates/sage-api/src/records/nft_collection.rs
@@ -10,4 +10,5 @@ pub struct NftCollectionRecord {
     pub visible: bool,
     pub name: Option<String>,
     pub icon: Option<String>,
+    pub nft_count: u32,
 }

--- a/crates/sage-database/src/tables/collections.rs
+++ b/crates/sage-database/src/tables/collections.rs
@@ -12,6 +12,7 @@ pub struct CollectionRow {
     pub banner_url: Option<String>,
     pub description: Option<String>,
     pub is_visible: bool,
+    pub nft_count: u32,
 }
 
 impl Database {
@@ -46,7 +47,8 @@ impl DatabaseTx<'_> {
 async fn collection(conn: impl SqliteExecutor<'_>, hash: Bytes32) -> Result<Option<CollectionRow>> {
     let hash_ref = hash.as_ref();
     let row = query!(
-        "SELECT id, hash, uuid, minter_hash, name, icon_url, banner_url, description, is_visible 
+        "SELECT id, hash, uuid, minter_hash, name, icon_url, banner_url, description, is_visible,
+        (SELECT COUNT(*) FROM owned_nfts WHERE owned_nfts.collection_id = collections.id AND asset_is_visible = 1) AS \"nft_count!: i64\"
         FROM collections
         WHERE hash = ?",
         hash_ref
@@ -64,6 +66,7 @@ async fn collection(conn: impl SqliteExecutor<'_>, hash: Bytes32) -> Result<Opti
             banner_url: row.banner_url,
             description: row.description,
             is_visible: row.is_visible,
+            nft_count: row.nft_count.try_into()?,
         })
     })
     .transpose()
@@ -77,8 +80,9 @@ async fn collections(
 ) -> Result<(Vec<CollectionRow>, u32)> {
     // we only return collections that have nfts
     let rows = query!(
-        "SELECT collections.hash, uuid, collections.minter_hash, collections.name, collections.icon_url, 
-        collections.banner_url, collections.description, collections.is_visible, COUNT(*) OVER() as total_count
+        "SELECT collections.hash, uuid, collections.minter_hash, collections.name, collections.icon_url,
+        collections.banner_url, collections.description, collections.is_visible, COUNT(*) OVER() as total_count,
+        (SELECT COUNT(*) FROM owned_nfts WHERE owned_nfts.collection_id = collections.id AND asset_is_visible = 1) AS \"nft_count!: i64\"
         FROM collections
         WHERE 1=1
         AND EXISTS (SELECT 1 FROM owned_nfts WHERE owned_nfts.collection_id = collections.id)
@@ -109,6 +113,7 @@ async fn collections(
                 banner_url: row.banner_url,
                 description: row.description,
                 is_visible: row.is_visible,
+                nft_count: row.nft_count.try_into()?,
             })
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/sage-wallet/src/utils/offchain_metadata.rs
+++ b/crates/sage-wallet/src/utils/offchain_metadata.rs
@@ -57,6 +57,8 @@ pub fn compute_nft_info(did_id: Option<Bytes32>, blob: &[u8]) -> ComputedNftInfo
                 }
             }),
             is_visible: true,
+            // Computed on read paths only; insert_collection ignores this field.
+            nft_count: 0,
         })
     } else {
         None

--- a/crates/sage/src/endpoints/data.rs
+++ b/crates/sage/src/endpoints/data.rs
@@ -563,6 +563,7 @@ impl Sage {
                     name: row.name,
                     icon: row.icon_url,
                     visible: row.is_visible,
+                    nft_count: row.nft_count,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -598,6 +599,7 @@ impl Sage {
                 visible: collection.is_visible,
                 name: collection.name,
                 icon: collection.icon_url,
+                nft_count: collection.nft_count,
             }
         } else {
             NftCollectionRecord {
@@ -607,6 +609,7 @@ impl Sage {
                 visible: true,
                 name: Some("Uncategorized".to_string()),
                 icon: None,
+                nft_count: 0,
             }
         };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   SupportedLanguage,
   useLanguage,
 } from './contexts/LanguageContext';
+import { NftPriceProvider } from './contexts/NftPriceContext';
 import { PeerProvider } from './contexts/PeerContext';
 import { PriceProvider } from './contexts/PriceContext';
 import { SafeAreaProvider } from './contexts/SafeAreaContext';
@@ -193,7 +194,9 @@ function AppInner() {
           <PeerProvider>
             <WalletConnectProvider>
               <PriceProvider>
-                <RouterProvider router={router} />
+                <NftPriceProvider>
+                  <RouterProvider router={router} />
+                </NftPriceProvider>
               </PriceProvider>
             </WalletConnectProvider>
           </PeerProvider>

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1915,7 +1915,7 @@ kind: NftUriKind;
  * The URI to add
  */
 uri: string }
-export type NftCollectionRecord = { collection_id: string; did_id: string; metadata_collection_id: string; visible: boolean; name: string | null; icon: string | null }
+export type NftCollectionRecord = { collection_id: string; did_id: string; metadata_collection_id: string; visible: boolean; name: string | null; icon: string | null; nft_count: number }
 export type NftData = { blob: string | null; mime_type: string | null; hash_matches: boolean; metadata_json: string | null; metadata_hash_matches: boolean }
 /**
  * Individual NFT to mint

--- a/src/components/NftGroupCard.tsx
+++ b/src/components/NftGroupCard.tsx
@@ -4,9 +4,13 @@ import {
   NftRecord,
   commands,
 } from '@/bindings';
+import { NumberFormat } from '@/components/NumberFormat';
+import { NO_COLLECTION_ID } from '@/hooks/useNftData';
 import { NftGroupMode } from '@/hooks/useNftParams';
 import { useNetwork } from '@/hooks/useNetwork';
+import { useNftPrices } from '@/hooks/useNftPrices';
 import useOfferStateWithDefault from '@/hooks/useOfferStateWithDefault';
+import { usePrices } from '@/hooks/usePrices';
 import { mintGardenCollectionUrl, mintGardenDidUrl } from '@/lib/urls';
 //import { getMintGardenProfile } from '@/lib/marketplaces';
 import { t } from '@lingui/core/macro';
@@ -71,6 +75,8 @@ export function NftGroupCard({
 }: NftGroupCardProps) {
   const navigate = useNavigate();
   const { isTestnet } = useNetwork();
+  const { collectionValues } = useNftPrices();
+  const { getPriceInUsd } = usePrices();
   const [offerState, setOfferState] = useOfferStateWithDefault();
   const isCollection = type === 'collection';
 
@@ -282,6 +288,40 @@ export function NftGroupCard({
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
+
+          {isCollectionRecord(item) &&
+            item.collection_id !== NO_COLLECTION_ID &&
+            (() => {
+              const value = collectionValues[item.collection_id];
+              if (!value) return null;
+
+              if (value.floorXch === null) {
+                return (
+                  <p className='text-xs text-muted-foreground truncate'>
+                    <Trans>No listings</Trans>
+                  </p>
+                );
+              }
+
+              return (
+                <p className='text-xs text-muted-foreground truncate'>
+                  <Trans>
+                    Floor{' '}
+                    <NumberFormat
+                      value={value.floorXch}
+                      maximumFractionDigits={3}
+                    />{' '}
+                    XCH · ~
+                    <NumberFormat
+                      value={value.valueXch * getPriceInUsd(null)}
+                      style='currency'
+                      currency='USD'
+                      maximumFractionDigits={2}
+                    />
+                  </Trans>
+                </p>
+              );
+            })()}
         </span>
 
         <DropdownMenu>

--- a/src/contexts/NftPriceContext.tsx
+++ b/src/contexts/NftPriceContext.tsx
@@ -1,0 +1,227 @@
+import { commands, events, NftCollectionRecord } from '@/bindings';
+import { NO_COLLECTION_ID } from '@/hooks/useNftData';
+import { useNetwork } from '@/hooks/useNetwork';
+import { usePrices } from '@/hooks/usePrices';
+import {
+  CollectionValue,
+  computeCollectionValues,
+  computeTotalXch,
+  FloorEntry,
+  isFresh,
+  sanitizeFloorCache,
+} from '@/lib/nftValue';
+import { mintGardenApiUrl } from '@/lib/urls';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocalStorage } from 'usehooks-ts';
+
+export interface NftPriceContextType {
+  nftTotalXch: number;
+  nftTotalUsd: number;
+  collectionValues: Record<string, CollectionValue>;
+  isLoading: boolean;
+  lastUpdated: number | null;
+}
+
+export const NftPriceContext = createContext<NftPriceContextType | undefined>(
+  undefined,
+);
+
+const FLOOR_FETCH_CONCURRENCY = 4;
+const FLOOR_FETCH_TIMEOUT_MS = 10000;
+const REFRESH_INTERVAL_MS = 60000;
+const SYNC_EVENT_DEBOUNCE_MS = 2000;
+
+async function fetchFloor(
+  collectionId: string,
+  isTestnet: boolean,
+): Promise<number | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FLOOR_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      mintGardenApiUrl(`collections/${collectionId}`, isTestnet),
+      { signal: controller.signal },
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data: { floor_price?: number | null } = await response.json();
+    return typeof data.floor_price === 'number' &&
+      Number.isFinite(data.floor_price) &&
+      data.floor_price >= 0
+      ? data.floor_price
+      : null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchOwnedCollections(): Promise<NftCollectionRecord[]> {
+  const pageSize = 100;
+  const collections: NftCollectionRecord[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const response = await commands.getNftCollections({
+      offset,
+      limit: pageSize,
+      include_hidden: false,
+    });
+    collections.push(...response.collections);
+
+    if (
+      collections.length >= response.total ||
+      response.collections.length === 0
+    ) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return collections;
+}
+
+export function NftPriceProvider({ children }: { children: ReactNode }) {
+  const { network, isTestnet } = useNetwork();
+  const { getPriceInUsd } = usePrices();
+
+  const [collections, setCollections] = useState<NftCollectionRecord[]>([]);
+  const [floors, setFloors] = useLocalStorage<Record<string, FloorEntry>>(
+    `nft-floors-${isTestnet ? 'testnet' : 'mainnet'}`,
+    {},
+    {
+      deserializer: (value) => sanitizeFloorCache(JSON.parse(value)),
+    },
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+
+  const refreshingRef = useRef(false);
+  const floorsRef = useRef(floors);
+  floorsRef.current = floors;
+
+  const refresh = useCallback(async () => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+
+    try {
+      const key = await commands.getKey({});
+      if (!key?.key) {
+        setCollections([]);
+        return;
+      }
+
+      const owned = await fetchOwnedCollections();
+      setCollections(owned);
+
+      const now = Date.now();
+      const stale = owned
+        .map((collection) => collection.collection_id)
+        .filter((id) => id !== NO_COLLECTION_ID)
+        .filter((id) => !isFresh(floorsRef.current[id], now));
+
+      if (stale.length > 0) {
+        const queue = [...stale];
+        const workers = Array.from(
+          { length: Math.min(FLOOR_FETCH_CONCURRENCY, queue.length) },
+          async () => {
+            for (;;) {
+              const id = queue.shift();
+              if (id === undefined) return;
+
+              try {
+                const floorXch = await fetchFloor(id, isTestnet);
+                setFloors((prev) => ({
+                  ...prev,
+                  [id]: { floorXch, fetchedAt: Date.now() },
+                }));
+              } catch (error) {
+                // Keep any stale entry; it is retried on the next cycle
+                console.error(`Failed to fetch floor for ${id}:`, error);
+              }
+            }
+          },
+        );
+        await Promise.all(workers);
+      }
+
+      setLastUpdated(Date.now());
+    } catch (error) {
+      console.error('Failed to refresh NFT collections:', error);
+    } finally {
+      refreshingRef.current = false;
+      setIsLoading(false);
+    }
+  }, [isTestnet, setFloors]);
+
+  useEffect(() => {
+    // Don't fetch until network is loaded, mirroring PriceContext
+    if (network === null) {
+      return;
+    }
+
+    setIsLoading(true);
+    refresh();
+    const interval = setInterval(refresh, REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [network, refresh]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | null = null;
+
+    const unlistenPromise = events.syncEvent.listen((event) => {
+      switch (event.payload.type) {
+        case 'coin_state':
+        case 'puzzle_batch_synced':
+        case 'nft_data':
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(() => refresh(), SYNC_EVENT_DEBOUNCE_MS);
+          break;
+      }
+    });
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [refresh]);
+
+  const collectionValues = useMemo(
+    () => computeCollectionValues(collections, floors),
+    [collections, floors],
+  );
+
+  const nftTotalXch = useMemo(
+    () => computeTotalXch(collectionValues),
+    [collectionValues],
+  );
+
+  const nftTotalUsd = nftTotalXch * getPriceInUsd(null);
+
+  return (
+    <NftPriceContext.Provider
+      value={{
+        nftTotalXch,
+        nftTotalUsd,
+        collectionValues,
+        isLoading,
+        lastUpdated,
+      }}
+    >
+      {children}
+    </NftPriceContext.Provider>
+  );
+}

--- a/src/hooks/useNftPrices.ts
+++ b/src/hooks/useNftPrices.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { NftPriceContext } from '../contexts/NftPriceContext';
+
+export function useNftPrices() {
+  const context = useContext(NftPriceContext);
+  if (context === undefined) {
+    throw new Error('useNftPrices must be used within an NftPriceProvider');
+  }
+  return context;
+}

--- a/src/lib/nftValue.ts
+++ b/src/lib/nftValue.ts
@@ -1,0 +1,83 @@
+import { NftCollectionRecord } from '@/bindings';
+import { NO_COLLECTION_ID } from '@/hooks/useNftData';
+
+export const FLOOR_TTL_MS = 15 * 60 * 1000;
+
+export interface FloorEntry {
+  floorXch: number | null;
+  fetchedAt: number;
+}
+
+export interface CollectionValue {
+  floorXch: number | null;
+  count: number;
+  valueXch: number;
+}
+
+export function isFresh(
+  entry: FloorEntry | undefined,
+  now: number,
+): entry is FloorEntry {
+  return entry !== undefined && now - entry.fetchedAt < FLOOR_TTL_MS;
+}
+
+export function computeCollectionValues(
+  collections: NftCollectionRecord[],
+  floors: Record<string, FloorEntry>,
+): Record<string, CollectionValue> {
+  const values: Record<string, CollectionValue> = {};
+
+  for (const collection of collections) {
+    // Uncategorized NFTs have no real collection, hence no floor
+    if (collection.collection_id === NO_COLLECTION_ID) continue;
+
+    const entry = floors[collection.collection_id];
+    // Never-fetched collections are omitted from totals entirely
+    if (!entry) continue;
+
+    values[collection.collection_id] = {
+      floorXch: entry.floorXch,
+      count: collection.nft_count,
+      valueXch: (entry.floorXch ?? 0) * collection.nft_count,
+    };
+  }
+
+  return values;
+}
+
+export function computeTotalXch(
+  values: Record<string, CollectionValue>,
+): number {
+  return Object.values(values).reduce(
+    (total, value) => total + value.valueXch,
+    0,
+  );
+}
+
+function isFloorEntry(value: unknown): value is FloorEntry {
+  if (value === null || typeof value !== 'object') return false;
+  const { fetchedAt, floorXch } = value as Record<string, unknown>;
+  return (
+    typeof fetchedAt === 'number' &&
+    Number.isFinite(fetchedAt) &&
+    fetchedAt >= 0 &&
+    (floorXch === null ||
+      (typeof floorXch === 'number' &&
+        Number.isFinite(floorXch) &&
+        floorXch >= 0))
+  );
+}
+
+export function sanitizeFloorCache(raw: unknown): Record<string, FloorEntry> {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+
+  const result: Record<string, FloorEntry> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (isFloorEntry(value)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "{0, plural, one {You do not currently have any option contracts. Would you like to mint one?} other {You do not currently have any option contracts. Would you like to mint one?}}"
 msgstr ""
 
-#: src/pages/Nft.tsx:250
+#: src/pages/Nft.tsx:260
 msgid "{0}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Aktionen"
 msgid "Actions for {selectedCount} selected NFTs"
 msgstr ""
 
-#: src/pages/NftList.tsx:196
+#: src/pages/NftList.tsx:241
 msgid "Actions for selected NFTs"
 msgstr ""
 
@@ -217,12 +217,12 @@ msgstr ""
 msgid "Add {selectedCount} selected NFTs to offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:485
-#: src/components/NftGroupCard.tsx:488
+#: src/components/NftGroupCard.tsx:525
+#: src/components/NftGroupCard.tsx:528
 msgid "Add all NFTs in {cardName} to an offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:489
+#: src/components/NftGroupCard.tsx:529
 msgid "Add All to Offer"
 msgstr ""
 
@@ -275,7 +275,7 @@ msgid "Add URL to NFT"
 msgstr ""
 
 #: src/components/MultiSelectActions.tsx:274
-#: src/components/NftGroupCard.tsx:469
+#: src/components/NftGroupCard.tsx:509
 msgid "Added {addedCount} {nfts} to offer"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgstr ""
 #: src/components/AddressList.tsx:23
 #: src/components/TransactionColumns.tsx:119
 #: src/components/TransferDialog.tsx:86
-#: src/pages/Nft.tsx:618
+#: src/pages/Nft.tsx:635
 #: src/pages/Option.tsx:275
 #: src/pages/Send.tsx:292
 msgid "Address"
@@ -447,7 +447,7 @@ msgstr ""
 msgid "assets"
 msgstr ""
 
-#: src/pages/TokenList.tsx:174
+#: src/pages/TokenList.tsx:176
 msgid "Assets"
 msgstr "Assets"
 
@@ -470,7 +470,7 @@ msgstr ""
 #~ msgstr "bei Höchststand {peerMaxHeight}"
 
 #: src/pages/CollectionMetaData.tsx:337
-#: src/pages/Nft.tsx:351
+#: src/pages/Nft.tsx:368
 msgid "Attributes"
 msgstr "Attribute"
 
@@ -525,6 +525,10 @@ msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:184
 msgid "Banner for {collectionName}"
+msgstr ""
+
+#: src/pages/NftList.tsx:202
+msgid "Based on MintGarden collection floor prices. This is an estimate only and does not account for liquidity"
 msgstr ""
 
 #: src/pages/Settings.tsx:307
@@ -822,7 +826,7 @@ msgstr ""
 
 #: src/components/AssetCoin.tsx:96
 #: src/components/CoinList.tsx:72
-#: src/pages/Nft.tsx:619
+#: src/pages/Nft.tsx:636
 #: src/pages/Option.tsx:274
 msgid "Coin ID"
 msgstr ""
@@ -867,12 +871,16 @@ msgstr ""
 msgid "Collapse sidebar"
 msgstr ""
 
-#: src/pages/Nft.tsx:281
+#: src/pages/Nft.tsx:291
 msgid "Collection"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:197
+#: src/components/NftGroupCard.tsx:203
 msgid "Collection {cardName}"
+msgstr ""
+
+#: src/pages/Nft.tsx:304
+msgid "Collection Floor"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:204
@@ -880,7 +888,7 @@ msgstr ""
 msgid "Collection ID"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:384
+#: src/components/NftGroupCard.tsx:424
 msgid "Collection ID copied to clipboard"
 msgstr ""
 
@@ -1046,7 +1054,7 @@ msgstr "Kopieren"
 msgid "Copy {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:390
+#: src/components/NftGroupCard.tsx:430
 msgid "Copy {cardName} ID to clipboard"
 msgstr ""
 
@@ -1087,7 +1095,7 @@ msgid "Copy Balance"
 msgstr ""
 
 #: src/components/NftCard.tsx:592
-#: src/components/NftGroupCard.tsx:394
+#: src/components/NftGroupCard.tsx:434
 #: src/components/OfferRowCard.tsx:144
 #: src/components/OptionCard.tsx:150
 #: src/components/OptionColumns.tsx:222
@@ -1135,7 +1143,7 @@ msgstr ""
 msgid "Create individual offers for each NFT"
 msgstr ""
 
-#: src/pages/NftList.tsx:136
+#: src/pages/NftList.tsx:145
 msgid "Create new NFT"
 msgstr ""
 
@@ -1156,13 +1164,13 @@ msgid "Create Wallet"
 msgstr "Wallet Erstellen"
 
 #: src/components/OfferCard.tsx:158
-#: src/pages/Nft.tsx:294
+#: src/pages/Nft.tsx:311
 #: src/pages/Option.tsx:143
 #: src/pages/Transaction.tsx:86
 msgid "Created"
 msgstr ""
 
-#: src/pages/Nft.tsx:575
+#: src/pages/Nft.tsx:592
 #: src/pages/Option.tsx:231
 msgid "Created: {0}"
 msgstr ""
@@ -1207,7 +1215,7 @@ msgstr ""
 msgid "Data"
 msgstr "Daten"
 
-#: src/pages/Nft.tsx:633
+#: src/pages/Nft.tsx:650
 msgid "Data and License Details"
 msgstr ""
 
@@ -1215,7 +1223,7 @@ msgstr ""
 msgid "Data copied to clipboard"
 msgstr ""
 
-#: src/pages/Nft.tsx:686
+#: src/pages/Nft.tsx:703
 msgid "Data Hash"
 msgstr "Daten Hash"
 
@@ -1223,7 +1231,7 @@ msgstr "Daten Hash"
 msgid "Data table"
 msgstr ""
 
-#: src/pages/Nft.tsx:638
+#: src/pages/Nft.tsx:655
 msgid "Data URIs"
 msgstr "Daten URIs"
 
@@ -1373,7 +1381,7 @@ msgid "Descending"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:241
-#: src/pages/Nft.tsx:276
+#: src/pages/Nft.tsx:286
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -1395,8 +1403,8 @@ msgstr ""
 msgid "Details"
 msgstr "Details"
 
-#: src/pages/Nft.tsx:492
-#: src/pages/Nft.tsx:544
+#: src/pages/Nft.tsx:509
+#: src/pages/Nft.tsx:561
 msgid "Dexie"
 msgstr ""
 
@@ -1483,7 +1491,7 @@ msgstr ""
 msgid "Edit Token Details"
 msgstr "Token Details Bearbeiten"
 
-#: src/pages/Nft.tsx:270
+#: src/pages/Nft.tsx:280
 msgid "Edition"
 msgstr ""
 
@@ -1632,6 +1640,10 @@ msgstr ""
 msgid "Error loading themes: {error}"
 msgstr ""
 
+#: src/pages/NftList.tsx:183
+msgid "Estimated value: <0/> XCH (~<1/>)"
+msgstr ""
+
 #: src/components/OptionCard.tsx:80
 #: src/components/OptionColumns.tsx:193
 #: src/hooks/useOptionActions.tsx:133
@@ -1725,12 +1737,12 @@ msgid "Export transactions"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:283
-#: src/pages/Nft.tsx:303
+#: src/pages/Nft.tsx:320
 #: src/pages/Option.tsx:282
 msgid "External Links"
 msgstr "Externe Links"
 
-#: src/components/NftGroupCard.tsx:481
+#: src/components/NftGroupCard.tsx:521
 msgid "Failed to add NFTs to offer"
 msgstr ""
 
@@ -1829,6 +1841,10 @@ msgstr ""
 #: src/components/ClawbackCoinsCard.tsx:270
 #: src/pages/Token.tsx:167
 msgid "Finalize Clawback Details"
+msgstr ""
+
+#: src/components/NftGroupCard.tsx:308
+msgid "Floor <0/> XCH · ~<1/>"
 msgstr ""
 
 #: src/pages/Addresses.tsx:75
@@ -1945,7 +1961,7 @@ msgid "Hex bytes"
 msgstr ""
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:346
+#: src/components/NftGroupCard.tsx:386
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -1959,7 +1975,7 @@ msgstr "Verstecken"
 msgid "Hide {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Hide {cardName}"
 msgstr ""
 
@@ -2025,11 +2041,11 @@ msgstr "Stunden"
 msgid "Icon for {collectionName}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:215
+#: src/components/NftGroupCard.tsx:221
 msgid "Icon for {name}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:275
+#: src/components/NftGroupCard.tsx:281
 msgid "ID: {cardId}"
 msgstr ""
 
@@ -2057,6 +2073,10 @@ msgstr ""
 
 #: src/components/dialogs/MigrationDialog.tsx:33
 msgid "In order to proceed with the update, the wallet will be fully resynced. This means any imported offer files or custom asset names will be removed, but you can manually add them again after if needed."
+msgstr ""
+
+#: src/pages/TokenList.tsx:281
+msgid "Includes ~<0/> in NFTs"
 msgstr ""
 
 #: src/pages/Swap.tsx:249
@@ -2111,13 +2131,13 @@ msgstr "IP Addresse"
 msgid "IP Addresses"
 msgstr ""
 
-#: src/pages/TokenList.tsx:182
+#: src/pages/TokenList.tsx:184
 msgid "Issue new token"
 msgstr ""
 
 #: src/pages/IssueToken.tsx:63
 #: src/pages/IssueToken.tsx:151
-#: src/pages/TokenList.tsx:186
+#: src/pages/TokenList.tsx:188
 msgid "Issue Token"
 msgstr "Token ausgeben"
 
@@ -2156,7 +2176,7 @@ msgid "Launcher Id"
 msgstr "Launcher Id"
 
 #: src/components/AssetCoin.tsx:88
-#: src/pages/Nft.tsx:263
+#: src/pages/Nft.tsx:273
 msgid "Launcher ID"
 msgstr ""
 
@@ -2177,11 +2197,11 @@ msgstr ""
 msgid "License"
 msgstr "Lizenz"
 
-#: src/pages/Nft.tsx:698
+#: src/pages/Nft.tsx:715
 msgid "License Hash"
 msgstr "Lizenz Hash"
 
-#: src/pages/Nft.tsx:670
+#: src/pages/Nft.tsx:687
 msgid "License URIs"
 msgstr "Lizenz URIs"
 
@@ -2206,7 +2226,7 @@ msgstr ""
 #~ msgid "Loading {0} details..."
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading collection"
 msgstr ""
 
@@ -2230,7 +2250,7 @@ msgstr ""
 msgid "Loading options..."
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading profile"
 msgstr ""
 
@@ -2257,7 +2277,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/pages/Nft.tsx:566
+#: src/pages/Nft.tsx:583
 #: src/pages/Option.tsx:222
 msgid "Local Offer"
 msgstr ""
@@ -2343,11 +2363,11 @@ msgstr ""
 #~ msgid "Metadata Collection ID copied to clipboard"
 #~ msgstr ""
 
-#: src/pages/Nft.tsx:692
+#: src/pages/Nft.tsx:709
 msgid "Metadata Hash"
 msgstr "Metadaten Hash"
 
-#: src/pages/Nft.tsx:654
+#: src/pages/Nft.tsx:671
 msgid "Metadata URIs"
 msgstr "Metadaten URIs"
 
@@ -2368,7 +2388,7 @@ msgid "Mint new option"
 msgstr ""
 
 #: src/pages/MintNft.tsx:155
-#: src/pages/NftList.tsx:139
+#: src/pages/NftList.tsx:148
 msgid "Mint NFT"
 msgstr "NFT Minten"
 
@@ -2378,12 +2398,12 @@ msgstr "NFT Minten"
 msgid "Mint Option"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:200
+#: src/components/NftGroupCard.tsx:206
 msgid "Minter {cardName}"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:210
-#: src/pages/Nft.tsx:385
+#: src/pages/Nft.tsx:402
 msgid "Minter DID"
 msgstr "DID des Minters"
 
@@ -2392,7 +2412,7 @@ msgstr "DID des Minters"
 #~ msgid "Minter DID copied to clipboard"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:387
+#: src/components/NftGroupCard.tsx:427
 msgid "Minter ID copied to clipboard"
 msgstr ""
 
@@ -2528,7 +2548,7 @@ msgid "Next page"
 msgstr "Nächste Seite"
 
 #: src/components/MultiSelectActions.tsx:271
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/selectors/AssetSelector.tsx:214
 msgid "NFT"
 msgstr "NFT"
@@ -2543,7 +2563,7 @@ msgstr ""
 #~ msgid "NFT artwork for unnamed NFT"
 #~ msgstr ""
 
-#: src/pages/NftList.tsx:168
+#: src/pages/NftList.tsx:213
 msgid "NFT Collection"
 msgstr ""
 
@@ -2571,8 +2591,12 @@ msgstr ""
 #~ msgid "NFT preview"
 #~ msgstr "NFT Vorschau"
 
-#: src/pages/Nft.tsx:179
+#: src/pages/Nft.tsx:189
 msgid "NFT Preview"
+msgstr ""
+
+#: src/pages/TokenList.tsx:261
+msgid "NFT values are floor price estimates from MintGarden"
 msgstr ""
 
 #: src/components/NftOptions.tsx:179
@@ -2581,7 +2605,7 @@ msgstr ""
 
 #: src/components/MultiSelectActions.tsx:271
 #: src/components/Nav.tsx:58
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/NftPageTitle.tsx:44
 msgid "NFTs"
 msgstr "NFTs"
@@ -2620,7 +2644,7 @@ msgstr ""
 msgid "No Collection Found"
 msgstr ""
 
-#: src/pages/Nft.tsx:448
+#: src/pages/Nft.tsx:465
 msgid "No Dexie offers requesting this NFT"
 msgstr ""
 
@@ -2639,6 +2663,10 @@ msgstr ""
 
 #: src/components/selectors/SearchableSelect.tsx:111
 msgid "No items found."
+msgstr ""
+
+#: src/components/NftGroupCard.tsx:301
+msgid "No listings"
 msgstr ""
 
 #: src/pages/Settings.tsx:866
@@ -2787,7 +2815,7 @@ msgstr "Offeriert"
 #~ msgid "Offered {0} amount must be a positive number."
 #~ msgstr ""
 
-#: src/pages/Nft.tsx:457
+#: src/pages/Nft.tsx:474
 msgid "Offered in exchange:"
 msgstr ""
 
@@ -2812,7 +2840,7 @@ msgstr "Offers"
 msgid "Offers Created"
 msgstr ""
 
-#: src/pages/Nft.tsx:443
+#: src/pages/Nft.tsx:460
 msgid "Offers Requesting This NFT"
 msgstr ""
 
@@ -2933,7 +2961,7 @@ msgstr ""
 msgid "Options exported successfully"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:292
+#: src/components/NftGroupCard.tsx:332
 msgid "Options for {cardName}"
 msgstr ""
 
@@ -2970,7 +2998,7 @@ msgstr ""
 msgid "Owned Coins"
 msgstr ""
 
-#: src/pages/Nft.tsx:412
+#: src/pages/Nft.tsx:429
 msgid "Owner DID"
 msgstr "Besitzer DID"
 
@@ -2982,7 +3010,7 @@ msgstr "Besitzer DID"
 msgid "Owner Profiles"
 msgstr ""
 
-#: src/pages/Nft.tsx:379
+#: src/pages/Nft.tsx:396
 msgid "Ownership"
 msgstr ""
 
@@ -3164,7 +3192,7 @@ msgstr "Verarbeitet die Offer-Daten..."
 msgid "Profile"
 msgstr "Profil"
 
-#: src/components/NftGroupCard.tsx:199
+#: src/components/NftGroupCard.tsx:205
 msgid "Profile {cardName}"
 msgstr ""
 
@@ -3181,7 +3209,7 @@ msgid "Profile ID"
 msgstr ""
 
 #: src/components/confirmations/NftConfirmation.tsx:98
-#: src/components/NftGroupCard.tsx:386
+#: src/components/NftGroupCard.tsx:426
 msgid "Profile ID copied to clipboard"
 msgstr ""
 
@@ -3285,7 +3313,7 @@ msgstr ""
 msgid "Refresh Info"
 msgstr "Info aktualisieren"
 
-#: src/pages/TokenList.tsx:153
+#: src/pages/TokenList.tsx:155
 msgid "Refreshing token info..."
 msgstr ""
 
@@ -3326,7 +3354,7 @@ msgstr "Angefordert"
 msgid "Requesting"
 msgstr ""
 
-#: src/pages/Nft.tsx:521
+#: src/pages/Nft.tsx:538
 msgid "Requesting in exchange:"
 msgstr ""
 
@@ -3385,7 +3413,7 @@ msgstr ""
 msgid "Revocable CAT"
 msgstr ""
 
-#: src/pages/Nft.tsx:436
+#: src/pages/Nft.tsx:453
 msgid "Royalties {royaltyPercentage}%"
 msgstr "Lizenzgebühren {royaltyPercentage}%"
 
@@ -3429,11 +3457,11 @@ msgstr "Mnemonic speichern"
 #~ msgid "Save Offer"
 #~ msgstr "Offer speichern"
 
-#: src/pages/Nft.tsx:255
+#: src/pages/Nft.tsx:265
 msgid "Save Theme"
 msgstr ""
 
-#: src/pages/Nft.tsx:254
+#: src/pages/Nft.tsx:264
 msgid "Saving..."
 msgstr ""
 
@@ -3624,7 +3652,7 @@ msgid "Selected NFTs actions"
 msgstr ""
 
 #: src/components/MultiSelectActions.tsx:275
-#: src/components/NftGroupCard.tsx:470
+#: src/components/NftGroupCard.tsx:510
 msgid "Selected NFTs are already in the offer"
 msgstr ""
 
@@ -3697,7 +3725,7 @@ msgid "Share your offer on these marketplaces."
 msgstr ""
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:353
+#: src/components/NftGroupCard.tsx:393
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -3711,7 +3739,7 @@ msgstr "Anzeigen"
 msgid "Show {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Show {cardName}"
 msgstr ""
 
@@ -3909,7 +3937,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: src/pages/Nft.tsx:569
+#: src/pages/Nft.tsx:586
 #: src/pages/Option.tsx:225
 msgid "Status: {0}"
 msgstr ""
@@ -4027,7 +4055,7 @@ msgstr "{syncedCoins} / {totalCoins} synchronisieren"
 msgid "Syncing Defaults"
 msgstr ""
 
-#: src/pages/TokenList.tsx:213
+#: src/pages/TokenList.tsx:215
 msgid "Syncing in progress..."
 msgstr "Synchronisierung läuft..."
 
@@ -4060,7 +4088,7 @@ msgstr ""
 msgid "Target Peers"
 msgstr "Ziel-Peers"
 
-#: src/pages/Nft.tsx:614
+#: src/pages/Nft.tsx:631
 #: src/pages/Option.tsx:266
 msgid "Technical Information"
 msgstr ""
@@ -4129,7 +4157,7 @@ msgstr ""
 msgid "The wallet generates a new address after each transaction. Old ones stay valid."
 msgstr "Die Wallet generiert nach jeder Transaktion eine neue Adresse. Die alten bleiben gültig."
 
-#: src/pages/TokenList.tsx:216
+#: src/pages/TokenList.tsx:218
 msgid "The wallet is still syncing. Balances may not be accurate until it completes."
 msgstr "Die Wallet synchronisiert noch. Der Guthaben ist möglicherweise nicht korrekt, bis der Vorgang abgeschlossen ist."
 
@@ -4142,7 +4170,7 @@ msgstr ""
 msgid "Theme deleted successfully"
 msgstr ""
 
-#: src/pages/Nft.tsx:252
+#: src/pages/Nft.tsx:262
 msgid "Theme Saved"
 msgstr ""
 
@@ -4218,7 +4246,7 @@ msgstr ""
 #~ msgid "This does not include a fee of {makerFee} which was already added by the maker."
 #~ msgstr "Dies beinhaltet keine Gebühr von {makerFee}, die bereits vom Maker hinzugefügt wurde."
 
-#: src/pages/TokenList.tsx:252
+#: src/pages/TokenList.tsx:254
 msgid "This is an estimate only and does not account for liquidity"
 msgstr ""
 
@@ -4234,7 +4262,7 @@ msgstr ""
 msgid "This is the raw JSON spend bundle for this transaction. If you sign it, the transaction can be submitted to the mempool externally."
 msgstr "Dies ist das Roh-JSON-Spendenbündel für diese Transaktion. Wenn Sie es signieren, kann die Transaktion extern an den Mempool übermittelt werden."
 
-#: src/pages/Nft.tsx:510
+#: src/pages/Nft.tsx:527
 msgid "This NFT is not currently offered for sale on Dexie"
 msgstr ""
 
@@ -4243,7 +4271,7 @@ msgstr ""
 msgid "This NFT is part of an open offer"
 msgstr ""
 
-#: src/pages/Nft.tsx:505
+#: src/pages/Nft.tsx:522
 msgid "This NFT Offered For Sale"
 msgstr ""
 
@@ -4506,7 +4534,7 @@ msgstr ""
 msgid "Total Duration"
 msgstr ""
 
-#: src/pages/TokenList.tsx:243
+#: src/pages/TokenList.tsx:245
 msgid "Total Estimated Balance"
 msgstr ""
 
@@ -4731,7 +4759,7 @@ msgstr ""
 msgid "Unknown Minter"
 msgstr ""
 
-#: src/pages/Nft.tsx:173
+#: src/pages/Nft.tsx:183
 msgid "Unknown NFT"
 msgstr "Unbekanntes NFT"
 
@@ -4752,7 +4780,7 @@ msgstr ""
 msgid "Unnamed"
 msgstr "Unbenannt"
 
-#: src/components/NftGroupCard.tsx:122
+#: src/components/NftGroupCard.tsx:128
 #: src/pages/CollectionMetaData.tsx:164
 msgid "Unnamed Collection"
 msgstr ""
@@ -4791,7 +4819,7 @@ msgstr ""
 #~ msgid "Untitled Option"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:126
+#: src/components/NftGroupCard.tsx:132
 #: src/components/NftPageTitle.tsx:29
 #: src/pages/DidList.tsx:219
 msgid "Untitled Profile"
@@ -4902,12 +4930,12 @@ msgstr ""
 #~ msgid "View {0} token details"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:309
+#: src/components/NftGroupCard.tsx:349
 msgid "View {cardName} Metadata"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:323
-#: src/components/NftGroupCard.tsx:368
+#: src/components/NftGroupCard.tsx:363
+#: src/components/NftGroupCard.tsx:408
 msgid "View {cardName} on Mintgarden"
 msgstr ""
 
@@ -4935,13 +4963,13 @@ msgstr "Versteckte anzeigen"
 msgid "View Local Offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:313
+#: src/components/NftGroupCard.tsx:353
 msgid "View Metadata"
 msgstr ""
 
 #: src/components/dialogs/ViewOfferDialog.tsx:49
-#: src/pages/Nft.tsx:478
-#: src/pages/Nft.tsx:597
+#: src/pages/Nft.tsx:495
+#: src/pages/Nft.tsx:614
 #: src/pages/Offers.tsx:264
 msgid "View Offer"
 msgstr "Offer anzeigen"
@@ -4955,8 +4983,8 @@ msgstr ""
 msgid "View on dexie"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:327
-#: src/components/NftGroupCard.tsx:372
+#: src/components/NftGroupCard.tsx:367
+#: src/components/NftGroupCard.tsx:412
 msgid "View on Mintgarden"
 msgstr ""
 
@@ -4965,7 +4993,7 @@ msgid "View on MintGarden"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:323
-#: src/pages/Nft.tsx:337
+#: src/pages/Nft.tsx:354
 msgid "View on Spacescan.io"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -37,7 +37,7 @@ msgstr "{0, plural, one {You do not currently have any DID profile. Would you li
 msgid "{0, plural, one {You do not currently have any option contracts. Would you like to mint one?} other {You do not currently have any option contracts. Would you like to mint one?}}"
 msgstr "{0, plural, one {You do not currently have any option contracts. Would you like to mint one?} other {You do not currently have any option contracts. Would you like to mint one?}}"
 
-#: src/pages/Nft.tsx:250
+#: src/pages/Nft.tsx:260
 msgid "{0}"
 msgstr "{0}"
 
@@ -195,7 +195,7 @@ msgstr "Actions"
 msgid "Actions for {selectedCount} selected NFTs"
 msgstr "Actions for {selectedCount} selected NFTs"
 
-#: src/pages/NftList.tsx:196
+#: src/pages/NftList.tsx:241
 msgid "Actions for selected NFTs"
 msgstr "Actions for selected NFTs"
 
@@ -217,12 +217,12 @@ msgstr "Add {nftName} to offer"
 msgid "Add {selectedCount} selected NFTs to offer"
 msgstr "Add {selectedCount} selected NFTs to offer"
 
-#: src/components/NftGroupCard.tsx:485
-#: src/components/NftGroupCard.tsx:488
+#: src/components/NftGroupCard.tsx:525
+#: src/components/NftGroupCard.tsx:528
 msgid "Add all NFTs in {cardName} to an offer"
 msgstr "Add all NFTs in {cardName} to an offer"
 
-#: src/components/NftGroupCard.tsx:489
+#: src/components/NftGroupCard.tsx:529
 msgid "Add All to Offer"
 msgstr "Add All to Offer"
 
@@ -275,7 +275,7 @@ msgid "Add URL to NFT"
 msgstr "Add URL to NFT"
 
 #: src/components/MultiSelectActions.tsx:274
-#: src/components/NftGroupCard.tsx:469
+#: src/components/NftGroupCard.tsx:509
 msgid "Added {addedCount} {nfts} to offer"
 msgstr "Added {addedCount} {nfts} to offer"
 
@@ -287,7 +287,7 @@ msgstr "Added {addedCount} {nfts} to offer"
 #: src/components/AddressList.tsx:23
 #: src/components/TransactionColumns.tsx:119
 #: src/components/TransferDialog.tsx:86
-#: src/pages/Nft.tsx:618
+#: src/pages/Nft.tsx:635
 #: src/pages/Option.tsx:275
 #: src/pages/Send.tsx:292
 msgid "Address"
@@ -447,7 +447,7 @@ msgstr "Asset ID copied to clipboard"
 msgid "assets"
 msgstr "assets"
 
-#: src/pages/TokenList.tsx:174
+#: src/pages/TokenList.tsx:176
 msgid "Assets"
 msgstr "Assets"
 
@@ -470,7 +470,7 @@ msgstr "Assign profile for {nftName}"
 #~ msgstr "at peak {peerMaxHeight}"
 
 #: src/pages/CollectionMetaData.tsx:337
-#: src/pages/Nft.tsx:351
+#: src/pages/Nft.tsx:368
 msgid "Attributes"
 msgstr "Attributes"
 
@@ -526,6 +526,10 @@ msgstr "Balance copied to clipboard"
 #: src/pages/CollectionMetaData.tsx:184
 msgid "Banner for {collectionName}"
 msgstr "Banner for {collectionName}"
+
+#: src/pages/NftList.tsx:202
+msgid "Based on MintGarden collection floor prices. This is an estimate only and does not account for liquidity"
+msgstr "Based on MintGarden collection floor prices. This is an estimate only and does not account for liquidity"
 
 #: src/pages/Settings.tsx:307
 msgid "Biometric Authentication"
@@ -822,7 +826,7 @@ msgstr "coin"
 
 #: src/components/AssetCoin.tsx:96
 #: src/components/CoinList.tsx:72
-#: src/pages/Nft.tsx:619
+#: src/pages/Nft.tsx:636
 #: src/pages/Option.tsx:274
 msgid "Coin ID"
 msgstr "Coin ID"
@@ -867,20 +871,24 @@ msgstr "Cold"
 msgid "Collapse sidebar"
 msgstr "Collapse sidebar"
 
-#: src/pages/Nft.tsx:281
+#: src/pages/Nft.tsx:291
 msgid "Collection"
 msgstr "Collection"
 
-#: src/components/NftGroupCard.tsx:197
+#: src/components/NftGroupCard.tsx:203
 msgid "Collection {cardName}"
 msgstr "Collection {cardName}"
+
+#: src/pages/Nft.tsx:304
+msgid "Collection Floor"
+msgstr "Collection Floor"
 
 #: src/pages/CollectionMetaData.tsx:204
 #: src/pages/CollectionMetaData.tsx:385
 msgid "Collection ID"
 msgstr "Collection ID"
 
-#: src/components/NftGroupCard.tsx:384
+#: src/components/NftGroupCard.tsx:424
 msgid "Collection ID copied to clipboard"
 msgstr "Collection ID copied to clipboard"
 
@@ -1046,7 +1054,7 @@ msgstr "Copy"
 msgid "Copy {0}"
 msgstr "Copy {0}"
 
-#: src/components/NftGroupCard.tsx:390
+#: src/components/NftGroupCard.tsx:430
 msgid "Copy {cardName} ID to clipboard"
 msgstr "Copy {cardName} ID to clipboard"
 
@@ -1087,7 +1095,7 @@ msgid "Copy Balance"
 msgstr "Copy Balance"
 
 #: src/components/NftCard.tsx:592
-#: src/components/NftGroupCard.tsx:394
+#: src/components/NftGroupCard.tsx:434
 #: src/components/OfferRowCard.tsx:144
 #: src/components/OptionCard.tsx:150
 #: src/components/OptionColumns.tsx:222
@@ -1135,7 +1143,7 @@ msgstr "Create an option?"
 msgid "Create individual offers for each NFT"
 msgstr "Create individual offers for each NFT"
 
-#: src/pages/NftList.tsx:136
+#: src/pages/NftList.tsx:145
 msgid "Create new NFT"
 msgstr "Create new NFT"
 
@@ -1156,13 +1164,13 @@ msgid "Create Wallet"
 msgstr "Create Wallet"
 
 #: src/components/OfferCard.tsx:158
-#: src/pages/Nft.tsx:294
+#: src/pages/Nft.tsx:311
 #: src/pages/Option.tsx:143
 #: src/pages/Transaction.tsx:86
 msgid "Created"
 msgstr "Created"
 
-#: src/pages/Nft.tsx:575
+#: src/pages/Nft.tsx:592
 #: src/pages/Option.tsx:231
 msgid "Created: {0}"
 msgstr "Created: {0}"
@@ -1207,7 +1215,7 @@ msgstr "Current Theme: {0}"
 msgid "Data"
 msgstr "Data"
 
-#: src/pages/Nft.tsx:633
+#: src/pages/Nft.tsx:650
 msgid "Data and License Details"
 msgstr "Data and License Details"
 
@@ -1215,7 +1223,7 @@ msgstr "Data and License Details"
 msgid "Data copied to clipboard"
 msgstr "Data copied to clipboard"
 
-#: src/pages/Nft.tsx:686
+#: src/pages/Nft.tsx:703
 msgid "Data Hash"
 msgstr "Data Hash"
 
@@ -1223,7 +1231,7 @@ msgstr "Data Hash"
 msgid "Data table"
 msgstr "Data table"
 
-#: src/pages/Nft.tsx:638
+#: src/pages/Nft.tsx:655
 msgid "Data URIs"
 msgstr "Data URIs"
 
@@ -1373,7 +1381,7 @@ msgid "Descending"
 msgstr "Descending"
 
 #: src/pages/CollectionMetaData.tsx:241
-#: src/pages/Nft.tsx:276
+#: src/pages/Nft.tsx:286
 msgid "Description"
 msgstr "Description"
 
@@ -1395,8 +1403,8 @@ msgstr "Detailed View"
 msgid "Details"
 msgstr "Details"
 
-#: src/pages/Nft.tsx:492
-#: src/pages/Nft.tsx:544
+#: src/pages/Nft.tsx:509
+#: src/pages/Nft.tsx:561
 msgid "Dexie"
 msgstr "Dexie"
 
@@ -1483,7 +1491,7 @@ msgstr "Edit profile for {selectedCount} selected NFTs"
 msgid "Edit Token Details"
 msgstr "Edit Token Details"
 
-#: src/pages/Nft.tsx:270
+#: src/pages/Nft.tsx:280
 msgid "Edition"
 msgstr "Edition"
 
@@ -1632,6 +1640,10 @@ msgstr "Error loading themes"
 msgid "Error loading themes: {error}"
 msgstr "Error loading themes: {error}"
 
+#: src/pages/NftList.tsx:183
+msgid "Estimated value: <0/> XCH (~<1/>)"
+msgstr "Estimated value: <0/> XCH (~<1/>)"
+
 #: src/components/OptionCard.tsx:80
 #: src/components/OptionColumns.tsx:193
 #: src/hooks/useOptionActions.tsx:133
@@ -1725,12 +1737,12 @@ msgid "Export transactions"
 msgstr "Export transactions"
 
 #: src/pages/CollectionMetaData.tsx:283
-#: src/pages/Nft.tsx:303
+#: src/pages/Nft.tsx:320
 #: src/pages/Option.tsx:282
 msgid "External Links"
 msgstr "External Links"
 
-#: src/components/NftGroupCard.tsx:481
+#: src/components/NftGroupCard.tsx:521
 msgid "Failed to add NFTs to offer"
 msgstr "Failed to add NFTs to offer"
 
@@ -1830,6 +1842,10 @@ msgstr "Finalize Clawback"
 #: src/pages/Token.tsx:167
 msgid "Finalize Clawback Details"
 msgstr "Finalize Clawback Details"
+
+#: src/components/NftGroupCard.tsx:308
+msgid "Floor <0/> XCH · ~<1/>"
+msgstr "Floor <0/> XCH · ~<1/>"
 
 #: src/pages/Addresses.tsx:75
 msgid "Fresh Address"
@@ -1945,7 +1961,7 @@ msgid "Hex bytes"
 msgstr "Hex bytes"
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:346
+#: src/components/NftGroupCard.tsx:386
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -1959,7 +1975,7 @@ msgstr "Hide"
 msgid "Hide {0}"
 msgstr "Hide {0}"
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Hide {cardName}"
 msgstr "Hide {cardName}"
 
@@ -2025,11 +2041,11 @@ msgstr "Hours"
 msgid "Icon for {collectionName}"
 msgstr "Icon for {collectionName}"
 
-#: src/components/NftGroupCard.tsx:215
+#: src/components/NftGroupCard.tsx:221
 msgid "Icon for {name}"
 msgstr "Icon for {name}"
 
-#: src/components/NftGroupCard.tsx:275
+#: src/components/NftGroupCard.tsx:281
 msgid "ID: {cardId}"
 msgstr "ID: {cardId}"
 
@@ -2058,6 +2074,10 @@ msgstr "Importing"
 #: src/components/dialogs/MigrationDialog.tsx:33
 msgid "In order to proceed with the update, the wallet will be fully resynced. This means any imported offer files or custom asset names will be removed, but you can manually add them again after if needed."
 msgstr "In order to proceed with the update, the wallet will be fully resynced. This means any imported offer files or custom asset names will be removed, but you can manually add them again after if needed."
+
+#: src/pages/TokenList.tsx:281
+msgid "Includes ~<0/> in NFTs"
+msgstr "Includes ~<0/> in NFTs"
 
 #: src/pages/Swap.tsx:249
 msgid "Includes a 1% swap fee"
@@ -2111,13 +2131,13 @@ msgstr "IP Address"
 msgid "IP Addresses"
 msgstr "IP Addresses"
 
-#: src/pages/TokenList.tsx:182
+#: src/pages/TokenList.tsx:184
 msgid "Issue new token"
 msgstr "Issue new token"
 
 #: src/pages/IssueToken.tsx:63
 #: src/pages/IssueToken.tsx:151
-#: src/pages/TokenList.tsx:186
+#: src/pages/TokenList.tsx:188
 msgid "Issue Token"
 msgstr "Issue Token"
 
@@ -2156,7 +2176,7 @@ msgid "Launcher Id"
 msgstr "Launcher Id"
 
 #: src/components/AssetCoin.tsx:88
-#: src/pages/Nft.tsx:263
+#: src/pages/Nft.tsx:273
 msgid "Launcher ID"
 msgstr "Launcher ID"
 
@@ -2177,11 +2197,11 @@ msgstr "Learn more"
 msgid "License"
 msgstr "License"
 
-#: src/pages/Nft.tsx:698
+#: src/pages/Nft.tsx:715
 msgid "License Hash"
 msgstr "License Hash"
 
-#: src/pages/Nft.tsx:670
+#: src/pages/Nft.tsx:687
 msgid "License URIs"
 msgstr "License URIs"
 
@@ -2206,7 +2226,7 @@ msgstr "Loading"
 #~ msgid "Loading {0} details..."
 #~ msgstr "Loading {0} details..."
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading collection"
 msgstr "Loading collection"
 
@@ -2230,7 +2250,7 @@ msgstr "Loading option details..."
 msgid "Loading options..."
 msgstr "Loading options..."
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading profile"
 msgstr "Loading profile"
 
@@ -2257,7 +2277,7 @@ msgstr "Loading transactions..."
 msgid "Loading..."
 msgstr "Loading..."
 
-#: src/pages/Nft.tsx:566
+#: src/pages/Nft.tsx:583
 #: src/pages/Option.tsx:222
 msgid "Local Offer"
 msgstr "Local Offer"
@@ -2343,11 +2363,11 @@ msgstr "Metadata Collection ID"
 #~ msgid "Metadata Collection ID copied to clipboard"
 #~ msgstr "Metadata Collection ID copied to clipboard"
 
-#: src/pages/Nft.tsx:692
+#: src/pages/Nft.tsx:709
 msgid "Metadata Hash"
 msgstr "Metadata Hash"
 
-#: src/pages/Nft.tsx:654
+#: src/pages/Nft.tsx:671
 msgid "Metadata URIs"
 msgstr "Metadata URIs"
 
@@ -2368,7 +2388,7 @@ msgid "Mint new option"
 msgstr "Mint new option"
 
 #: src/pages/MintNft.tsx:155
-#: src/pages/NftList.tsx:139
+#: src/pages/NftList.tsx:148
 msgid "Mint NFT"
 msgstr "Mint NFT"
 
@@ -2378,12 +2398,12 @@ msgstr "Mint NFT"
 msgid "Mint Option"
 msgstr "Mint Option"
 
-#: src/components/NftGroupCard.tsx:200
+#: src/components/NftGroupCard.tsx:206
 msgid "Minter {cardName}"
 msgstr "Minter {cardName}"
 
 #: src/pages/CollectionMetaData.tsx:210
-#: src/pages/Nft.tsx:385
+#: src/pages/Nft.tsx:402
 msgid "Minter DID"
 msgstr "Minter DID"
 
@@ -2392,7 +2412,7 @@ msgstr "Minter DID"
 #~ msgid "Minter DID copied to clipboard"
 #~ msgstr "Minter DID copied to clipboard"
 
-#: src/components/NftGroupCard.tsx:387
+#: src/components/NftGroupCard.tsx:427
 msgid "Minter ID copied to clipboard"
 msgstr "Minter ID copied to clipboard"
 
@@ -2528,7 +2548,7 @@ msgid "Next page"
 msgstr "Next page"
 
 #: src/components/MultiSelectActions.tsx:271
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/selectors/AssetSelector.tsx:214
 msgid "NFT"
 msgstr "NFT"
@@ -2543,7 +2563,7 @@ msgstr "NFT artwork for {nftName}"
 #~ msgid "NFT artwork for unnamed NFT"
 #~ msgstr "NFT artwork for unnamed NFT"
 
-#: src/pages/NftList.tsx:168
+#: src/pages/NftList.tsx:213
 msgid "NFT Collection"
 msgstr "NFT Collection"
 
@@ -2571,9 +2591,13 @@ msgstr "NFT ID copied to clipboard"
 #~ msgid "NFT preview"
 #~ msgstr "NFT preview"
 
-#: src/pages/Nft.tsx:179
+#: src/pages/Nft.tsx:189
 msgid "NFT Preview"
 msgstr "NFT Preview"
+
+#: src/pages/TokenList.tsx:261
+msgid "NFT values are floor price estimates from MintGarden"
+msgstr "NFT values are floor price estimates from MintGarden"
 
 #: src/components/NftOptions.tsx:179
 msgid "NFT view options"
@@ -2581,7 +2605,7 @@ msgstr "NFT view options"
 
 #: src/components/MultiSelectActions.tsx:271
 #: src/components/Nav.tsx:58
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/NftPageTitle.tsx:44
 msgid "NFTs"
 msgstr "NFTs"
@@ -2620,7 +2644,7 @@ msgstr "No Collection"
 msgid "No Collection Found"
 msgstr "No Collection Found"
 
-#: src/pages/Nft.tsx:448
+#: src/pages/Nft.tsx:465
 msgid "No Dexie offers requesting this NFT"
 msgstr "No Dexie offers requesting this NFT"
 
@@ -2640,6 +2664,10 @@ msgstr "No Grouping"
 #: src/components/selectors/SearchableSelect.tsx:111
 msgid "No items found."
 msgstr "No items found."
+
+#: src/components/NftGroupCard.tsx:301
+msgid "No listings"
+msgstr "No listings"
 
 #: src/pages/Settings.tsx:866
 msgid "No matching log entries found"
@@ -2787,7 +2815,7 @@ msgstr "Offered"
 #~ msgid "Offered {0} amount must be a positive number."
 #~ msgstr "Offered {0} amount must be a positive number."
 
-#: src/pages/Nft.tsx:457
+#: src/pages/Nft.tsx:474
 msgid "Offered in exchange:"
 msgstr "Offered in exchange:"
 
@@ -2812,7 +2840,7 @@ msgstr "Offers"
 msgid "Offers Created"
 msgstr "Offers Created"
 
-#: src/pages/Nft.tsx:443
+#: src/pages/Nft.tsx:460
 msgid "Offers Requesting This NFT"
 msgstr "Offers Requesting This NFT"
 
@@ -2933,7 +2961,7 @@ msgstr "Options"
 msgid "Options exported successfully"
 msgstr "Options exported successfully"
 
-#: src/components/NftGroupCard.tsx:292
+#: src/components/NftGroupCard.tsx:332
 msgid "Options for {cardName}"
 msgstr "Options for {cardName}"
 
@@ -2970,7 +2998,7 @@ msgstr "Override the default network for this wallet"
 msgid "Owned Coins"
 msgstr "Owned Coins"
 
-#: src/pages/Nft.tsx:412
+#: src/pages/Nft.tsx:429
 msgid "Owner DID"
 msgstr "Owner DID"
 
@@ -2982,7 +3010,7 @@ msgstr "Owner DID"
 msgid "Owner Profiles"
 msgstr "Owner Profiles"
 
-#: src/pages/Nft.tsx:379
+#: src/pages/Nft.tsx:396
 msgid "Ownership"
 msgstr "Ownership"
 
@@ -3164,7 +3192,7 @@ msgstr "Processing offer data..."
 msgid "Profile"
 msgstr "Profile"
 
-#: src/components/NftGroupCard.tsx:199
+#: src/components/NftGroupCard.tsx:205
 msgid "Profile {cardName}"
 msgstr "Profile {cardName}"
 
@@ -3181,7 +3209,7 @@ msgid "Profile ID"
 msgstr "Profile ID"
 
 #: src/components/confirmations/NftConfirmation.tsx:98
-#: src/components/NftGroupCard.tsx:386
+#: src/components/NftGroupCard.tsx:426
 msgid "Profile ID copied to clipboard"
 msgstr "Profile ID copied to clipboard"
 
@@ -3285,7 +3313,7 @@ msgstr "Refresh"
 msgid "Refresh Info"
 msgstr "Refresh Info"
 
-#: src/pages/TokenList.tsx:153
+#: src/pages/TokenList.tsx:155
 msgid "Refreshing token info..."
 msgstr "Refreshing token info..."
 
@@ -3326,7 +3354,7 @@ msgstr "Requested"
 msgid "Requesting"
 msgstr "Requesting"
 
-#: src/pages/Nft.tsx:521
+#: src/pages/Nft.tsx:538
 msgid "Requesting in exchange:"
 msgstr "Requesting in exchange:"
 
@@ -3385,7 +3413,7 @@ msgstr "Revocable"
 msgid "Revocable CAT"
 msgstr "Revocable CAT"
 
-#: src/pages/Nft.tsx:436
+#: src/pages/Nft.tsx:453
 msgid "Royalties {royaltyPercentage}%"
 msgstr "Royalties {royaltyPercentage}%"
 
@@ -3429,11 +3457,11 @@ msgstr "Save mnemonic"
 #~ msgid "Save Offer"
 #~ msgstr "Save Offer"
 
-#: src/pages/Nft.tsx:255
+#: src/pages/Nft.tsx:265
 msgid "Save Theme"
 msgstr "Save Theme"
 
-#: src/pages/Nft.tsx:254
+#: src/pages/Nft.tsx:264
 msgid "Saving..."
 msgstr "Saving..."
 
@@ -3624,7 +3652,7 @@ msgid "Selected NFTs actions"
 msgstr "Selected NFTs actions"
 
 #: src/components/MultiSelectActions.tsx:275
-#: src/components/NftGroupCard.tsx:470
+#: src/components/NftGroupCard.tsx:510
 msgid "Selected NFTs are already in the offer"
 msgstr "Selected NFTs are already in the offer"
 
@@ -3697,7 +3725,7 @@ msgid "Share your offer on these marketplaces."
 msgstr "Share your offer on these marketplaces."
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:353
+#: src/components/NftGroupCard.tsx:393
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -3711,7 +3739,7 @@ msgstr "Show"
 msgid "Show {0}"
 msgstr "Show {0}"
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Show {cardName}"
 msgstr "Show {cardName}"
 
@@ -3909,7 +3937,7 @@ msgstr "Start"
 msgid "Status"
 msgstr "Status"
 
-#: src/pages/Nft.tsx:569
+#: src/pages/Nft.tsx:586
 #: src/pages/Option.tsx:225
 msgid "Status: {0}"
 msgstr "Status: {0}"
@@ -4027,7 +4055,7 @@ msgstr "Syncing {syncedCoins} / {totalCoins}"
 msgid "Syncing Defaults"
 msgstr "Syncing Defaults"
 
-#: src/pages/TokenList.tsx:213
+#: src/pages/TokenList.tsx:215
 msgid "Syncing in progress..."
 msgstr "Syncing in progress..."
 
@@ -4060,7 +4088,7 @@ msgstr "Taking this offer will send the assets you are paying to the recipient."
 msgid "Target Peers"
 msgstr "Target Peers"
 
-#: src/pages/Nft.tsx:614
+#: src/pages/Nft.tsx:631
 #: src/pages/Option.tsx:266
 msgid "Technical Information"
 msgstr "Technical Information"
@@ -4129,7 +4157,7 @@ msgstr "The offer to fulfill the swap has been created successfully. It will now
 msgid "The wallet generates a new address after each transaction. Old ones stay valid."
 msgstr "The wallet generates a new address after each transaction. Old ones stay valid."
 
-#: src/pages/TokenList.tsx:216
+#: src/pages/TokenList.tsx:218
 msgid "The wallet is still syncing. Balances may not be accurate until it completes."
 msgstr "The wallet is still syncing. Balances may not be accurate until it completes."
 
@@ -4142,7 +4170,7 @@ msgstr "Theme"
 msgid "Theme deleted successfully"
 msgstr "Theme deleted successfully"
 
-#: src/pages/Nft.tsx:252
+#: src/pages/Nft.tsx:262
 msgid "Theme Saved"
 msgstr "Theme Saved"
 
@@ -4218,7 +4246,7 @@ msgstr "This collection ID does not exist."
 #~ msgid "This does not include a fee of {makerFee} which was already added by the maker."
 #~ msgstr "This does not include a fee of {makerFee} which was already added by the maker."
 
-#: src/pages/TokenList.tsx:252
+#: src/pages/TokenList.tsx:254
 msgid "This is an estimate only and does not account for liquidity"
 msgstr "This is an estimate only and does not account for liquidity"
 
@@ -4234,7 +4262,7 @@ msgstr "This is how a card component looks with the current theme."
 msgid "This is the raw JSON spend bundle for this transaction. If you sign it, the transaction can be submitted to the mempool externally."
 msgstr "This is the raw JSON spend bundle for this transaction. If you sign it, the transaction can be submitted to the mempool externally."
 
-#: src/pages/Nft.tsx:510
+#: src/pages/Nft.tsx:527
 msgid "This NFT is not currently offered for sale on Dexie"
 msgstr "This NFT is not currently offered for sale on Dexie"
 
@@ -4243,7 +4271,7 @@ msgstr "This NFT is not currently offered for sale on Dexie"
 msgid "This NFT is part of an open offer"
 msgstr "This NFT is part of an open offer"
 
-#: src/pages/Nft.tsx:505
+#: src/pages/Nft.tsx:522
 msgid "This NFT Offered For Sale"
 msgstr "This NFT Offered For Sale"
 
@@ -4506,7 +4534,7 @@ msgstr "Total Amount"
 msgid "Total Duration"
 msgstr "Total Duration"
 
-#: src/pages/TokenList.tsx:243
+#: src/pages/TokenList.tsx:245
 msgid "Total Estimated Balance"
 msgstr "Total Estimated Balance"
 
@@ -4731,7 +4759,7 @@ msgstr "Unknown error"
 msgid "Unknown Minter"
 msgstr "Unknown Minter"
 
-#: src/pages/Nft.tsx:173
+#: src/pages/Nft.tsx:183
 msgid "Unknown NFT"
 msgstr "Unknown NFT"
 
@@ -4752,7 +4780,7 @@ msgstr "Unless you import it as a cold wallet, your seed phrase and/or secret ke
 msgid "Unnamed"
 msgstr "Unnamed"
 
-#: src/components/NftGroupCard.tsx:122
+#: src/components/NftGroupCard.tsx:128
 #: src/pages/CollectionMetaData.tsx:164
 msgid "Unnamed Collection"
 msgstr "Unnamed Collection"
@@ -4791,7 +4819,7 @@ msgstr "Untitled {0}"
 #~ msgid "Untitled Option"
 #~ msgstr "Untitled Option"
 
-#: src/components/NftGroupCard.tsx:126
+#: src/components/NftGroupCard.tsx:132
 #: src/components/NftPageTitle.tsx:29
 #: src/pages/DidList.tsx:219
 msgid "Untitled Profile"
@@ -4902,12 +4930,12 @@ msgstr "Version {version}"
 #~ msgid "View {0} token details"
 #~ msgstr "View {0} token details"
 
-#: src/components/NftGroupCard.tsx:309
+#: src/components/NftGroupCard.tsx:349
 msgid "View {cardName} Metadata"
 msgstr "View {cardName} Metadata"
 
-#: src/components/NftGroupCard.tsx:323
-#: src/components/NftGroupCard.tsx:368
+#: src/components/NftGroupCard.tsx:363
+#: src/components/NftGroupCard.tsx:408
 msgid "View {cardName} on Mintgarden"
 msgstr "View {cardName} on Mintgarden"
 
@@ -4935,13 +4963,13 @@ msgstr "View hidden"
 msgid "View Local Offer"
 msgstr "View Local Offer"
 
-#: src/components/NftGroupCard.tsx:313
+#: src/components/NftGroupCard.tsx:353
 msgid "View Metadata"
 msgstr "View Metadata"
 
 #: src/components/dialogs/ViewOfferDialog.tsx:49
-#: src/pages/Nft.tsx:478
-#: src/pages/Nft.tsx:597
+#: src/pages/Nft.tsx:495
+#: src/pages/Nft.tsx:614
 #: src/pages/Offers.tsx:264
 msgid "View Offer"
 msgstr "View Offer"
@@ -4955,8 +4983,8 @@ msgstr "View on {0}"
 msgid "View on dexie"
 msgstr "View on dexie"
 
-#: src/components/NftGroupCard.tsx:327
-#: src/components/NftGroupCard.tsx:372
+#: src/components/NftGroupCard.tsx:367
+#: src/components/NftGroupCard.tsx:412
 msgid "View on Mintgarden"
 msgstr "View on Mintgarden"
 
@@ -4965,7 +4993,7 @@ msgid "View on MintGarden"
 msgstr "View on MintGarden"
 
 #: src/pages/CollectionMetaData.tsx:323
-#: src/pages/Nft.tsx:337
+#: src/pages/Nft.tsx:354
 msgid "View on Spacescan.io"
 msgstr "View on Spacescan.io"
 

--- a/src/locales/es-MX/messages.po
+++ b/src/locales/es-MX/messages.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "{0, plural, one {You do not currently have any option contracts. Would you like to mint one?} other {You do not currently have any option contracts. Would you like to mint one?}}"
 msgstr ""
 
-#: src/pages/Nft.tsx:250
+#: src/pages/Nft.tsx:260
 msgid "{0}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "Acciones"
 msgid "Actions for {selectedCount} selected NFTs"
 msgstr "Acciones para {selectedCount} NFT seleccionados"
 
-#: src/pages/NftList.tsx:196
+#: src/pages/NftList.tsx:241
 msgid "Actions for selected NFTs"
 msgstr "Acciones para NFT seleccionados"
 
@@ -217,12 +217,12 @@ msgstr "Añadir {nftName} a la oferta"
 msgid "Add {selectedCount} selected NFTs to offer"
 msgstr "Agregar {selectedCount} NFT seleccionados a la oferta"
 
-#: src/components/NftGroupCard.tsx:485
-#: src/components/NftGroupCard.tsx:488
+#: src/components/NftGroupCard.tsx:525
+#: src/components/NftGroupCard.tsx:528
 msgid "Add all NFTs in {cardName} to an offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:489
+#: src/components/NftGroupCard.tsx:529
 msgid "Add All to Offer"
 msgstr ""
 
@@ -275,7 +275,7 @@ msgid "Add URL to NFT"
 msgstr "Agregar URL a NFT"
 
 #: src/components/MultiSelectActions.tsx:274
-#: src/components/NftGroupCard.tsx:469
+#: src/components/NftGroupCard.tsx:509
 msgid "Added {addedCount} {nfts} to offer"
 msgstr "Agregados {addedCount} {nfts} a la oferta"
 
@@ -287,7 +287,7 @@ msgstr "Agregados {addedCount} {nfts} a la oferta"
 #: src/components/AddressList.tsx:23
 #: src/components/TransactionColumns.tsx:119
 #: src/components/TransferDialog.tsx:86
-#: src/pages/Nft.tsx:618
+#: src/pages/Nft.tsx:635
 #: src/pages/Option.tsx:275
 #: src/pages/Send.tsx:292
 msgid "Address"
@@ -447,7 +447,7 @@ msgstr "ID de activo copiado al portapapeles"
 msgid "assets"
 msgstr "activo"
 
-#: src/pages/TokenList.tsx:174
+#: src/pages/TokenList.tsx:176
 msgid "Assets"
 msgstr "Activos"
 
@@ -470,7 +470,7 @@ msgstr "Asignar perfil para {nftName}"
 #~ msgstr "at peak {peerMaxHeight}"
 
 #: src/pages/CollectionMetaData.tsx:337
-#: src/pages/Nft.tsx:351
+#: src/pages/Nft.tsx:368
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -526,6 +526,10 @@ msgstr "Saldo copiado al portapapeles"
 #: src/pages/CollectionMetaData.tsx:184
 msgid "Banner for {collectionName}"
 msgstr "Banner para {collectionName}"
+
+#: src/pages/NftList.tsx:202
+msgid "Based on MintGarden collection floor prices. This is an estimate only and does not account for liquidity"
+msgstr ""
 
 #: src/pages/Settings.tsx:307
 msgid "Biometric Authentication"
@@ -822,7 +826,7 @@ msgstr "moneda"
 
 #: src/components/AssetCoin.tsx:96
 #: src/components/CoinList.tsx:72
-#: src/pages/Nft.tsx:619
+#: src/pages/Nft.tsx:636
 #: src/pages/Option.tsx:274
 msgid "Coin ID"
 msgstr "ID de moneda"
@@ -867,20 +871,24 @@ msgstr "Frío"
 msgid "Collapse sidebar"
 msgstr "Contraer barra lateral"
 
-#: src/pages/Nft.tsx:281
+#: src/pages/Nft.tsx:291
 msgid "Collection"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:197
+#: src/components/NftGroupCard.tsx:203
 msgid "Collection {cardName}"
 msgstr "Colección {cardName}"
+
+#: src/pages/Nft.tsx:304
+msgid "Collection Floor"
+msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:204
 #: src/pages/CollectionMetaData.tsx:385
 msgid "Collection ID"
 msgstr "ID de Colección"
 
-#: src/components/NftGroupCard.tsx:384
+#: src/components/NftGroupCard.tsx:424
 msgid "Collection ID copied to clipboard"
 msgstr "ID de la colección copiado al portapapeles"
 
@@ -1046,7 +1054,7 @@ msgstr "Copia"
 msgid "Copy {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:390
+#: src/components/NftGroupCard.tsx:430
 msgid "Copy {cardName} ID to clipboard"
 msgstr "Copiar ID de {cardName} al portapapeles"
 
@@ -1087,7 +1095,7 @@ msgid "Copy Balance"
 msgstr "Copiar saldo"
 
 #: src/components/NftCard.tsx:592
-#: src/components/NftGroupCard.tsx:394
+#: src/components/NftGroupCard.tsx:434
 #: src/components/OfferRowCard.tsx:144
 #: src/components/OptionCard.tsx:150
 #: src/components/OptionColumns.tsx:222
@@ -1135,7 +1143,7 @@ msgstr ""
 msgid "Create individual offers for each NFT"
 msgstr ""
 
-#: src/pages/NftList.tsx:136
+#: src/pages/NftList.tsx:145
 msgid "Create new NFT"
 msgstr "Crear nuevo NFT"
 
@@ -1156,13 +1164,13 @@ msgid "Create Wallet"
 msgstr "Crear billetera"
 
 #: src/components/OfferCard.tsx:158
-#: src/pages/Nft.tsx:294
+#: src/pages/Nft.tsx:311
 #: src/pages/Option.tsx:143
 #: src/pages/Transaction.tsx:86
 msgid "Created"
 msgstr "Creado"
 
-#: src/pages/Nft.tsx:575
+#: src/pages/Nft.tsx:592
 #: src/pages/Option.tsx:231
 msgid "Created: {0}"
 msgstr ""
@@ -1207,7 +1215,7 @@ msgstr ""
 msgid "Data"
 msgstr "Datos"
 
-#: src/pages/Nft.tsx:633
+#: src/pages/Nft.tsx:650
 msgid "Data and License Details"
 msgstr ""
 
@@ -1215,7 +1223,7 @@ msgstr ""
 msgid "Data copied to clipboard"
 msgstr "Datos copiados al portapapeles"
 
-#: src/pages/Nft.tsx:686
+#: src/pages/Nft.tsx:703
 msgid "Data Hash"
 msgstr "Hash de datos"
 
@@ -1223,7 +1231,7 @@ msgstr "Hash de datos"
 msgid "Data table"
 msgstr "Tabla de datos"
 
-#: src/pages/Nft.tsx:638
+#: src/pages/Nft.tsx:655
 msgid "Data URIs"
 msgstr "URI de datos"
 
@@ -1373,7 +1381,7 @@ msgid "Descending"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:241
-#: src/pages/Nft.tsx:276
+#: src/pages/Nft.tsx:286
 msgid "Description"
 msgstr "Descripción"
 
@@ -1395,8 +1403,8 @@ msgstr "Vista detallada"
 msgid "Details"
 msgstr "Detalles"
 
-#: src/pages/Nft.tsx:492
-#: src/pages/Nft.tsx:544
+#: src/pages/Nft.tsx:509
+#: src/pages/Nft.tsx:561
 msgid "Dexie"
 msgstr "Dexie"
 
@@ -1483,7 +1491,7 @@ msgstr "Editar perfil para {selectedCount} NFT seleccionados"
 msgid "Edit Token Details"
 msgstr "Editar detalles del token"
 
-#: src/pages/Nft.tsx:270
+#: src/pages/Nft.tsx:280
 msgid "Edition"
 msgstr ""
 
@@ -1632,6 +1640,10 @@ msgstr ""
 msgid "Error loading themes: {error}"
 msgstr ""
 
+#: src/pages/NftList.tsx:183
+msgid "Estimated value: <0/> XCH (~<1/>)"
+msgstr ""
+
 #: src/components/OptionCard.tsx:80
 #: src/components/OptionColumns.tsx:193
 #: src/hooks/useOptionActions.tsx:133
@@ -1725,12 +1737,12 @@ msgid "Export transactions"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:283
-#: src/pages/Nft.tsx:303
+#: src/pages/Nft.tsx:320
 #: src/pages/Option.tsx:282
 msgid "External Links"
 msgstr "Enlaces externos"
 
-#: src/components/NftGroupCard.tsx:481
+#: src/components/NftGroupCard.tsx:521
 msgid "Failed to add NFTs to offer"
 msgstr ""
 
@@ -1829,6 +1841,10 @@ msgstr ""
 #: src/components/ClawbackCoinsCard.tsx:270
 #: src/pages/Token.tsx:167
 msgid "Finalize Clawback Details"
+msgstr ""
+
+#: src/components/NftGroupCard.tsx:308
+msgid "Floor <0/> XCH · ~<1/>"
 msgstr ""
 
 #: src/pages/Addresses.tsx:75
@@ -1945,7 +1961,7 @@ msgid "Hex bytes"
 msgstr ""
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:346
+#: src/components/NftGroupCard.tsx:386
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -1959,7 +1975,7 @@ msgstr "Ocultar"
 msgid "Hide {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Hide {cardName}"
 msgstr "Ocultar {cardName}"
 
@@ -2025,11 +2041,11 @@ msgstr "Horas"
 msgid "Icon for {collectionName}"
 msgstr "Icono de {collectionName}"
 
-#: src/components/NftGroupCard.tsx:215
+#: src/components/NftGroupCard.tsx:221
 msgid "Icon for {name}"
 msgstr "Icono de {name}"
 
-#: src/components/NftGroupCard.tsx:275
+#: src/components/NftGroupCard.tsx:281
 msgid "ID: {cardId}"
 msgstr "ID: {cardId}"
 
@@ -2057,6 +2073,10 @@ msgstr "Importando"
 
 #: src/components/dialogs/MigrationDialog.tsx:33
 msgid "In order to proceed with the update, the wallet will be fully resynced. This means any imported offer files or custom asset names will be removed, but you can manually add them again after if needed."
+msgstr ""
+
+#: src/pages/TokenList.tsx:281
+msgid "Includes ~<0/> in NFTs"
 msgstr ""
 
 #: src/pages/Swap.tsx:249
@@ -2111,13 +2131,13 @@ msgstr "Dirección IP"
 msgid "IP Addresses"
 msgstr "Direcciones IP"
 
-#: src/pages/TokenList.tsx:182
+#: src/pages/TokenList.tsx:184
 msgid "Issue new token"
 msgstr "Emisión de nuevo token"
 
 #: src/pages/IssueToken.tsx:63
 #: src/pages/IssueToken.tsx:151
-#: src/pages/TokenList.tsx:186
+#: src/pages/TokenList.tsx:188
 msgid "Issue Token"
 msgstr "Emisión de Token"
 
@@ -2156,7 +2176,7 @@ msgid "Launcher Id"
 msgstr "ID de lanzador"
 
 #: src/components/AssetCoin.tsx:88
-#: src/pages/Nft.tsx:263
+#: src/pages/Nft.tsx:273
 msgid "Launcher ID"
 msgstr "ID de lanzador"
 
@@ -2177,11 +2197,11 @@ msgstr ""
 msgid "License"
 msgstr "Licencia"
 
-#: src/pages/Nft.tsx:698
+#: src/pages/Nft.tsx:715
 msgid "License Hash"
 msgstr "Código de hash de licencia"
 
-#: src/pages/Nft.tsx:670
+#: src/pages/Nft.tsx:687
 msgid "License URIs"
 msgstr "URIs de licencia"
 
@@ -2206,7 +2226,7 @@ msgstr ""
 #~ msgid "Loading {0} details..."
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading collection"
 msgstr "Cargando colección"
 
@@ -2230,7 +2250,7 @@ msgstr ""
 msgid "Loading options..."
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading profile"
 msgstr "Cargando perfil"
 
@@ -2257,7 +2277,7 @@ msgstr "Cargando transacciones..."
 msgid "Loading..."
 msgstr ""
 
-#: src/pages/Nft.tsx:566
+#: src/pages/Nft.tsx:583
 #: src/pages/Option.tsx:222
 msgid "Local Offer"
 msgstr ""
@@ -2343,11 +2363,11 @@ msgstr "ID de Colección de Metadatos"
 #~ msgid "Metadata Collection ID copied to clipboard"
 #~ msgstr "ID de la colección de metadatos copiado al portapapeles"
 
-#: src/pages/Nft.tsx:692
+#: src/pages/Nft.tsx:709
 msgid "Metadata Hash"
 msgstr "Resumen de metadatos"
 
-#: src/pages/Nft.tsx:654
+#: src/pages/Nft.tsx:671
 msgid "Metadata URIs"
 msgstr "URI de metadatos"
 
@@ -2368,7 +2388,7 @@ msgid "Mint new option"
 msgstr ""
 
 #: src/pages/MintNft.tsx:155
-#: src/pages/NftList.tsx:139
+#: src/pages/NftList.tsx:148
 msgid "Mint NFT"
 msgstr "Crear NFT"
 
@@ -2378,12 +2398,12 @@ msgstr "Crear NFT"
 msgid "Mint Option"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:200
+#: src/components/NftGroupCard.tsx:206
 msgid "Minter {cardName}"
 msgstr "Minter {cardName}"
 
 #: src/pages/CollectionMetaData.tsx:210
-#: src/pages/Nft.tsx:385
+#: src/pages/Nft.tsx:402
 msgid "Minter DID"
 msgstr "Minter DID"
 
@@ -2392,7 +2412,7 @@ msgstr "Minter DID"
 #~ msgid "Minter DID copied to clipboard"
 #~ msgstr "Minter DID copiado al portapapeles"
 
-#: src/components/NftGroupCard.tsx:387
+#: src/components/NftGroupCard.tsx:427
 msgid "Minter ID copied to clipboard"
 msgstr "ID de Minter copiado al portapapeles"
 
@@ -2528,7 +2548,7 @@ msgid "Next page"
 msgstr "Página siguiente"
 
 #: src/components/MultiSelectActions.tsx:271
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/selectors/AssetSelector.tsx:214
 msgid "NFT"
 msgstr "NFT"
@@ -2543,7 +2563,7 @@ msgstr "Obra de arte NFT para {nftName}"
 #~ msgid "NFT artwork for unnamed NFT"
 #~ msgstr "Obra de arte NFT para NFT sin nombre"
 
-#: src/pages/NftList.tsx:168
+#: src/pages/NftList.tsx:213
 msgid "NFT Collection"
 msgstr "Colección de NFT"
 
@@ -2571,8 +2591,12 @@ msgstr "ID de NFT copiado al portapapeles"
 #~ msgid "NFT preview"
 #~ msgstr "Vista previa de NFT"
 
-#: src/pages/Nft.tsx:179
+#: src/pages/Nft.tsx:189
 msgid "NFT Preview"
+msgstr ""
+
+#: src/pages/TokenList.tsx:261
+msgid "NFT values are floor price estimates from MintGarden"
 msgstr ""
 
 #: src/components/NftOptions.tsx:179
@@ -2581,7 +2605,7 @@ msgstr "Opciones de vista de NFT"
 
 #: src/components/MultiSelectActions.tsx:271
 #: src/components/Nav.tsx:58
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/NftPageTitle.tsx:44
 msgid "NFTs"
 msgstr "NFTs"
@@ -2620,7 +2644,7 @@ msgstr "Sin Colección"
 msgid "No Collection Found"
 msgstr "No se encontró colección"
 
-#: src/pages/Nft.tsx:448
+#: src/pages/Nft.tsx:465
 msgid "No Dexie offers requesting this NFT"
 msgstr ""
 
@@ -2639,6 +2663,10 @@ msgstr "Sin agrupación"
 
 #: src/components/selectors/SearchableSelect.tsx:111
 msgid "No items found."
+msgstr ""
+
+#: src/components/NftGroupCard.tsx:301
+msgid "No listings"
 msgstr ""
 
 #: src/pages/Settings.tsx:866
@@ -2787,7 +2815,7 @@ msgstr "Ofrecido"
 #~ msgid "Offered {0} amount must be a positive number."
 #~ msgstr ""
 
-#: src/pages/Nft.tsx:457
+#: src/pages/Nft.tsx:474
 msgid "Offered in exchange:"
 msgstr ""
 
@@ -2812,7 +2840,7 @@ msgstr "Ofertas"
 msgid "Offers Created"
 msgstr ""
 
-#: src/pages/Nft.tsx:443
+#: src/pages/Nft.tsx:460
 msgid "Offers Requesting This NFT"
 msgstr ""
 
@@ -2933,7 +2961,7 @@ msgstr "Opcioens"
 msgid "Options exported successfully"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:292
+#: src/components/NftGroupCard.tsx:332
 msgid "Options for {cardName}"
 msgstr "Opciones para {cardName}"
 
@@ -2970,7 +2998,7 @@ msgstr "Sobrescribir la red predeterminada para esta billetera"
 msgid "Owned Coins"
 msgstr ""
 
-#: src/pages/Nft.tsx:412
+#: src/pages/Nft.tsx:429
 msgid "Owner DID"
 msgstr "Propietario DID"
 
@@ -2982,7 +3010,7 @@ msgstr "Propietario DID"
 msgid "Owner Profiles"
 msgstr "Perfiles de propietarios"
 
-#: src/pages/Nft.tsx:379
+#: src/pages/Nft.tsx:396
 msgid "Ownership"
 msgstr ""
 
@@ -3164,7 +3192,7 @@ msgstr "Procesando datos de la oferta..."
 msgid "Profile"
 msgstr "Perfil"
 
-#: src/components/NftGroupCard.tsx:199
+#: src/components/NftGroupCard.tsx:205
 msgid "Profile {cardName}"
 msgstr "Perfil {cardName}"
 
@@ -3181,7 +3209,7 @@ msgid "Profile ID"
 msgstr "ID de perfil"
 
 #: src/components/confirmations/NftConfirmation.tsx:98
-#: src/components/NftGroupCard.tsx:386
+#: src/components/NftGroupCard.tsx:426
 msgid "Profile ID copied to clipboard"
 msgstr "ID de perfil copiado al portapapeles"
 
@@ -3285,7 +3313,7 @@ msgstr ""
 msgid "Refresh Info"
 msgstr "Actualizar Información"
 
-#: src/pages/TokenList.tsx:153
+#: src/pages/TokenList.tsx:155
 msgid "Refreshing token info..."
 msgstr "Actualizando información del token..."
 
@@ -3326,7 +3354,7 @@ msgstr "Solicitado"
 msgid "Requesting"
 msgstr ""
 
-#: src/pages/Nft.tsx:521
+#: src/pages/Nft.tsx:538
 msgid "Requesting in exchange:"
 msgstr ""
 
@@ -3385,7 +3413,7 @@ msgstr ""
 msgid "Revocable CAT"
 msgstr ""
 
-#: src/pages/Nft.tsx:436
+#: src/pages/Nft.tsx:453
 msgid "Royalties {royaltyPercentage}%"
 msgstr "Regalías {royaltyPercentage}%"
 
@@ -3429,11 +3457,11 @@ msgstr "Guardar mnemónico"
 #~ msgid "Save Offer"
 #~ msgstr "Guardar Oferta"
 
-#: src/pages/Nft.tsx:255
+#: src/pages/Nft.tsx:265
 msgid "Save Theme"
 msgstr ""
 
-#: src/pages/Nft.tsx:254
+#: src/pages/Nft.tsx:264
 msgid "Saving..."
 msgstr ""
 
@@ -3624,7 +3652,7 @@ msgid "Selected NFTs actions"
 msgstr "Acciones de NFT seleccionados"
 
 #: src/components/MultiSelectActions.tsx:275
-#: src/components/NftGroupCard.tsx:470
+#: src/components/NftGroupCard.tsx:510
 msgid "Selected NFTs are already in the offer"
 msgstr "NFT seleccionados ya están en la oferta"
 
@@ -3697,7 +3725,7 @@ msgid "Share your offer on these marketplaces."
 msgstr ""
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:353
+#: src/components/NftGroupCard.tsx:393
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -3711,7 +3739,7 @@ msgstr "Mostrar"
 msgid "Show {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Show {cardName}"
 msgstr "Mostrar {cardName}"
 
@@ -3909,7 +3937,7 @@ msgstr "Comenzar"
 msgid "Status"
 msgstr "Estado"
 
-#: src/pages/Nft.tsx:569
+#: src/pages/Nft.tsx:586
 #: src/pages/Option.tsx:225
 msgid "Status: {0}"
 msgstr ""
@@ -4027,7 +4055,7 @@ msgstr "Sincronizando {syncedCoins} / {totalCoins}"
 msgid "Syncing Defaults"
 msgstr ""
 
-#: src/pages/TokenList.tsx:213
+#: src/pages/TokenList.tsx:215
 msgid "Syncing in progress..."
 msgstr "Sincronización en curso..."
 
@@ -4060,7 +4088,7 @@ msgstr "Aceptar esta oferta enviará los activos que está pagando al destinatar
 msgid "Target Peers"
 msgstr "Nodos objetivo"
 
-#: src/pages/Nft.tsx:614
+#: src/pages/Nft.tsx:631
 #: src/pages/Option.tsx:266
 msgid "Technical Information"
 msgstr ""
@@ -4129,7 +4157,7 @@ msgstr ""
 msgid "The wallet generates a new address after each transaction. Old ones stay valid."
 msgstr "La billetera genera una nueva dirección después de cada transacción. Las antiguas siguen siendo válidas."
 
-#: src/pages/TokenList.tsx:216
+#: src/pages/TokenList.tsx:218
 msgid "The wallet is still syncing. Balances may not be accurate until it completes."
 msgstr "La billetera sigue sincronizando. Los saldos pueden no ser precisos hasta que se complete."
 
@@ -4142,7 +4170,7 @@ msgstr ""
 msgid "Theme deleted successfully"
 msgstr ""
 
-#: src/pages/Nft.tsx:252
+#: src/pages/Nft.tsx:262
 msgid "Theme Saved"
 msgstr ""
 
@@ -4218,7 +4246,7 @@ msgstr "Este ID de colección no existe."
 #~ msgid "This does not include a fee of {makerFee} which was already added by the maker."
 #~ msgstr "Esto no incluye una tarifa de {makerFee} que ya fue añadida por el creador."
 
-#: src/pages/TokenList.tsx:252
+#: src/pages/TokenList.tsx:254
 msgid "This is an estimate only and does not account for liquidity"
 msgstr ""
 
@@ -4234,7 +4262,7 @@ msgstr ""
 msgid "This is the raw JSON spend bundle for this transaction. If you sign it, the transaction can be submitted to the mempool externally."
 msgstr "Este es el paquete de gastos JSON raw para esta transacción. Si lo firma, la transacción se puede enviar al mempool externamente."
 
-#: src/pages/Nft.tsx:510
+#: src/pages/Nft.tsx:527
 msgid "This NFT is not currently offered for sale on Dexie"
 msgstr ""
 
@@ -4243,7 +4271,7 @@ msgstr ""
 msgid "This NFT is part of an open offer"
 msgstr ""
 
-#: src/pages/Nft.tsx:505
+#: src/pages/Nft.tsx:522
 msgid "This NFT Offered For Sale"
 msgstr ""
 
@@ -4506,7 +4534,7 @@ msgstr "Cantidad total"
 msgid "Total Duration"
 msgstr ""
 
-#: src/pages/TokenList.tsx:243
+#: src/pages/TokenList.tsx:245
 msgid "Total Estimated Balance"
 msgstr ""
 
@@ -4731,7 +4759,7 @@ msgstr ""
 msgid "Unknown Minter"
 msgstr "Minter Desconocido"
 
-#: src/pages/Nft.tsx:173
+#: src/pages/Nft.tsx:183
 msgid "Unknown NFT"
 msgstr "NFT desconocido"
 
@@ -4752,7 +4780,7 @@ msgstr ""
 msgid "Unnamed"
 msgstr "Sin nombre"
 
-#: src/components/NftGroupCard.tsx:122
+#: src/components/NftGroupCard.tsx:128
 #: src/pages/CollectionMetaData.tsx:164
 msgid "Unnamed Collection"
 msgstr "Colección sin nombre"
@@ -4791,7 +4819,7 @@ msgstr ""
 #~ msgid "Untitled Option"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:126
+#: src/components/NftGroupCard.tsx:132
 #: src/components/NftPageTitle.tsx:29
 #: src/pages/DidList.tsx:219
 msgid "Untitled Profile"
@@ -4902,12 +4930,12 @@ msgstr "Versión {version}"
 #~ msgid "View {0} token details"
 #~ msgstr "Ver detalles del token {0}"
 
-#: src/components/NftGroupCard.tsx:309
+#: src/components/NftGroupCard.tsx:349
 msgid "View {cardName} Metadata"
 msgstr "Ver metadatos de {cardName}"
 
-#: src/components/NftGroupCard.tsx:323
-#: src/components/NftGroupCard.tsx:368
+#: src/components/NftGroupCard.tsx:363
+#: src/components/NftGroupCard.tsx:408
 msgid "View {cardName} on Mintgarden"
 msgstr "Ver {cardName} en Mintgarden"
 
@@ -4935,13 +4963,13 @@ msgstr "Ver oculto"
 msgid "View Local Offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:313
+#: src/components/NftGroupCard.tsx:353
 msgid "View Metadata"
 msgstr "Ver metadatos"
 
 #: src/components/dialogs/ViewOfferDialog.tsx:49
-#: src/pages/Nft.tsx:478
-#: src/pages/Nft.tsx:597
+#: src/pages/Nft.tsx:495
+#: src/pages/Nft.tsx:614
 #: src/pages/Offers.tsx:264
 msgid "View Offer"
 msgstr "Ver Oferta"
@@ -4955,8 +4983,8 @@ msgstr ""
 msgid "View on dexie"
 msgstr "Ver en Dexie"
 
-#: src/components/NftGroupCard.tsx:327
-#: src/components/NftGroupCard.tsx:372
+#: src/components/NftGroupCard.tsx:367
+#: src/components/NftGroupCard.tsx:412
 msgid "View on Mintgarden"
 msgstr "Ver en Mintgarden"
 
@@ -4965,7 +4993,7 @@ msgid "View on MintGarden"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:323
-#: src/pages/Nft.tsx:337
+#: src/pages/Nft.tsx:354
 msgid "View on Spacescan.io"
 msgstr ""
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "{0, plural, one {You do not currently have any option contracts. Would you like to mint one?} other {You do not currently have any option contracts. Would you like to mint one?}}"
 msgstr ""
 
-#: src/pages/Nft.tsx:250
+#: src/pages/Nft.tsx:260
 msgid "{0}"
 msgstr ""
 
@@ -195,7 +195,7 @@ msgstr "操作"
 msgid "Actions for {selectedCount} selected NFTs"
 msgstr ""
 
-#: src/pages/NftList.tsx:196
+#: src/pages/NftList.tsx:241
 msgid "Actions for selected NFTs"
 msgstr ""
 
@@ -217,12 +217,12 @@ msgstr ""
 msgid "Add {selectedCount} selected NFTs to offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:485
-#: src/components/NftGroupCard.tsx:488
+#: src/components/NftGroupCard.tsx:525
+#: src/components/NftGroupCard.tsx:528
 msgid "Add all NFTs in {cardName} to an offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:489
+#: src/components/NftGroupCard.tsx:529
 msgid "Add All to Offer"
 msgstr ""
 
@@ -275,7 +275,7 @@ msgid "Add URL to NFT"
 msgstr ""
 
 #: src/components/MultiSelectActions.tsx:274
-#: src/components/NftGroupCard.tsx:469
+#: src/components/NftGroupCard.tsx:509
 msgid "Added {addedCount} {nfts} to offer"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgstr ""
 #: src/components/AddressList.tsx:23
 #: src/components/TransactionColumns.tsx:119
 #: src/components/TransferDialog.tsx:86
-#: src/pages/Nft.tsx:618
+#: src/pages/Nft.tsx:635
 #: src/pages/Option.tsx:275
 #: src/pages/Send.tsx:292
 msgid "Address"
@@ -447,7 +447,7 @@ msgstr ""
 msgid "assets"
 msgstr ""
 
-#: src/pages/TokenList.tsx:174
+#: src/pages/TokenList.tsx:176
 msgid "Assets"
 msgstr "资产"
 
@@ -470,7 +470,7 @@ msgstr ""
 #~ msgstr "于高度 {peerMaxHeight}"
 
 #: src/pages/CollectionMetaData.tsx:337
-#: src/pages/Nft.tsx:351
+#: src/pages/Nft.tsx:368
 msgid "Attributes"
 msgstr "属性"
 
@@ -525,6 +525,10 @@ msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:184
 msgid "Banner for {collectionName}"
+msgstr ""
+
+#: src/pages/NftList.tsx:202
+msgid "Based on MintGarden collection floor prices. This is an estimate only and does not account for liquidity"
 msgstr ""
 
 #: src/pages/Settings.tsx:307
@@ -822,7 +826,7 @@ msgstr ""
 
 #: src/components/AssetCoin.tsx:96
 #: src/components/CoinList.tsx:72
-#: src/pages/Nft.tsx:619
+#: src/pages/Nft.tsx:636
 #: src/pages/Option.tsx:274
 msgid "Coin ID"
 msgstr ""
@@ -867,12 +871,16 @@ msgstr ""
 msgid "Collapse sidebar"
 msgstr ""
 
-#: src/pages/Nft.tsx:281
+#: src/pages/Nft.tsx:291
 msgid "Collection"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:197
+#: src/components/NftGroupCard.tsx:203
 msgid "Collection {cardName}"
+msgstr ""
+
+#: src/pages/Nft.tsx:304
+msgid "Collection Floor"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:204
@@ -880,7 +888,7 @@ msgstr ""
 msgid "Collection ID"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:384
+#: src/components/NftGroupCard.tsx:424
 msgid "Collection ID copied to clipboard"
 msgstr ""
 
@@ -1046,7 +1054,7 @@ msgstr "复制"
 msgid "Copy {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:390
+#: src/components/NftGroupCard.tsx:430
 msgid "Copy {cardName} ID to clipboard"
 msgstr ""
 
@@ -1087,7 +1095,7 @@ msgid "Copy Balance"
 msgstr ""
 
 #: src/components/NftCard.tsx:592
-#: src/components/NftGroupCard.tsx:394
+#: src/components/NftGroupCard.tsx:434
 #: src/components/OfferRowCard.tsx:144
 #: src/components/OptionCard.tsx:150
 #: src/components/OptionColumns.tsx:222
@@ -1135,7 +1143,7 @@ msgstr ""
 msgid "Create individual offers for each NFT"
 msgstr ""
 
-#: src/pages/NftList.tsx:136
+#: src/pages/NftList.tsx:145
 msgid "Create new NFT"
 msgstr ""
 
@@ -1156,13 +1164,13 @@ msgid "Create Wallet"
 msgstr "创建钱包"
 
 #: src/components/OfferCard.tsx:158
-#: src/pages/Nft.tsx:294
+#: src/pages/Nft.tsx:311
 #: src/pages/Option.tsx:143
 #: src/pages/Transaction.tsx:86
 msgid "Created"
 msgstr ""
 
-#: src/pages/Nft.tsx:575
+#: src/pages/Nft.tsx:592
 #: src/pages/Option.tsx:231
 msgid "Created: {0}"
 msgstr ""
@@ -1207,7 +1215,7 @@ msgstr ""
 msgid "Data"
 msgstr "数据"
 
-#: src/pages/Nft.tsx:633
+#: src/pages/Nft.tsx:650
 msgid "Data and License Details"
 msgstr ""
 
@@ -1215,7 +1223,7 @@ msgstr ""
 msgid "Data copied to clipboard"
 msgstr ""
 
-#: src/pages/Nft.tsx:686
+#: src/pages/Nft.tsx:703
 msgid "Data Hash"
 msgstr "数据哈希"
 
@@ -1223,7 +1231,7 @@ msgstr "数据哈希"
 msgid "Data table"
 msgstr ""
 
-#: src/pages/Nft.tsx:638
+#: src/pages/Nft.tsx:655
 msgid "Data URIs"
 msgstr "数据URI"
 
@@ -1373,7 +1381,7 @@ msgid "Descending"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:241
-#: src/pages/Nft.tsx:276
+#: src/pages/Nft.tsx:286
 msgid "Description"
 msgstr "描述"
 
@@ -1395,8 +1403,8 @@ msgstr ""
 msgid "Details"
 msgstr "详情"
 
-#: src/pages/Nft.tsx:492
-#: src/pages/Nft.tsx:544
+#: src/pages/Nft.tsx:509
+#: src/pages/Nft.tsx:561
 msgid "Dexie"
 msgstr ""
 
@@ -1483,7 +1491,7 @@ msgstr ""
 msgid "Edit Token Details"
 msgstr "编辑代币详情"
 
-#: src/pages/Nft.tsx:270
+#: src/pages/Nft.tsx:280
 msgid "Edition"
 msgstr ""
 
@@ -1632,6 +1640,10 @@ msgstr ""
 msgid "Error loading themes: {error}"
 msgstr ""
 
+#: src/pages/NftList.tsx:183
+msgid "Estimated value: <0/> XCH (~<1/>)"
+msgstr ""
+
 #: src/components/OptionCard.tsx:80
 #: src/components/OptionColumns.tsx:193
 #: src/hooks/useOptionActions.tsx:133
@@ -1725,12 +1737,12 @@ msgid "Export transactions"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:283
-#: src/pages/Nft.tsx:303
+#: src/pages/Nft.tsx:320
 #: src/pages/Option.tsx:282
 msgid "External Links"
 msgstr "外部链接"
 
-#: src/components/NftGroupCard.tsx:481
+#: src/components/NftGroupCard.tsx:521
 msgid "Failed to add NFTs to offer"
 msgstr ""
 
@@ -1829,6 +1841,10 @@ msgstr ""
 #: src/components/ClawbackCoinsCard.tsx:270
 #: src/pages/Token.tsx:167
 msgid "Finalize Clawback Details"
+msgstr ""
+
+#: src/components/NftGroupCard.tsx:308
+msgid "Floor <0/> XCH · ~<1/>"
 msgstr ""
 
 #: src/pages/Addresses.tsx:75
@@ -1945,7 +1961,7 @@ msgid "Hex bytes"
 msgstr ""
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:346
+#: src/components/NftGroupCard.tsx:386
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -1959,7 +1975,7 @@ msgstr "隐藏"
 msgid "Hide {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Hide {cardName}"
 msgstr ""
 
@@ -2025,11 +2041,11 @@ msgstr "小时"
 msgid "Icon for {collectionName}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:215
+#: src/components/NftGroupCard.tsx:221
 msgid "Icon for {name}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:275
+#: src/components/NftGroupCard.tsx:281
 msgid "ID: {cardId}"
 msgstr ""
 
@@ -2057,6 +2073,10 @@ msgstr ""
 
 #: src/components/dialogs/MigrationDialog.tsx:33
 msgid "In order to proceed with the update, the wallet will be fully resynced. This means any imported offer files or custom asset names will be removed, but you can manually add them again after if needed."
+msgstr ""
+
+#: src/pages/TokenList.tsx:281
+msgid "Includes ~<0/> in NFTs"
 msgstr ""
 
 #: src/pages/Swap.tsx:249
@@ -2111,13 +2131,13 @@ msgstr "IP地址"
 msgid "IP Addresses"
 msgstr ""
 
-#: src/pages/TokenList.tsx:182
+#: src/pages/TokenList.tsx:184
 msgid "Issue new token"
 msgstr ""
 
 #: src/pages/IssueToken.tsx:63
 #: src/pages/IssueToken.tsx:151
-#: src/pages/TokenList.tsx:186
+#: src/pages/TokenList.tsx:188
 msgid "Issue Token"
 msgstr "发行代币"
 
@@ -2156,7 +2176,7 @@ msgid "Launcher Id"
 msgstr "启动器Id"
 
 #: src/components/AssetCoin.tsx:88
-#: src/pages/Nft.tsx:263
+#: src/pages/Nft.tsx:273
 msgid "Launcher ID"
 msgstr ""
 
@@ -2177,11 +2197,11 @@ msgstr ""
 msgid "License"
 msgstr "许可证"
 
-#: src/pages/Nft.tsx:698
+#: src/pages/Nft.tsx:715
 msgid "License Hash"
 msgstr "许可证哈希"
 
-#: src/pages/Nft.tsx:670
+#: src/pages/Nft.tsx:687
 msgid "License URIs"
 msgstr "许可证网址"
 
@@ -2206,7 +2226,7 @@ msgstr ""
 #~ msgid "Loading {0} details..."
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading collection"
 msgstr ""
 
@@ -2230,7 +2250,7 @@ msgstr ""
 msgid "Loading options..."
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:158
+#: src/components/NftGroupCard.tsx:164
 msgid "Loading profile"
 msgstr ""
 
@@ -2257,7 +2277,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/pages/Nft.tsx:566
+#: src/pages/Nft.tsx:583
 #: src/pages/Option.tsx:222
 msgid "Local Offer"
 msgstr ""
@@ -2343,11 +2363,11 @@ msgstr ""
 #~ msgid "Metadata Collection ID copied to clipboard"
 #~ msgstr ""
 
-#: src/pages/Nft.tsx:692
+#: src/pages/Nft.tsx:709
 msgid "Metadata Hash"
 msgstr "元数据哈希"
 
-#: src/pages/Nft.tsx:654
+#: src/pages/Nft.tsx:671
 msgid "Metadata URIs"
 msgstr "元数据网址"
 
@@ -2368,7 +2388,7 @@ msgid "Mint new option"
 msgstr ""
 
 #: src/pages/MintNft.tsx:155
-#: src/pages/NftList.tsx:139
+#: src/pages/NftList.tsx:148
 msgid "Mint NFT"
 msgstr "铸造NFT"
 
@@ -2378,12 +2398,12 @@ msgstr "铸造NFT"
 msgid "Mint Option"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:200
+#: src/components/NftGroupCard.tsx:206
 msgid "Minter {cardName}"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:210
-#: src/pages/Nft.tsx:385
+#: src/pages/Nft.tsx:402
 msgid "Minter DID"
 msgstr "铸造者DID"
 
@@ -2392,7 +2412,7 @@ msgstr "铸造者DID"
 #~ msgid "Minter DID copied to clipboard"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:387
+#: src/components/NftGroupCard.tsx:427
 msgid "Minter ID copied to clipboard"
 msgstr ""
 
@@ -2528,7 +2548,7 @@ msgid "Next page"
 msgstr "下一页"
 
 #: src/components/MultiSelectActions.tsx:271
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/selectors/AssetSelector.tsx:214
 msgid "NFT"
 msgstr "NFT"
@@ -2543,7 +2563,7 @@ msgstr ""
 #~ msgid "NFT artwork for unnamed NFT"
 #~ msgstr ""
 
-#: src/pages/NftList.tsx:168
+#: src/pages/NftList.tsx:213
 msgid "NFT Collection"
 msgstr ""
 
@@ -2571,8 +2591,12 @@ msgstr ""
 #~ msgid "NFT preview"
 #~ msgstr "NFT预览"
 
-#: src/pages/Nft.tsx:179
+#: src/pages/Nft.tsx:189
 msgid "NFT Preview"
+msgstr ""
+
+#: src/pages/TokenList.tsx:261
+msgid "NFT values are floor price estimates from MintGarden"
 msgstr ""
 
 #: src/components/NftOptions.tsx:179
@@ -2581,7 +2605,7 @@ msgstr ""
 
 #: src/components/MultiSelectActions.tsx:271
 #: src/components/Nav.tsx:58
-#: src/components/NftGroupCard.tsx:466
+#: src/components/NftGroupCard.tsx:506
 #: src/components/NftPageTitle.tsx:44
 msgid "NFTs"
 msgstr "NFT"
@@ -2620,7 +2644,7 @@ msgstr ""
 msgid "No Collection Found"
 msgstr ""
 
-#: src/pages/Nft.tsx:448
+#: src/pages/Nft.tsx:465
 msgid "No Dexie offers requesting this NFT"
 msgstr ""
 
@@ -2639,6 +2663,10 @@ msgstr ""
 
 #: src/components/selectors/SearchableSelect.tsx:111
 msgid "No items found."
+msgstr ""
+
+#: src/components/NftGroupCard.tsx:301
+msgid "No listings"
 msgstr ""
 
 #: src/pages/Settings.tsx:866
@@ -2787,7 +2815,7 @@ msgstr "提供"
 #~ msgid "Offered {0} amount must be a positive number."
 #~ msgstr ""
 
-#: src/pages/Nft.tsx:457
+#: src/pages/Nft.tsx:474
 msgid "Offered in exchange:"
 msgstr ""
 
@@ -2812,7 +2840,7 @@ msgstr "报价"
 msgid "Offers Created"
 msgstr ""
 
-#: src/pages/Nft.tsx:443
+#: src/pages/Nft.tsx:460
 msgid "Offers Requesting This NFT"
 msgstr ""
 
@@ -2933,7 +2961,7 @@ msgstr ""
 msgid "Options exported successfully"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:292
+#: src/components/NftGroupCard.tsx:332
 msgid "Options for {cardName}"
 msgstr ""
 
@@ -2970,7 +2998,7 @@ msgstr ""
 msgid "Owned Coins"
 msgstr ""
 
-#: src/pages/Nft.tsx:412
+#: src/pages/Nft.tsx:429
 msgid "Owner DID"
 msgstr "拥有者DID"
 
@@ -2982,7 +3010,7 @@ msgstr "拥有者DID"
 msgid "Owner Profiles"
 msgstr ""
 
-#: src/pages/Nft.tsx:379
+#: src/pages/Nft.tsx:396
 msgid "Ownership"
 msgstr ""
 
@@ -3164,7 +3192,7 @@ msgstr "正在处理报价数据..."
 msgid "Profile"
 msgstr "个人资料"
 
-#: src/components/NftGroupCard.tsx:199
+#: src/components/NftGroupCard.tsx:205
 msgid "Profile {cardName}"
 msgstr ""
 
@@ -3181,7 +3209,7 @@ msgid "Profile ID"
 msgstr ""
 
 #: src/components/confirmations/NftConfirmation.tsx:98
-#: src/components/NftGroupCard.tsx:386
+#: src/components/NftGroupCard.tsx:426
 msgid "Profile ID copied to clipboard"
 msgstr ""
 
@@ -3285,7 +3313,7 @@ msgstr ""
 msgid "Refresh Info"
 msgstr "刷新信息"
 
-#: src/pages/TokenList.tsx:153
+#: src/pages/TokenList.tsx:155
 msgid "Refreshing token info..."
 msgstr ""
 
@@ -3326,7 +3354,7 @@ msgstr "请求"
 msgid "Requesting"
 msgstr ""
 
-#: src/pages/Nft.tsx:521
+#: src/pages/Nft.tsx:538
 msgid "Requesting in exchange:"
 msgstr ""
 
@@ -3385,7 +3413,7 @@ msgstr ""
 msgid "Revocable CAT"
 msgstr ""
 
-#: src/pages/Nft.tsx:436
+#: src/pages/Nft.tsx:453
 msgid "Royalties {royaltyPercentage}%"
 msgstr "版税 {royaltyPercentage}%"
 
@@ -3429,11 +3457,11 @@ msgstr "保存助记词"
 #~ msgid "Save Offer"
 #~ msgstr "保存报价"
 
-#: src/pages/Nft.tsx:255
+#: src/pages/Nft.tsx:265
 msgid "Save Theme"
 msgstr ""
 
-#: src/pages/Nft.tsx:254
+#: src/pages/Nft.tsx:264
 msgid "Saving..."
 msgstr ""
 
@@ -3624,7 +3652,7 @@ msgid "Selected NFTs actions"
 msgstr ""
 
 #: src/components/MultiSelectActions.tsx:275
-#: src/components/NftGroupCard.tsx:470
+#: src/components/NftGroupCard.tsx:510
 msgid "Selected NFTs are already in the offer"
 msgstr ""
 
@@ -3697,7 +3725,7 @@ msgid "Share your offer on these marketplaces."
 msgstr ""
 
 #: src/components/NftCard.tsx:577
-#: src/components/NftGroupCard.tsx:353
+#: src/components/NftGroupCard.tsx:393
 #: src/components/OptionCard.tsx:170
 #: src/components/OptionColumns.tsx:234
 #: src/components/TokenCard.tsx:178
@@ -3711,7 +3739,7 @@ msgstr "显示"
 msgid "Show {0}"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:339
+#: src/components/NftGroupCard.tsx:379
 msgid "Show {cardName}"
 msgstr ""
 
@@ -3909,7 +3937,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: src/pages/Nft.tsx:569
+#: src/pages/Nft.tsx:586
 #: src/pages/Option.tsx:225
 msgid "Status: {0}"
 msgstr ""
@@ -4027,7 +4055,7 @@ msgstr "正在同步 {syncedCoins} / {totalCoins}"
 msgid "Syncing Defaults"
 msgstr ""
 
-#: src/pages/TokenList.tsx:213
+#: src/pages/TokenList.tsx:215
 msgid "Syncing in progress..."
 msgstr "同步进行中..."
 
@@ -4060,7 +4088,7 @@ msgstr ""
 msgid "Target Peers"
 msgstr "目标节点"
 
-#: src/pages/Nft.tsx:614
+#: src/pages/Nft.tsx:631
 #: src/pages/Option.tsx:266
 msgid "Technical Information"
 msgstr ""
@@ -4129,7 +4157,7 @@ msgstr ""
 msgid "The wallet generates a new address after each transaction. Old ones stay valid."
 msgstr "钱包在每次交易后会生成一个新的地址, 旧地址仍然有效."
 
-#: src/pages/TokenList.tsx:216
+#: src/pages/TokenList.tsx:218
 msgid "The wallet is still syncing. Balances may not be accurate until it completes."
 msgstr "钱包仍在同步中. 同步完成之前, 余额可能不准确."
 
@@ -4142,7 +4170,7 @@ msgstr ""
 msgid "Theme deleted successfully"
 msgstr ""
 
-#: src/pages/Nft.tsx:252
+#: src/pages/Nft.tsx:262
 msgid "Theme Saved"
 msgstr ""
 
@@ -4217,7 +4245,7 @@ msgstr ""
 #~ msgid "This does not include a fee of {makerFee} which was already added by the maker."
 #~ msgstr "这不包括已由创建者添加的手续费 {makerFee}."
 
-#: src/pages/TokenList.tsx:252
+#: src/pages/TokenList.tsx:254
 msgid "This is an estimate only and does not account for liquidity"
 msgstr ""
 
@@ -4233,7 +4261,7 @@ msgstr ""
 msgid "This is the raw JSON spend bundle for this transaction. If you sign it, the transaction can be submitted to the mempool externally."
 msgstr "这是该交易的原始 JSON 支出捆绑包. 如果签署它, 交易可以通过外部提交到内存池."
 
-#: src/pages/Nft.tsx:510
+#: src/pages/Nft.tsx:527
 msgid "This NFT is not currently offered for sale on Dexie"
 msgstr ""
 
@@ -4242,7 +4270,7 @@ msgstr ""
 msgid "This NFT is part of an open offer"
 msgstr ""
 
-#: src/pages/Nft.tsx:505
+#: src/pages/Nft.tsx:522
 msgid "This NFT Offered For Sale"
 msgstr ""
 
@@ -4505,7 +4533,7 @@ msgstr ""
 msgid "Total Duration"
 msgstr ""
 
-#: src/pages/TokenList.tsx:243
+#: src/pages/TokenList.tsx:245
 msgid "Total Estimated Balance"
 msgstr ""
 
@@ -4729,7 +4757,7 @@ msgstr ""
 msgid "Unknown Minter"
 msgstr ""
 
-#: src/pages/Nft.tsx:173
+#: src/pages/Nft.tsx:183
 msgid "Unknown NFT"
 msgstr "未知NFT"
 
@@ -4750,7 +4778,7 @@ msgstr ""
 msgid "Unnamed"
 msgstr "未命名"
 
-#: src/components/NftGroupCard.tsx:122
+#: src/components/NftGroupCard.tsx:128
 #: src/pages/CollectionMetaData.tsx:164
 msgid "Unnamed Collection"
 msgstr ""
@@ -4789,7 +4817,7 @@ msgstr ""
 #~ msgid "Untitled Option"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:126
+#: src/components/NftGroupCard.tsx:132
 #: src/components/NftPageTitle.tsx:29
 #: src/pages/DidList.tsx:219
 msgid "Untitled Profile"
@@ -4900,12 +4928,12 @@ msgstr ""
 #~ msgid "View {0} token details"
 #~ msgstr ""
 
-#: src/components/NftGroupCard.tsx:309
+#: src/components/NftGroupCard.tsx:349
 msgid "View {cardName} Metadata"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:323
-#: src/components/NftGroupCard.tsx:368
+#: src/components/NftGroupCard.tsx:363
+#: src/components/NftGroupCard.tsx:408
 msgid "View {cardName} on Mintgarden"
 msgstr ""
 
@@ -4933,13 +4961,13 @@ msgstr "查看已隐藏的"
 msgid "View Local Offer"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:313
+#: src/components/NftGroupCard.tsx:353
 msgid "View Metadata"
 msgstr ""
 
 #: src/components/dialogs/ViewOfferDialog.tsx:49
-#: src/pages/Nft.tsx:478
-#: src/pages/Nft.tsx:597
+#: src/pages/Nft.tsx:495
+#: src/pages/Nft.tsx:614
 #: src/pages/Offers.tsx:264
 msgid "View Offer"
 msgstr "查看报价"
@@ -4953,8 +4981,8 @@ msgstr ""
 msgid "View on dexie"
 msgstr ""
 
-#: src/components/NftGroupCard.tsx:327
-#: src/components/NftGroupCard.tsx:372
+#: src/components/NftGroupCard.tsx:367
+#: src/components/NftGroupCard.tsx:412
 msgid "View on Mintgarden"
 msgstr ""
 
@@ -4963,7 +4991,7 @@ msgid "View on MintGarden"
 msgstr ""
 
 #: src/pages/CollectionMetaData.tsx:323
-#: src/pages/Nft.tsx:337
+#: src/pages/Nft.tsx:354
 msgid "View on Spacescan.io"
 msgstr ""
 

--- a/src/pages/Nft.tsx
+++ b/src/pages/Nft.tsx
@@ -6,6 +6,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useErrors } from '@/hooks/useErrors';
 import { useNetwork } from '@/hooks/useNetwork';
+import { useNftPrices } from '@/hooks/useNftPrices';
+import { usePrices } from '@/hooks/usePrices';
+import { formatNumber } from '@/i18n';
 import {
   dexieOfferUrl,
   mintGardenDidUrl,
@@ -43,6 +46,13 @@ export default function Nft() {
   const [themeExists, setThemeExists] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const royaltyPercentage = (nft?.royalty_ten_thousandths ?? 0) / 100;
+
+  const { collectionValues } = useNftPrices();
+  const { getPriceInUsd } = usePrices();
+
+  const collectionFloorXch = nft?.collection_id
+    ? (collectionValues[nft.collection_id]?.floorXch ?? null)
+    : null;
 
   const [requestedOffers, setRequestedOffers] = useState<DexieOffer[]>([]);
   const [offeredOffers, setOfferedOffers] = useState<DexieOffer[]>([]);
@@ -288,6 +298,13 @@ export default function Nft() {
                     }
                   }}
                 />
+
+                {collectionFloorXch !== null && (
+                  <LabeledItem
+                    label={t`Collection Floor`}
+                    content={`${formatNumber({ value: collectionFloorXch, maximumFractionDigits: 3 })} XCH (~${formatNumber({ value: collectionFloorXch * getPriceInUsd(null), style: 'currency', currency: 'USD', maximumFractionDigits: 2 })})`}
+                  />
+                )}
 
                 {nft?.created_timestamp && (
                   <LabeledItem

--- a/src/pages/NftList.tsx
+++ b/src/pages/NftList.tsx
@@ -4,17 +4,25 @@ import { MultiSelectActions } from '@/components/MultiSelectActions';
 import { NftCardList } from '@/components/NftCardList';
 import { NftOptions } from '@/components/NftOptions';
 import { NftPageTitle } from '@/components/NftPageTitle';
+import { NumberFormat } from '@/components/NumberFormat';
 import { Pagination } from '@/components/Pagination';
 import { ReceiveAddress } from '@/components/ReceiveAddress';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { useErrors } from '@/hooks/useErrors';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { useNftData } from '@/hooks/useNftData';
 import { NftGroupMode, useNftParams } from '@/hooks/useNftParams';
+import { useNftPrices } from '@/hooks/useNftPrices';
 import { exportNfts } from '@/lib/exportNfts';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
-import { ImagePlusIcon } from 'lucide-react';
+import { ImagePlusIcon, ShieldAlert } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -27,6 +35,7 @@ export function NftList() {
   } = useParams();
   const [params, setParams] = useNftParams();
   const { pageSize, sort, group, showHidden, query } = params;
+  const { nftTotalXch, nftTotalUsd } = useNftPrices();
   const [multiSelect, setMultiSelect] = useState(false);
   const [selected, setSelected] = useState<string[]>([]);
   const { addError } = useErrors();
@@ -164,6 +173,42 @@ export function NftList() {
             }
           />
         </div>
+
+        {group === NftGroupMode.Collection &&
+          !collectionId &&
+          !ownerDid &&
+          !minterDid &&
+          nftTotalXch > 0 && (
+            <div className='mt-4 flex items-center gap-2 text-sm text-muted-foreground'>
+              <Trans>
+                Estimated value:{' '}
+                <NumberFormat value={nftTotalXch} maximumFractionDigits={3} />{' '}
+                XCH (~
+                <NumberFormat
+                  value={nftTotalUsd}
+                  style='currency'
+                  currency='USD'
+                  maximumFractionDigits={2}
+                />
+                )
+              </Trans>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <ShieldAlert className='h-4 w-4 text-muted-foreground cursor-help' />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      <Trans>
+                        Based on MintGarden collection floor prices. This is an
+                        estimate only and does not account for liquidity
+                      </Trans>
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          )}
 
         <main aria-label={t`NFT Collection`}>
           <NftCardList

--- a/src/pages/TokenList.tsx
+++ b/src/pages/TokenList.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useErrors } from '@/hooks/useErrors';
+import { useNftPrices } from '@/hooks/useNftPrices';
 import { usePrices } from '@/hooks/usePrices';
 import { TokenSortMode, useTokenParams } from '@/hooks/useTokenParams';
 import { exportTokens } from '@/lib/exportTokens';
@@ -32,6 +33,7 @@ export function TokenList() {
   const navigate = useNavigate();
   const walletState = useWalletState();
   const { getBalanceInUsd, getPriceInUsd } = usePrices();
+  const { nftTotalUsd } = useNftPrices();
   const { addError } = useErrors();
   const [params, setParams] = useTokenParams();
   const { viewMode, sortMode, showZeroBalanceTokens, showHiddenCats } = params;
@@ -254,19 +256,40 @@ export function TokenList() {
                           liquidity
                         </Trans>
                       </p>
+                      {nftTotalUsd > 0 && (
+                        <p>
+                          <Trans>
+                            NFT values are floor price estimates from MintGarden
+                          </Trans>
+                        </p>
+                      )}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               </div>
               <span className='foreground'>
                 <NumberFormat
-                  value={totalUsdBalance}
+                  value={totalUsdBalance + nftTotalUsd}
                   style='currency'
                   currency='USD'
                   maximumFractionDigits={2}
                 />
               </span>
             </div>
+            {nftTotalUsd > 0 && (
+              <div className='flex justify-end text-sm text-muted-foreground mt-1'>
+                <Trans>
+                  Includes ~
+                  <NumberFormat
+                    value={nftTotalUsd}
+                    style='currency'
+                    currency='USD'
+                    maximumFractionDigits={2}
+                  />{' '}
+                  in NFTs
+                </Trans>
+              </div>
+            )}
           </div>
         )}
       </Container>


### PR DESCRIPTION
## Summary

- Adds NFT valuation to the portfolio: collection floor price (MintGarden) × owned NFT count, converted to USD via the existing XCH/USD rate
- Backend: `nft_count` (visible NFTs only) computed per collection via a correlated subquery and exposed on `NftCollectionRecord` — no migrations, no new endpoints
- Frontend: new `NftPriceContext` (mirrors `PriceContext`) with a 15-minute TTL floor cache persisted in localStorage per network, concurrency-capped MintGarden fetches (4 at a time, 10s timeout), and pure valuation math in `src/lib/nftValue.ts`
- Surfaces the value in four places: main "Total Estimated Balance" (+ "Includes ~$X in NFTs"), NFT collections view summary, per-collection-card floor lines, and a "Collection Floor" row on the NFT detail page
- Privacy: only public collection IDs are sent to MintGarden — never addresses or holdings; testnet uses `api.testnet.mintgarden.io`
- Hidden NFTs and the "Uncategorized" pseudo-collection are excluded from valuation; never-fetched/unlisted collections contribute nothing rather than blocking the UI
- Translations extracted for all four locales

## Test Plan

- [x] `cargo t -p sage-wallet` — 45/45 pass
- [x] `cargo clippy --workspace` — clean; `cargo sqlx prepare` cache committed (offline build verified)
- [x] `pnpm lint` (0 errors), `tsc -b`, `pnpm build` — clean
- [x] Manual: mainnet wallet with NFT collections — totals, collection cards, NFT detail floor all render; values spot-checked against mintgarden.io
- [x] Cold start shows tokens-only total (no layout shift); floors appear as fetched; restart shows cached values instantly
- [ ] Testnet wallet smoke test