### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,10 @@ jobs:
           - platform: 'linux-arm64'
             platform_name: Linux (ARM)
             build: 'pnpm tauri build --target aarch64-unknown-linux-gnu'
-          - platform: 'windows-latest'
+          - platform: 'windows-2022'
             platform_name: Windows (x64)
             build: 'pnpm tauri build'
-          - platform: 'windows-latest'
+          - platform: 'windows-2022'
             platform_name: Windows (ARM)
             build: 'pnpm tauri build --target aarch64-pc-windows-msvc'
           - platform: 'macos-26'
@@ -114,12 +114,10 @@ jobs:
         run: sudo apt-get install --reinstall xdg-utils
 
       - name: Windows dependencies
-        if: matrix.platform == 'windows-latest'
+        if: startsWith(matrix.platform, 'windows-')
         run: |
           choco install nasm
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          "CFLAGS_x86_64_pc_windows_msvc=/std:c11" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "CFLAGS_aarch64_pc_windows_msvc=/std:c11" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install Android NDK
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,8 @@ jobs:
         run: |
           choco install nasm
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "CFLAGS_x86_64_pc_windows_msvc=/std:c11" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CFLAGS_aarch64_pc_windows_msvc=/std:c11" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install Android NDK
         uses: nttld/setup-ndk@v1

--- a/README.md
+++ b/README.md
@@ -126,3 +126,5 @@ The following things have to be done before a new release is published:
 6. Upload to TestFlight and the Google Play Store
 7. Generate the OpenAPI specification `cargo run --bin sage rpc generate_openapi -o dist/openapi.json`
 8. Upload to docusaurus
+
+Test

--- a/README.md
+++ b/README.md
@@ -126,5 +126,3 @@ The following things have to be done before a new release is published:
 6. Upload to TestFlight and the Google Play Store
 7. Generate the OpenAPI specification `cargo run --bin sage rpc generate_openapi -o dist/openapi.json`
 8. Upload to docusaurus
-
-Test


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only runner pinning and a broader step `if` condition; no application or release artifact logic changes.
> 
> **Overview**
> Pins the **Windows (x64)** and **Windows (ARM)** build matrix jobs from `windows-latest` to **`windows-2022`** so Tauri builds run on a fixed GitHub-hosted image instead of a moving `latest` label.
> 
> Updates the **Windows dependencies** step condition from an exact `windows-latest` match to **`startsWith(matrix.platform, 'windows-')`**, so NASM setup still runs for both Windows matrix entries after the runner rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e07c312058aa04c72e6ea952319ec4a47e48ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->