### PR TITLE
Fix (critical): scope app bridge responses/events to their webview

### DIFF
--- a/crates/sage-apps/src/bridge/event_emit.rs
+++ b/crates/sage-apps/src/bridge/event_emit.rs
@@ -198,6 +198,11 @@ where
     .await
 }
 
+// NOTE: These deliberately broadcast to every first-party Sage host window
+// (all trusted "main"-family webviews) via `emit`. The sensitive, per-app
+// rails (`sage-bridge:response` and the user/system runtime event rails) are
+// scoped to a single app webview via `emit_to` below so that one app can never
+// observe another app's bridge traffic.
 pub(crate) fn emit_user_runtime_event_to_sage_webview<T>(
     app_handle: &AppHandle,
     event: T,
@@ -227,8 +232,9 @@ pub(crate) async fn emit_bridge_response_to_app(
     app: &SharedSageApp,
     response: &RustBridgeResponse,
 ) -> Result<(), String> {
-    get_webview_in_sage_window(app_handle, &app.webview_label())?
-        .emit("sage-bridge:response", response)
+    let webview_label = app.webview_label();
+    get_webview_in_sage_window(app_handle, &webview_label)?
+        .emit_to(webview_label.as_str(), "sage-bridge:response", response)
         .map_err(|err| format!("failed to emit bridge response: {err}"))
 }
 
@@ -261,6 +267,10 @@ where
     );
 
     get_webview_in_sage_window(app_handle, &webview_label)?
-        .emit(rail.event_name(), runtime_event(event_type, event))
+        .emit_to(
+            webview_label.as_str(),
+            rail.event_name(),
+            runtime_event(event_type, event),
+        )
         .map_err(|err| format!("failed to emit runtime event: {err}"))
 }


### PR DESCRIPTION
## Severity: Critical (C1)

### Problem
Bridge responses and per-app runtime events are delivered with `Emitter::emit`. In Tauri 2.10, `Webview::emit` routes to `manager.emit`, which iterates **all** webviews and delivers to every JS listener registered for that event name — regardless of which webview handle you call it on. The scoped `emit_to`/`emit_filter` variants were never used.

Because approval-gated results (notably `wallet.getSecretKey`, and signed `wallet.sendXch` results) are delivered over the `sage-bridge:response` rail, a **second user app running concurrently** (taskbar runtimes allow multiple live apps) can register `getCurrentWebview().listen('sage-bridge:response', …)` and read another app's payload directly via `event.payload` — including secret key material. The same applies to the `sage-bridge:event` / `sage-system-bridge:*` rails.

### Fix
Deliver `sage-bridge:response` and the user/system runtime-event rails with `emit_to(<app webview label>, …)` so each payload reaches only the originating app's webview. The SDK subscribes via `getCurrentWebview().listen(...)` (an `EventTarget::Webview { label }` listener), which `emit_to(AnyLabel { label })` matches exactly.

The broadcast to the trusted main Sage webview (`apps:runtime-event`, consumed by `AppsContext`) is intentionally left as-is and documented, because the main UI subscribes with the core `listen` (target `Any`) and that channel carries host-level state, not per-app secrets.

### Follow-up (not in this PR)
As defense-in-depth, scope the `core:event:allow-listen` capability in `apps.json` / `system-apps.json` to an allowlist of event names so an app webview cannot subscribe to `apps:runtime-event` or the opposite rail at all. The current Tauri ACL schema in `gen/schemas` doesn't expose per-event scoping, so this needs a capability/schema change tracked separately.

### Testing
No local build (per request); relying on CI. Worth adding an integration test asserting app B never receives app A's `sage-bridge:response`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-critical fix for wallet/bridge secret leakage across concurrent apps; behavior change is narrow but touches authentication-sensitive delivery paths.
> 
> **Overview**
> **Fixes a critical cross-app leak** where `sage-bridge:response` and per-app `sage-bridge:event` / `sage-system-bridge:event` traffic was sent with Tauri `emit`, which in 2.10 can deliver to every webview listening on that event name—not only the originating app.
> 
> `emit_bridge_response_to_app` and `emit_runtime_event_to_app_id` now use **`emit_to` with the app's webview label** so bridge responses and user/system runtime events reach only that app's webview. Host-level `apps:runtime-event` emissions to the trusted Sage main webview stay on **`emit`**; a comment documents that split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616f9eeb219931529a192daf308112c97a20d5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->