### PR TITLE
Fix (high): harden zip extraction (bomb + partial-state)

### DIFF
--- a/crates/sage-apps/src/lifecycle/package.rs
+++ b/crates/sage-apps/src/lifecycle/package.rs
@@ -1,10 +1,12 @@
 use std::{
     collections::BTreeSet,
-    fs, io,
+    fs,
+    io::{self, Read},
     path::{Component, Path, PathBuf},
 };
 
 use anyhow::{Context, Result as AnyResult};
+use uuid::Uuid;
 use zip::ZipArchive;
 
 use crate::{MANIFEST_FILE_NAME, SageAppPackageManifest, SageAppSnapshot, bytes_sha256_hex};
@@ -23,17 +25,58 @@ pub fn unzip_to_dir(zip_path: &Path, out_dir: &Path) -> AnyResult<()> {
         anyhow::bail!("zip archive contains too many entries");
     }
 
+    // Extract into a private staging directory and only swap it into place once
+    // extraction fully succeeds. This means a rejected or partially-extracted
+    // archive (e.g. a zip bomb caught mid-stream) never leaves a usable tree at
+    // `out_dir`, and nothing can observe `out_dir` while it is half-written.
+    let parent = out_dir
+        .parent()
+        .context("output dir has no parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create directory {}", parent.display()))?;
+
+    let staging = staging_dir_for(out_dir);
+    if staging.exists() {
+        fs::remove_dir_all(&staging)?;
+    }
+    fs::create_dir_all(&staging)
+        .with_context(|| format!("failed to create staging dir {}", staging.display()))?;
+
+    if let Err(err) = extract_archive_into(&mut archive, &staging) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err);
+    }
+
     if out_dir.exists() {
         fs::remove_dir_all(out_dir)?;
     }
 
-    fs::create_dir_all(out_dir)?;
+    if let Err(err) = fs::rename(&staging, out_dir) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err).with_context(|| {
+            format!("failed to move extracted package into {}", out_dir.display())
+        });
+    }
 
-    let root = out_dir
+    Ok(())
+}
+
+fn staging_dir_for(out_dir: &Path) -> PathBuf {
+    let file_name = out_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "package".to_string());
+    let parent = out_dir.parent().unwrap_or_else(|| Path::new("."));
+
+    parent.join(format!(".{file_name}.staging-{}", Uuid::new_v4()))
+}
+
+fn extract_archive_into(archive: &mut ZipArchive<fs::File>, staging: &Path) -> AnyResult<()> {
+    let root = staging
         .canonicalize()
-        .with_context(|| format!("failed to canonicalize output dir {}", out_dir.display()))?;
+        .with_context(|| format!("failed to canonicalize staging dir {}", staging.display()))?;
 
-    let mut total_uncompressed = 0u64;
+    let mut total_written = 0u64;
 
     for index in 0..archive.len() {
         let mut entry = archive
@@ -47,20 +90,15 @@ pub fn unzip_to_dir(zip_path: &Path, out_dir: &Path) -> AnyResult<()> {
         let uncompressed_size = entry.size();
         let compressed_size = entry.compressed_size();
 
+        // Cheap up-front rejection using the header-declared sizes. These are
+        // attacker-controlled, so they are only a fast path; the authoritative
+        // limits below are enforced against the actual decompressed byte count.
         if uncompressed_size > MAX_ZIP_SINGLE_FILE_BYTES {
             anyhow::bail!("zip entry is too large: {}", entry.name());
         }
 
         if compressed_size > 0 && uncompressed_size / compressed_size > MAX_ZIP_COMPRESSION_RATIO {
             anyhow::bail!("zip entry compression ratio is too high: {}", entry.name());
-        }
-
-        total_uncompressed = total_uncompressed
-            .checked_add(uncompressed_size)
-            .context("zip uncompressed size overflow")?;
-
-        if total_uncompressed > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES {
-            anyhow::bail!("zip archive exceeds maximum extracted size");
         }
 
         let target = root.join(enclosed_name);
@@ -90,8 +128,28 @@ pub fn unzip_to_dir(zip_path: &Path, out_dir: &Path) -> AnyResult<()> {
         let mut out = fs::File::create(&target)
             .with_context(|| format!("failed to create file {}", target.display()))?;
 
-        io::copy(&mut entry, &mut out)
+        // Enforce the size caps on the *actual* decompressed stream rather than
+        // the header metadata, so a zip whose header understates its real size
+        // cannot bomb the disk. Read at most one byte past the allowed limit so
+        // we can detect (and reject) an entry that would exceed it.
+        let remaining_total = MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES.saturating_sub(total_written);
+        let per_entry_limit = remaining_total.min(MAX_ZIP_SINGLE_FILE_BYTES);
+
+        let mut limited = (&mut entry).take(per_entry_limit + 1);
+        let written = io::copy(&mut limited, &mut out)
             .with_context(|| format!("failed to extract zip entry {}", entry.name()))?;
+
+        if written > MAX_ZIP_SINGLE_FILE_BYTES {
+            anyhow::bail!("zip entry is too large: {}", entry.name());
+        }
+
+        total_written = total_written
+            .checked_add(written)
+            .context("zip uncompressed size overflow")?;
+
+        if total_written > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES {
+            anyhow::bail!("zip archive exceeds maximum extracted size");
+        }
     }
 
     Ok(())
@@ -324,6 +382,47 @@ mod tests {
             fs::read_to_string(out_dir.join("nested/index.html")).unwrap(),
             "<html></html>"
         );
+    }
+
+    fn staging_dir_count(parent: &Path) -> usize {
+        fs::read_dir(parent)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .contains(".out.staging-")
+            })
+            .count()
+    }
+
+    #[test]
+    fn unzip_to_dir_leaves_no_staging_dir_on_success() {
+        let dir = tempdir().unwrap();
+        let zip_path = dir.path().join("app.zip");
+        let out_dir = dir.path().join("out");
+
+        write_zip(&zip_path, &[("index.html", b"<html></html>")]);
+
+        unzip_to_dir(&zip_path, &out_dir).unwrap();
+
+        assert!(out_dir.join("index.html").is_file());
+        assert_eq!(staging_dir_count(dir.path()), 0);
+    }
+
+    #[test]
+    fn unzip_to_dir_leaves_no_staging_dir_on_rejection() {
+        let dir = tempdir().unwrap();
+        let zip_path = dir.path().join("evil.zip");
+        let out_dir = dir.path().join("out");
+
+        write_zip(&zip_path, &[("../evil.txt", b"owned")]);
+
+        unzip_to_dir(&zip_path, &out_dir).unwrap_err();
+
+        assert!(!out_dir.exists());
+        assert_eq!(staging_dir_count(dir.path()), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Severity: High (H3 + extraction TOCTOU/partial-state)

### Problem
`unzip_to_dir` enforced `MAX_ZIP_SINGLE_FILE_BYTES` / `MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES` using `entry.size()` and `entry.compressed_size()` — values read from the zip's headers, which are **attacker-controlled** — and then copied the entry with an unbounded `io::copy(&mut entry, &mut out)`. A crafted archive can understate its uncompressed size in the header and still stream far more bytes than the caps permit, filling the disk (classic zip bomb).

Extraction also wrote directly into `out_dir` (after `remove_dir_all`), so a rejected or mid-stream-aborted archive left a partial/usable tree behind, and `out_dir` was observable while half-written.

### Fix
- Enforce both size caps against the **actual decompressed byte count** using `entry.take(limit + 1)` + counting the bytes `io::copy` returns. The header-based checks remain only as a cheap fast path.
- Extract into a private, per-call staging directory (`.<name>.staging-<uuid>`), then `fs::rename` it into place only after extraction fully succeeds; remove it on any failure. This removes the partial-state window and the TOCTOU on `out_dir`.

### Tests
Added `unzip_to_dir_leaves_no_staging_dir_on_success` / `_on_rejection`; existing extraction/escape/oversize tests still apply.

No local build (per request); relying on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive package unpack path: fixes zip-bomb and partial-extraction TOCTOU; incorrect limits or staging/rename logic could still allow disk exhaustion or inconsistent install state.
> 
> **Overview**
> **Hardens `unzip_to_dir`** so malicious Sage app packages cannot bypass size limits or leave a half-extracted tree on disk.
> 
> Size caps are now enforced on **bytes actually decompressed** (`take(limit + 1)` + counting `io::copy` output), not only on zip header `entry.size()` / `compressed_size()`, which closes the classic understated-header zip bomb path. Header checks remain as a fast reject.
> 
> Extraction runs into a **private staging dir** (`.<out-name>.staging-<uuid>`) and only **`rename`s into `out_dir` after success**; staging is removed on any failure, so rejected or mid-stream failures do not expose a usable `out_dir` or a lingering partial tree.
> 
> Adds tests that successful and rejected unpacks leave **no staging directories** and that failed path escapes still do not create `out_dir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed53130a5c8110b7070398a7b63999257a2e08e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->