### PR TITLE
Fix (high): bind applyUpdate to the reviewed manifest hash

### DIFF
--- a/builtin-apps/src/system/apps/app-update/src/components/UpdateReviewBody.tsx
+++ b/builtin-apps/src/system/apps/app-update/src/components/UpdateReviewBody.tsx
@@ -57,6 +57,7 @@ export function UpdateReviewBody({ state, onReload }: any) {
       await client.appUpdate.applyUpdate({
         appId: state.app.common.identity.id,
         additionalGrantedPermissions,
+        reviewedManifestHash: state.app.pendingUpdate?.manifestHash ?? '',
       });
 
       await close();

--- a/crates/sage-apps/src/bridge/methods/system/app_update/apply_update.rs
+++ b/crates/sage-apps/src/bridge/methods/system/app_update/apply_update.rs
@@ -14,6 +14,9 @@ use crate::{
 pub struct AppUpdateApplyUpdateParams {
     pub app_id: String,
     pub additional_granted_permissions: SageGrantedPermissionsInput,
+    /// Manifest hash of the pending update the user actually reviewed. Apply is
+    /// rejected if the pending update no longer matches this hash.
+    pub reviewed_manifest_hash: String,
 }
 
 #[derive(Debug, Clone, Serialize, Type)]
@@ -56,6 +59,7 @@ impl BridgeMethod for AppUpdateApplyUpdate {
             tools.host_state,
             &params.app_id,
             Some(params.additional_granted_permissions),
+            Some(params.reviewed_manifest_hash),
         )
         .await
         .map_err(|err| {

--- a/crates/sage-apps/src/lifecycle/update/apply.rs
+++ b/crates/sage-apps/src/lifecycle/update/apply.rs
@@ -16,6 +16,7 @@ pub(crate) async fn apply_app_update_inner(
     apps_state: &State<'_, AppsHostState>,
     app_id: &str,
     additional_granted_permissions_input: Option<SageGrantedPermissionsInput>,
+    expected_manifest_hash: Option<String>,
 ) -> Result<SageAppView> {
     let _update_guard = apps_state
         .try_begin_app_update(app_id)
@@ -38,6 +39,19 @@ pub(crate) async fn apply_app_update_inner(
         })?;
 
         return Ok(resolved.with_app(|app| app.into()));
+    }
+
+    // When applying a reviewed update, bind the apply to the exact manifest the
+    // user reviewed. If the pending update changed in between (e.g. the
+    // background checker fetched a newer manifest), refuse to apply the reviewed
+    // permission grants to a manifest the user never saw.
+    if let Some(expected) = expected_manifest_hash.as_deref()
+        && preflight.pending.manifest_hash() != expected
+    {
+        return Err(io::Error::other(format!(
+            "pending update for {app_id} changed since it was reviewed; re-check the update before applying"
+        ))
+        .into());
     }
 
     let reopen_after_update = ReopenAfterUpdate::capture(app_handle, apps_state, app_id).await?;
@@ -110,7 +124,7 @@ pub(crate) async fn try_auto_apply_pending_update(
         return Ok(false);
     }
 
-    apply_app_update_inner(app_handle, apps_state, app_id, None).await?;
+    apply_app_update_inner(app_handle, apps_state, app_id, None, None).await?;
 
     Ok(true)
 }

--- a/crates/sage-apps/src/lifecycle/update/commands.rs
+++ b/crates/sage-apps/src/lifecycle/update/commands.rs
@@ -22,5 +22,5 @@ pub async fn apps_apply_app_update(
     apps_state: State<'_, AppsHostState>,
     app_id: String,
 ) -> Result<SageAppView> {
-    apply_app_update_inner(&app_handle, &apps_state, &app_id, None).await
+    apply_app_update_inner(&app_handle, &apps_state, &app_id, None, None).await
 }


### PR DESCRIPTION
## Severity: High (H4)

### Problem
`appUpdate.applyUpdate` re-reads whatever pending update is currently staged on the app (`preflight.pending`) and applies the user's reviewed permission grants (`additionalGrantedPermissions`) to it. Between `appUpdate.getReviewContext` (what the user reviews) and `applyUpdate` (what runs), the background update checker can replace the pending update with a newer manifest requesting different permissions. The grants the user reviewed then get applied to a manifest they never saw — a review/apply TOCTOU.

### Fix
- `AppUpdateApplyUpdateParams` gains `reviewed_manifest_hash`. `apply_app_update_inner` takes an `expected_manifest_hash: Option<String>` and, when set, refuses to apply if `preflight.pending.manifest_hash()` no longer matches (error asks the user to re-check).
- Automatic/background apply paths (`try_auto_apply_pending_update`, `apps_apply_app_update` command) pass `None` and are unaffected.
- The update-review builtin app forwards `state.app.pendingUpdate.manifestHash` (the manifest whose decision/permissions it displayed).

### Files
- `crates/sage-apps/src/lifecycle/update/apply.rs`, `.../update/commands.rs`
- `crates/sage-apps/src/bridge/methods/system/app_update/apply_update.rs`
- `builtin-apps/src/system/apps/app-update/src/components/UpdateReviewBody.tsx`

No local build (per request); relying on CI. (SDK `generated-types.ts` is gitignored and regenerated from the Rust types.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permission-granting update apply logic, but the change tightens security (hash binding) and leaves non-interactive apply paths unchanged.
> 
> **Overview**
> Closes a **review/apply TOCTOU**: user-confirmed permission grants could be applied to a newer pending manifest if the background update checker swapped the staged update between review and `applyUpdate`.
> 
> `appUpdate.applyUpdate` now requires **`reviewedManifestHash`**. `apply_app_update_inner` compares it to the current pending update’s manifest hash and **fails** with a message to re-check when they differ. The update-review UI sends `state.app.pendingUpdate.manifestHash` on confirm.
> 
> **Auto-apply** paths (`try_auto_apply_pending_update`, `apps_apply_app_update`) pass `None` for the hash and behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0554b49efb16a0f19529bb804ff44e16d2747ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->