### PR TITLE
Fix (high): sandbox launch-gate rerun bypass, crash cleanup, isolation probe seeding

### DIFF
--- a/crates/sage-apps/src/sandbox/probes/isolation.rs
+++ b/crates/sage-apps/src/sandbox/probes/isolation.rs
@@ -1,10 +1,56 @@
+use std::time::Duration;
+
 use tauri::{AppHandle, State};
 
 use super::super::runtime::{start_test_app, stop_test_apps, unique_run_id};
 use super::poll::poll_isolation;
 use crate::{
     AppsHostState, BUILTIN_STORAGE_ISOLATION_INCOGNITO_ID, BUILTIN_STORAGE_ISOLATION_PERSISTENT_ID,
+    get_sage_webview,
 };
+
+/// Writes probe data into the host (main Sage) webview's `localStorage` and
+/// `indexedDB` before the isolation probes run. Without this, the probe apps
+/// read fixed keys that nothing ever wrote, so the test passed vacuously even
+/// if storage isolation were completely broken. With the host seeded, a sandbox
+/// app that can observe these values proves an isolation failure.
+async fn seed_host_isolation_probe(app: &AppHandle, run_id: &str) -> Result<(), String> {
+    let webview = get_sage_webview(app)?;
+
+    let value = serde_json::to_string(run_id)
+        .map_err(|err| format!("failed to encode isolation probe value: {err}"))?;
+
+    let script = format!(
+        r#"(function () {{
+  var value = {value};
+  try {{ localStorage.setItem('sage_probe_local_storage', value); }} catch (e) {{}}
+  try {{
+    var open = indexedDB.open('sage_probe_db', 1);
+    open.onupgradeneeded = function () {{
+      try {{
+        var db = open.result;
+        if (!db.objectStoreNames.contains('probe_store')) {{
+          db.createObjectStore('probe_store');
+        }}
+      }} catch (e) {{}}
+    }};
+    open.onsuccess = function () {{
+      try {{
+        var db = open.result;
+        if (!db.objectStoreNames.contains('probe_store')) {{ db.close(); return; }}
+        var tx = db.transaction('probe_store', 'readwrite');
+        tx.objectStore('probe_store').put(value, 'sage_probe_key');
+        tx.oncomplete = function () {{ db.close(); }};
+      }} catch (e) {{}}
+    }};
+  }} catch (e) {{}}
+}})();"#
+    );
+
+    webview
+        .eval(script)
+        .map_err(|err| format!("failed to seed host isolation probe data: {err}"))
+}
 
 pub(in crate::sandbox) async fn run_isolation_test(
     app: &AppHandle,
@@ -17,6 +63,11 @@ pub(in crate::sandbox) async fn run_isolation_test(
     ];
 
     stop_test_apps(app, apps_state, &app_ids).await;
+
+    // Seed the host storage first, then give the async IndexedDB write a brief
+    // moment to commit before launching the sandbox probes.
+    seed_host_isolation_probe(app, &run_id).await?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
     start_test_app(
         app,
@@ -76,6 +127,9 @@ pub(in crate::sandbox) async fn run_isolation_test(
 
     Ok((
         true,
-        Some("Both sandbox probe modes were unable to observe Sage probe data.".into()),
+        Some(
+            "Both sandbox probe modes were unable to observe the seeded Sage host probe data."
+                .into(),
+        ),
     ))
 }

--- a/crates/sage-apps/src/sandbox/runner.rs
+++ b/crates/sage-apps/src/sandbox/runner.rs
@@ -4,9 +4,35 @@ use super::probes::{run_isolation_test, run_network_test, run_persistence_test};
 use super::state_view::{build_effective_state, build_state_view};
 use super::types::{
     SandboxCapability, SandboxCapabilityStatus, SandboxRunState, SandboxState,
-    build_running_sandbox_state, mark_cap,
+    build_initial_sandbox_state, build_running_sandbox_state, mark_cap,
 };
 use crate::{AppsHostState, emit_sandbox_state_changed, unix_timestamp_ms};
+
+/// Resets sandbox run state if the runner exits abnormally (panic / early
+/// return) before it finalizes. Without this, a crash mid-run would leave
+/// `running == true` and a stale (possibly `Passed`) baseline in place, keeping
+/// the app launch gate open even though no run is actually in flight.
+struct SandboxRunCleanup {
+    app: AppHandle,
+    completed: bool,
+}
+
+impl Drop for SandboxRunCleanup {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+
+        let app = self.app.clone();
+        tauri::async_runtime::spawn(async move {
+            let apps_state = app.state::<AppsHostState>();
+            *apps_state.sandbox.current_run.lock().await = None;
+            *apps_state.sandbox.baseline.lock().await = build_initial_sandbox_state();
+            *apps_state.sandbox.running.lock().await = false;
+            emit_sandbox_state_changed(&app, &apps_state).await;
+        });
+    }
+}
 
 pub async fn ensure_initial_sandbox_run(app: AppHandle) -> Result<(), String> {
     let apps_state = app.state::<AppsHostState>();
@@ -79,6 +105,11 @@ async fn update_current_run_state(
 }
 
 pub async fn sandbox_runner(app: AppHandle) {
+    let mut cleanup = SandboxRunCleanup {
+        app: app.clone(),
+        completed: false,
+    };
+
     let apps_state = app.state::<AppsHostState>();
 
     let mut current_state = {
@@ -225,6 +256,9 @@ pub async fn sandbox_runner(app: AppHandle) {
     *apps_state.sandbox.running.lock().await = false;
 
     emit_sandbox_state_changed(&app, &apps_state).await;
+
+    // Reached the finalize path cleanly; suppress the abnormal-exit reset.
+    cleanup.completed = true;
 }
 
 fn sandbox_state_is_all_pending(state: &SandboxState) -> bool {

--- a/crates/sage-apps/src/sandbox/state_view.rs
+++ b/crates/sage-apps/src/sandbox/state_view.rs
@@ -1,19 +1,22 @@
 use tauri::State;
 
 use super::types::{
-    SandboxCapabilityResult, SandboxCapabilityStatus, SandboxRunState, SandboxState,
-    SandboxStateView,
+    SandboxCapabilityResult, SandboxRunState, SandboxState, SandboxStateView,
 };
 use crate::AppsHostState;
 
 fn effective_cap(
-    baseline: &SandboxCapabilityResult,
+    _baseline: &SandboxCapabilityResult,
     current: &SandboxCapabilityResult,
 ) -> SandboxCapabilityResult {
-    match current.status {
-        SandboxCapabilityStatus::Passed | SandboxCapabilityStatus::Failed => current.clone(),
-        SandboxCapabilityStatus::Pending | SandboxCapabilityStatus::Running => baseline.clone(),
-    }
+    // While a run is in progress we must reflect the *live* status of each
+    // capability, never the previous baseline. Falling back to a stale
+    // (previously `Passed`) baseline for a `Pending`/`Running` capability let a
+    // user-triggered rerun keep the launch gate open using results that no
+    // longer apply — and a runner that crashed mid-rerun could leave apps
+    // launchable indefinitely. Surfacing the live `Running`/`Pending` status
+    // makes the gate block until the rerun actually re-establishes each result.
+    current.clone()
 }
 
 pub fn build_effective_state(


### PR DESCRIPTION
## Severity: High (H5 + H6, same subsystem)

### H6 — launch gate bypassed during a sandbox rerun (stale baseline)
`effective_cap` returned the previous `baseline` for any `Pending`/`Running` capability. `begin_sandbox_run` sets every capability to `Running` without resetting a previously-`Passed` baseline, so during a user-triggered rerun the effective state stayed `Passed` and user apps remained launchable using results that no longer applied. A runner that crashed mid-rerun could leave this "passed but dead" state indefinitely.

**Fix:**
- `effective_cap` now surfaces the **live** run status (a run is only consulted when `current_run` is `Some`, so during a run the gate correctly blocks on `Running`/`Pending` until each result is re-established).
- A `SandboxRunCleanup` Drop guard resets `current_run`/`running` and the `baseline` (to pending) if `sandbox_runner` exits abnormally before finalizing, so a crash fails safe (gate blocks) instead of trusting a stale `Passed` baseline.

### H5 — storage-isolation probe passed vacuously
The isolation probes read fixed keys (`sage_probe_local_storage`, `sage_probe_db`/`sage_probe_key`) and passed when absent — and nothing ever wrote them, so a completely broken isolation implementation would still pass.

**Fix:** before launching the probes, the backend seeds those keys into the **host** (main Sage) webview's `localStorage` and `IndexedDB` via `webview.eval`, then waits briefly for the async IndexedDB write to commit. A sandbox app that can now observe the seeded values proves an isolation failure; genuine isolation still passes.

### Files
- `crates/sage-apps/src/sandbox/state_view.rs`
- `crates/sage-apps/src/sandbox/runner.rs`
- `crates/sage-apps/src/sandbox/probes/isolation.rs`

### Notes / follow-ups
- Seeding is treated as fail-safe: if the host seed can't be written the isolation test errors (blocks launches) rather than passing vacuously. If maintainers prefer a softer failure mode that's an easy tweak.
- The rerun UX now briefly blocks launches while a manual rerun runs — this is the intended safe behavior called out in the review.

No local build (per request); relying on CI. This gate blocks all user-app launches, so it's worth exercising the sandbox run manually before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the gate that blocks all user-app launches and sandbox security probes; behavior changes are intentional but should be manually verified before merge.
> 
> **Overview**
> Hardens the **sandbox app launch gate** and **storage-isolation checks** so user apps cannot launch on stale or meaningless probe results.
> 
> **Launch gate during reruns:** `effective_cap` now always reflects the **in-flight** capability status instead of falling back to a previously `Passed` baseline while capabilities are `Pending`/`Running`. Manual reruns therefore block launches until each check finishes again.
> 
> **Crash fail-safe:** `sandbox_runner` installs a `SandboxRunCleanup` `Drop` guard that clears `current_run`, resets `running`, and restores a pending `baseline` if the runner exits before finalize—avoiding a stuck “passed but no run” state.
> 
> **Isolation probe seeding:** Before isolation probe apps run, the host Sage webview is seeded via `eval` with matching `localStorage` and `IndexedDB` probe keys (plus a short delay for IndexedDB). Probes that read those values now detect real isolation breaks; seed failure surfaces as a test error rather than a vacuous pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445eeed98b484bb7de1881270335c3150e9860c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->