### PR TITLE
Fix (high): serialize runtime creation under the per-app operation lock

### DIFF
--- a/crates/sage-apps/src/runtime/start.rs
+++ b/crates/sage-apps/src/runtime/start.rs
@@ -122,6 +122,7 @@ pub(crate) async fn start_origin_cleanup_runtime(
             query,
         },
         false,
+        None,
     )
     .await
 }
@@ -131,15 +132,21 @@ async fn create_runtime(
     apps_state: &State<'_, AppsHostState>,
     args: CreateRuntimeArgs,
 ) -> Result<SharedRuntime, String> {
-    let app = match resolve_app(app_handle, &args.app_id)
+    // Keep the per-app operation guard held across the whole create/rotate
+    // sequence. Dropping it here (as `into_app` did) let two concurrent starts
+    // for the same app both observe it as stopped and both create a runtime,
+    // and let a concurrent `resolve_app` observe a runtime that was recorded
+    // before its webview existed. Holding the guard until the webview is created
+    // serializes starts so the second caller sees the finished runtime instead.
+    let (app, guard) = match resolve_app(app_handle, &args.app_id)
         .await
         .map_err(|e| e.to_string())?
     {
         ResolvedApp::Running(running) => return Ok(running.runtime()),
-        ResolvedApp::Stopped(stopped) => stopped.into_app(),
+        ResolvedApp::Stopped(stopped) => stopped.into_app_and_guard(),
     };
 
-    create_runtime_for_app(app_handle, apps_state, app, args, true).await
+    create_runtime_for_app(app_handle, apps_state, app, args, true, Some(guard)).await
 }
 
 async fn create_runtime_for_app(
@@ -148,6 +155,10 @@ async fn create_runtime_for_app(
     app: SharedSageApp,
     args: CreateRuntimeArgs,
     apply_user_lifecycle: bool,
+    // Held (when present) for the whole create/rotate/webview sequence to
+    // serialize concurrent starts for the same app. Named with a leading
+    // underscore so it lives until the end of this function scope.
+    _op_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
 ) -> Result<SharedRuntime, String> {
     let is_internal = app.with(|app| app.common().is_sandbox_test())
         || app.id() == sandbox::BUILTIN_ORIGIN_CLEANUP_RUNTIME_ID;

--- a/crates/sage-apps/src/types/app/user_apps.rs
+++ b/crates/sage-apps/src/types/app/user_apps.rs
@@ -35,6 +35,15 @@ impl ResolvedStoppedApp {
     pub fn into_app(self) -> SharedSageApp {
         self.app
     }
+
+    /// Splits into the app and its held per-app operation guard, letting the
+    /// caller keep the operation lock held across a create/rotate sequence
+    /// instead of dropping it (as `into_app` does). Holding the guard serializes
+    /// concurrent starts for the same app so they can't create duplicate or
+    /// pre-webview "phantom" runtimes.
+    pub fn into_app_and_guard(self) -> (SharedSageApp, OwnedMutexGuard<()>) {
+        (self.app, self._guard)
+    }
 }
 
 impl ResolvedRunningApp {


### PR DESCRIPTION
## Severity: High (H7)

### Problem
`create_runtime` resolved the app via `resolve_app` — which acquires the per-app operation lock and returns it inside `ResolvedStoppedApp` — and then immediately dropped that guard with `stopped.into_app()` **before** rotating storage, calling `write_runtime`, and creating the child webview.

Consequences:
- Two concurrent `apps_start_user_app` calls for the same app can both observe it as stopped and both proceed, producing duplicate runtimes (both maps get overwritten with no "already exists" check).
- `write_runtime` records a "running" runtime before the webview exists, so a concurrent `resolve_app` returns `Running` for an app whose webview lookup then fails (a "phantom" runtime).

### Fix
Add `ResolvedStoppedApp::into_app_and_guard()` and keep the operation guard held through the entire create/rotate/webview sequence in `create_runtime_for_app` (passed as an `Option<OwnedMutexGuard<()>>`). A second concurrent start now blocks in `resolve_app` until the first finishes and then observes the completed runtime instead of creating a duplicate. Internal/origin-cleanup starts that don't go through `resolve_app` pass `None`.

### Files
- `crates/sage-apps/src/runtime/start.rs`
- `crates/sage-apps/src/types/app/user_apps.rs`

### Follow-up (not in this PR)
The related clear-data race the review notes — `resolve_stopped_app` releases the op lock between its close-and-retry attempts, so a concurrent start can interleave with `apps_clear_runtime_browsing_data` after rotation — is a separate change to the retry/close protocol and is left for a focused follow-up.

No local build (per request); relying on CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core app runtime lifecycle and concurrency; scope is narrow and behavior-preserving aside from fixing races, but incorrect locking could still affect startup reliability.
> 
> **Overview**
> **Serializes user-app runtime startup** by keeping the per-app operation mutex from `resolve_app` until the webview is created, instead of dropping it when extracting the stopped app.
> 
> `create_runtime` now uses **`into_app_and_guard()`** and passes that guard into **`create_runtime_for_app`** as an optional `_op_guard` held for the full rotate → `write_runtime` → child webview path. Concurrent starts for the same app block on the lock; the second caller should see an already-running runtime rather than spawning duplicates or a **phantom** runtime recorded before the webview exists.
> 
> Internal paths that skip `resolve_app` (e.g. origin cleanup) pass **`None`** for the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b288068cd1b69e095ac2d8d47d32d98f29558240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->