### PR TITLE
Move issue token and mint NFT buttons to header as icon-only actions

### DIFF
--- a/src/pages/NftList.tsx
+++ b/src/pages/NftList.tsx
@@ -13,7 +13,6 @@ import { useNftData } from '@/hooks/useNftData';
 import { NftGroupMode, useNftParams } from '@/hooks/useNftParams';
 import { exportNfts } from '@/lib/exportNfts';
 import { t } from '@lingui/core/macro';
-import { Trans } from '@lingui/react/macro';
 import { ImagePlusIcon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -110,6 +109,18 @@ export function NftList() {
     [params.page, params.pageSize, total, setParams, canLoadMore, isLoading],
   );
 
+  const mintNftButton = (
+    <Button
+      variant='outline'
+      size='icon'
+      onClick={() => navigate('/nfts/mint')}
+      aria-label={t`Create new NFT`}
+      title={t`Create new NFT`}
+    >
+      <ImagePlusIcon className='h-4 w-4' aria-hidden='true' />
+    </Button>
+  );
+
   return (
     <>
       <Header
@@ -126,19 +137,15 @@ export function NftList() {
         paginationControls={
           !isOptionsVisible ? renderPagination(true) : undefined
         }
+        mobileActionItems={mintNftButton}
       >
-        <ReceiveAddress />
+        <div className='flex items-center gap-2'>
+          {mintNftButton}
+          <ReceiveAddress />
+        </div>
       </Header>
 
       <Container>
-        <Button
-          onClick={() => navigate('/nfts/mint')}
-          aria-label={t`Create new NFT`}
-        >
-          <ImagePlusIcon className='h-4 w-4 mr-2' aria-hidden='true' />
-          <Trans>Mint NFT</Trans>
-        </Button>
-
         <div ref={optionsRef}>
           <NftOptions
             params={params}
@@ -148,7 +155,7 @@ export function NftList() {
               setMultiSelect(value);
               setSelected([]);
             }}
-            className='mt-4'
+            className='mb-4'
             renderPagination={() => renderPagination(false)}
             aria-live='polite'
             onExport={() =>

--- a/src/pages/TokenList.tsx
+++ b/src/pages/TokenList.tsx
@@ -169,23 +169,27 @@ export function TokenList() {
     },
   };
 
+  const issueTokenButton = (
+    <Button
+      variant='outline'
+      size='icon'
+      onClick={() => navigate('/wallet/issue-token')}
+      aria-label={t`Issue new token`}
+      title={t`Issue new token`}
+    >
+      <Coins className='h-4 w-4' aria-hidden='true' />
+    </Button>
+  );
+
   return (
     <>
-      <Header title={<Trans>Assets</Trans>}>
+      <Header title={<Trans>Assets</Trans>} mobileActionItems={issueTokenButton}>
         <div className='flex items-center gap-2'>
+          {issueTokenButton}
           <ReceiveAddress />
         </div>
       </Header>
       <Container>
-        <Button
-          onClick={() => navigate('/wallet/issue-token')}
-          aria-label={t`Issue new token`}
-          className='mb-4'
-        >
-          <Coins className='h-4 w-4 mr-2' aria-hidden='true' />
-          <Trans>Issue Token</Trans>
-        </Button>
-
         <TokenOptions
           query={params.search}
           setQuery={(value) => setParams({ search: value })}

--- a/src/pages/TokenList.tsx
+++ b/src/pages/TokenList.tsx
@@ -183,7 +183,10 @@ export function TokenList() {
 
   return (
     <>
-      <Header title={<Trans>Assets</Trans>} mobileActionItems={issueTokenButton}>
+      <Header
+        title={<Trans>Assets</Trans>}
+        mobileActionItems={issueTokenButton}
+      >
         <div className='flex items-center gap-2'>
           {issueTokenButton}
           <ReceiveAddress />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the **Issue Token** and **Mint NFT** primary actions from the page body into the top-right header corner, next to the receive address. Both buttons are now icon-only (`size="icon"`, `variant="outline"`) with `aria-label` and `title` for accessibility.

## Changes

- **Assets page (`TokenList`)**: Issue Token button moved to header; uses `Coins` icon
- **NFTs page (`NftList`)**: Mint NFT button moved to header; uses `ImagePlus` icon
- Both buttons appear on mobile via `mobileActionItems`
- Removed extra top margin on `NftOptions` now that the body button is gone

## Screenshots

N/A — UI layout change only; no visual regression expected beyond button placement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f51ee-b84b-7437-9d3a-5853592507be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f51ee-b84b-7437-9d3a-5853592507be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

