### PR TITLE
Recover Owned Coins pagination after coin combines

### DIFF
--- a/crates/sage-database/src/tables/coins.rs
+++ b/crates/sage-database/src/tables/coins.rs
@@ -2,7 +2,7 @@ use chia_wallet_sdk::{
     chia::puzzle_types::{LineageProof, Proof},
     prelude::*,
 };
-use sqlx::{Row, SqliteExecutor, query};
+use sqlx::{QueryBuilder, Row, Sqlite, SqliteExecutor, SqlitePool, query};
 
 use crate::{
     AssetKind, Convert, Database, DatabaseError, DatabaseTx, Result, SerializedDid,
@@ -619,7 +619,7 @@ async fn coins_by_ids(conn: impl SqliteExecutor<'_>, coin_ids: &[String]) -> Res
 }
 
 async fn coin_records(
-    conn: impl SqliteExecutor<'_>,
+    conn: &SqlitePool,
     asset_filter: AssetFilter,
     limit: u32,
     offset: u32,
@@ -635,7 +635,7 @@ async fn coin_records(
         CoinFilterMode::Clawback => "clawback_coins",
     };
 
-    let mut query = sqlx::QueryBuilder::new(format!(
+    let mut query = QueryBuilder::new(format!(
         "
         SELECT
             parent_coin_hash, puzzle_hash, amount,
@@ -647,18 +647,7 @@ async fn coin_records(
         ",
     ));
 
-    match asset_filter {
-        AssetFilter::Id(asset_id) => {
-            query.push(" WHERE asset_hash = ");
-            query.push_bind(asset_id.to_vec());
-        }
-        AssetFilter::Nfts => {
-            query.push(" WHERE asset_kind = 1");
-        }
-        AssetFilter::Dids => {
-            query.push(" WHERE asset_kind = 2");
-        }
-    }
+    push_asset_filter(&mut query, asset_filter);
 
     query.push(" ORDER BY ");
     match sort_mode {
@@ -680,9 +669,24 @@ async fn coin_records(
     query.push_bind(offset as i64);
 
     let rows = query.build().fetch_all(conn).await?;
-    let total_count = rows
-        .first()
-        .map_or(Ok(0), |row| row.get::<i64, _>("total_count").try_into())?;
+    let total_count = if let Some(row) = rows.first() {
+        row.get::<i64, _>("total_count").try_into()?
+    } else {
+        // COUNT(*) OVER() has no row from which to read the total when the
+        // requested offset is beyond the end of the filtered result set.
+        // Run the equivalent count query so callers can recover to the last
+        // available page.
+        let mut count_query =
+            QueryBuilder::new(format!("SELECT COUNT(*) AS total_count FROM {table}"));
+        push_asset_filter(&mut count_query, asset_filter);
+
+        count_query
+            .build()
+            .fetch_one(conn)
+            .await?
+            .get::<i64, _>("total_count")
+            .try_into()?
+    };
     let coins = rows
         .into_iter()
         .map(|row| {
@@ -718,6 +722,21 @@ async fn coin_records(
         .collect::<Result<Vec<_>>>()?;
 
     Ok((coins, total_count))
+}
+
+fn push_asset_filter(query: &mut QueryBuilder<'_, Sqlite>, asset_filter: AssetFilter) {
+    match asset_filter {
+        AssetFilter::Id(asset_id) => {
+            query.push(" WHERE asset_hash = ");
+            query.push_bind(asset_id.to_vec());
+        }
+        AssetFilter::Nfts => {
+            query.push(" WHERE asset_kind = 1");
+        }
+        AssetFilter::Dids => {
+            query.push(" WHERE asset_kind = 2");
+        }
+    }
 }
 
 async fn selectable_xch_coins(conn: impl SqliteExecutor<'_>) -> Result<Vec<Coin>> {

--- a/src/components/OwnedCoinsCard.tsx
+++ b/src/components/OwnedCoinsCard.tsx
@@ -194,8 +194,19 @@ export function OwnedCoinsCard({
             filter_mode: includeSpentCoins ? 'spent' : 'owned',
           })
           .then((res) => {
+            // Ignore a late response for a page the user has already left.
+            if (page !== currentPageRef.current) return;
+
             setCoins(res.coins);
             setTotalCoins(res.total);
+
+            // A combine can remove enough coins to make the current page
+            // invalid. Move to the last page that still exists after the
+            // refreshed total is known; the page effect will load it.
+            const lastPage = Math.max(0, Math.ceil(res.total / pageSize) - 1);
+            if (page > lastPage) {
+              setCurrentPage(lastPage);
+            }
           })
           .catch(addError);
       },


### PR DESCRIPTION
Closes #809

## Summary

- Keep the Owned Coins page within the available range after refreshes that shrink the list, including combine operations.
- Ignore late responses for pages the user has already left.
- Return the correct filtered total for an out-of-range coin query so the UI can recover to the last page.

## Why

Combining coins can remove enough entries that the page the user was viewing no longer exists. The existing COUNT(*) OVER() total is only available when the paginated query returns at least one row; an empty out-of-range page therefore looked like a zero-coin list, and the UI had no reliable last-page value.

The extra COUNT(*) query runs only when the requested page is empty. It reuses the same asset filter to recover the exact total for that exceptional case, while normal page loads keep the existing single-query path. This lets the UI move to the last valid page without adding work to ordinary refreshes.

## Validation

- cargo check -p sage-database
- rustfmt --edition 2024 --check crates/sage-database/src/tables/coins.rs
- pnpm prettier:check
- pnpm lint (0 errors; existing warnings only)
- pnpm build (successful; existing chunk-size warning only)

No new dependencies or tests were added.