### PR TITLE
Revocable CAT issuance support

### DIFF
--- a/.cursor/rules/generated-artifacts.mdc
+++ b/.cursor/rules/generated-artifacts.mdc
@@ -1,0 +1,14 @@
+---
+description: Protect generated bindings and release-time translation catalogs
+alwaysApply: true
+---
+
+# Generated Artifacts
+
+- Never edit `src/bindings.ts` manually. Change its Rust/Specta source definitions instead.
+- Never run Sage automatically to regenerate `src/bindings.ts`; Sage is a GUI application.
+- Regenerate bindings with `pnpm generate:bindings` when needed; this command must not launch Sage.
+- Release builds must never generate or modify `src/bindings.ts`.
+- Do not run `pnpm extract` or modify `src/locales/**/*.po` during normal feature work.
+- Update `.po` catalogs only when explicitly requested, typically as part of release preparation.
+- If a task requires generated artifacts to be refreshed, report that follow-up rather than hand-editing them.

--- a/.cursor/rules/validation.mdc
+++ b/.cursor/rules/validation.mdc
@@ -1,0 +1,19 @@
+---
+description: Required validation after code changes
+alwaysApply: true
+---
+
+# Validation
+
+Before completing substantive code changes, run the applicable checks for every language changed:
+
+1. TypeScript formatting: `pnpm prettier:check`
+2. TypeScript linting: `pnpm lint`
+3. Rust formatting: `cargo fmt --all -- --files-with-diff --check`
+4. Rust linting: `cargo clippy --workspace --all-features --all-targets`
+5. Relevant targeted tests, expanded to broader test suites when warranted by the change's risk
+
+- Run both TypeScript checks for TypeScript/TSX changes and both Rust checks for Rust changes.
+- Builds, type checks, and IDE diagnostics do not replace formatting or linting.
+- Do not claim validation passed unless the corresponding commands ran successfully.
+- Report any skipped, blocked, or failing checks, including failures unrelated to the current changes.

--- a/crates/sage-api/src/requests/transactions.rs
+++ b/crates/sage-api/src/requests/transactions.rs
@@ -210,6 +210,10 @@ pub struct IssueCat {
     pub ticker: String,
     /// Initial supply amount
     pub amount: Amount,
+    /// Whether the CAT can be revoked by the issuer
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(default = false))]
+    pub revocable: bool,
     /// Transaction fee
     pub fee: Amount,
     /// Whether to automatically submit the transaction

--- a/crates/sage-wallet/src/wallet/cats.rs
+++ b/crates/sage-wallet/src/wallet/cats.rs
@@ -11,14 +11,25 @@ impl Wallet {
         fee: u64,
         multi_issuance_key: Option<PublicKey>,
     ) -> Result<(Vec<CoinSpend>, Bytes32), WalletError> {
+        self.issue_cat_with_hidden_puzzle_hash(amount, fee, multi_issuance_key, None)
+            .await
+    }
+
+    pub async fn issue_cat_with_hidden_puzzle_hash(
+        &self,
+        amount: u64,
+        fee: u64,
+        multi_issuance_key: Option<PublicKey>,
+        hidden_puzzle_hash: Option<Bytes32>,
+    ) -> Result<(Vec<CoinSpend>, Bytes32), WalletError> {
         let mut ctx = SpendContext::new();
 
         let issue_cat = if let Some(public_key) = multi_issuance_key {
             let tail = ctx.curry(EverythingWithSignatureTailArgs::new(public_key))?;
             let tail_spend = Spend::new(tail, NodePtr::NIL);
-            Action::issue_cat(tail_spend, None, amount)
+            Action::issue_cat(tail_spend, hidden_puzzle_hash, amount)
         } else {
-            Action::single_issue_cat(None, amount)
+            Action::single_issue_cat(hidden_puzzle_hash, amount)
         };
         let actions = vec![Action::fee(fee), issue_cat];
         let outputs = self.spend(&mut ctx, vec![], &actions).await?;
@@ -86,6 +97,31 @@ mod tests {
     use tokio::time::sleep;
 
     use crate::TestWallet;
+
+    #[test(tokio::test)]
+    async fn test_issue_revocable_cat() -> anyhow::Result<()> {
+        let mut test = TestWallet::new(1000).await?;
+        let hidden_puzzle_hash = test.wallet.change_p2_puzzle_hash().await?;
+
+        let (coin_spends, asset_id) = test
+            .wallet
+            .issue_cat_with_hidden_puzzle_hash(1000, 0, None, Some(hidden_puzzle_hash))
+            .await?;
+
+        test.transact(coin_spends).await?;
+        test.wait_for_coins().await;
+
+        assert_eq!(
+            test.wallet
+                .db
+                .asset(asset_id)
+                .await?
+                .and_then(|asset| asset.hidden_puzzle_hash),
+            Some(hidden_puzzle_hash)
+        );
+
+        Ok(())
+    }
 
     #[test(tokio::test)]
     async fn test_send_cat() -> anyhow::Result<()> {

--- a/crates/sage/src/endpoints/transactions.rs
+++ b/crates/sage/src/endpoints/transactions.rs
@@ -157,8 +157,15 @@ impl Sage {
         let wallet = self.wallet()?;
         let amount = parse_amount(req.amount)?;
         let fee = parse_amount(req.fee)?;
+        let hidden_puzzle_hash = if req.revocable {
+            Some(wallet.change_p2_puzzle_hash().await?)
+        } else {
+            None
+        };
 
-        let (coin_spends, asset_id) = wallet.issue_cat(amount, fee, None).await?;
+        let (coin_spends, asset_id) = wallet
+            .issue_cat_with_hidden_puzzle_hash(amount, fee, None, hidden_puzzle_hash)
+            .await?;
         let mut tx = wallet.db.tx().await?;
 
         tx.insert_asset(Asset {
@@ -170,7 +177,7 @@ impl Sage {
             description: None,
             is_sensitive_content: false,
             is_visible: true,
-            hidden_puzzle_hash: None,
+            hidden_puzzle_hash,
             kind: AssetKind::Token,
         })
         .await?;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "dev:system-apps": "node scripts/dev-system-apps-watch.mjs",
+    "generate:bindings": "cargo run -p sage-tauri --bin generate-bindings",
     "generate:bridge-types": "node scripts/generate-bridge-types.mjs",
     "generate:app-docs": "cargo run -p sage-apps --bin generate_docs",
     "generate:sdk-types": "pnpm --silent --filter @sage-app/sdk run generate:types && pnpm --silent --filter @sage-system-app/sdk run generate:types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sage-tauri"
 version = "0.12.11"
+default-run = "sage-tauri"
 description = "A next generation Chia wallet."
 authors = ["Rigidity <me@rigidnetwork.com>"]
 license = "Apache-2.0"

--- a/src-tauri/src/bin/generate-bindings.rs
+++ b/src-tauri/src/bin/generate-bindings.rs
@@ -1,0 +1,10 @@
+#[cfg(debug_assertions)]
+fn main() {
+    sage_lib::export_bindings();
+}
+
+#[cfg(not(debug_assertions))]
+fn main() {
+    eprintln!("Binding generation is disabled in release builds.");
+    std::process::exit(1);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(all(debug_assertions, not(mobile)))]
+use std::path::PathBuf;
+
 use app_state::{AppState, Initialized, RpcTask};
 use rustls::crypto::aws_lc_rs::default_provider;
 use sage::Sage;
@@ -150,14 +153,9 @@ macro_rules! sage_commands {
     };
 }
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
-    default_provider()
-        .install_default()
-        .expect("could not install AWS LC provider");
-
-    #[cfg(not(mobile))]
-    let builder = Builder::<tauri::Wry>::new()
+#[cfg(not(mobile))]
+fn specta_builder() -> Builder<tauri::Wry> {
+    Builder::<tauri::Wry>::new()
         .error_handling(ErrorHandlingMode::Throw)
         .commands(sage_commands![
             apps::apps_enter_workspace,
@@ -183,21 +181,35 @@ pub fn run() {
             apps::apps_get_auto_update_enabled,
             apps::apps_set_auto_update_enabled,
         ])
-        .events(collect_events![SyncEvent]);
+        .events(collect_events![SyncEvent])
+}
+
+#[cfg(all(debug_assertions, not(mobile)))]
+pub fn export_bindings() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../src/bindings.ts");
+
+    specta_builder()
+        .export(
+            Typescript::default().bigint(BigIntExportBehavior::Number),
+            path,
+        )
+        .expect("Failed to export TypeScript bindings");
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    default_provider()
+        .install_default()
+        .expect("could not install AWS LC provider");
+
+    #[cfg(not(mobile))]
+    let builder = specta_builder();
 
     #[cfg(mobile)]
     let builder = Builder::<tauri::Wry>::new()
         .error_handling(ErrorHandlingMode::Throw)
         .commands(sage_commands![])
         .events(collect_events![SyncEvent]);
-
-    #[cfg(all(debug_assertions, not(mobile)))]
-    builder
-        .export(
-            Typescript::default().bigint(BigIntExportBehavior::Number),
-            "../src/bindings.ts",
-        )
-        .expect("Failed to export TypeScript bindings");
 
     let mut tauri_builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1804,6 +1804,10 @@ ticker: string;
  */
 amount: Amount; 
 /**
+ * Whether the CAT can be revoked by the issuer
+ */
+revocable?: boolean; 
+/**
  * Transaction fee
  */
 fee: Amount; 

--- a/src/components/confirmations/TokenConfirmation.tsx
+++ b/src/components/confirmations/TokenConfirmation.tsx
@@ -1,15 +1,20 @@
 import { CoinRecord } from '@/bindings';
 import { CopyButton } from '@/components/CopyButton';
+import { MemoDisplay } from '@/components/MemoDisplay.tsx';
+import { formatNumber } from '@/i18n.ts';
 import { fromMojos } from '@/lib/utils';
+import { formatMemo, Memo } from '@/types/CoinMemo.ts';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
-import { CoinsIcon, MergeIcon, SplitIcon } from 'lucide-react';
+import {
+  CoinsIcon,
+  MergeIcon,
+  SplitIcon,
+  TriangleAlertIcon,
+} from 'lucide-react';
 import { toast } from 'react-toastify';
-import { formatNumber } from '@/i18n.ts';
 import { ConfirmationAlert } from './ConfirmationAlert';
 import { ConfirmationCard } from './ConfirmationCard';
-import { formatMemo, Memo } from '@/types/CoinMemo.ts';
-import { MemoDisplay } from '@/components/MemoDisplay.tsx';
 
 type TokenOperationType =
   | 'split'
@@ -27,6 +32,7 @@ interface TokenConfirmationProps {
   precision?: number;
   name?: string;
   amount?: string;
+  revocable?: boolean;
   currentMemo?: Memo;
 }
 
@@ -38,6 +44,7 @@ export function TokenConfirmation({
   precision,
   name,
   amount,
+  revocable,
   currentMemo,
 }: TokenConfirmationProps) {
   const config = {
@@ -68,10 +75,18 @@ export function TokenConfirmation({
       title: <Trans>Token Issuance</Trans>,
       variant: 'info' as const,
       message: (
-        <Trans>
-          You are issuing a new token. This will create a CAT (Chia Asset Token)
-          that can be sent to other users and traded on exchanges.
-        </Trans>
+        <>
+          <Trans>
+            You are issuing a new token. This will create a CAT (Chia Asset
+            Token) that can be sent to other users and traded on exchanges.
+          </Trans>{' '}
+          {revocable && (
+            <Trans>
+              This wallet&apos;s change address will be used as the revocation
+              address.
+            </Trans>
+          )}
+        </>
       ),
     },
     clawback: {
@@ -124,6 +139,19 @@ export function TokenConfirmation({
         </ConfirmationAlert>
       )}
 
+      {type === 'issue' && revocable && (
+        <ConfirmationAlert
+          icon={TriangleAlertIcon}
+          title={<Trans>Revocable CAT Warning</Trans>}
+          variant='warning'
+        >
+          <Trans>
+            Only issue a revocable CAT if you understand the risks. Sage cannot
+            revoke it; revocation currently requires external tools.
+          </Trans>
+        </ConfirmationAlert>
+      )}
+
       {type === 'send' && currentMemo && (
         <ConfirmationCard>
           <div className='flex items-center justify-between'>
@@ -144,7 +172,7 @@ export function TokenConfirmation({
           icon={<CoinsIcon className='h-8 w-8 text-blue-500' />}
           title={name}
         >
-          <div className='grid grid-cols-2 gap-2'>
+          <div className='grid grid-cols-3 gap-2'>
             <div>
               <div className='text-muted-foreground text-xs mb-1'>
                 <Trans>Ticker</Trans>
@@ -164,6 +192,15 @@ export function TokenConfirmation({
                   maximumFractionDigits: 0,
                 })}{' '}
                 {ticker}
+              </div>
+            </div>
+
+            <div>
+              <div className='text-muted-foreground text-xs mb-1'>
+                <Trans>Revocable</Trans>
+              </div>
+              <div className='font-medium'>
+                {revocable ? <Trans>Yes</Trans> : <Trans>No</Trans>}
               </div>
             </div>
           </div>

--- a/src/pages/IssueToken.tsx
+++ b/src/pages/IssueToken.tsx
@@ -1,6 +1,7 @@
 import ConfirmationDialog from '@/components/ConfirmationDialog';
 import { TokenConfirmation } from '@/components/confirmations/TokenConfirmation';
 import Header from '@/components/Header';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
   Form,
@@ -11,13 +12,16 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { FeeAmountInput, TokenAmountInput } from '@/components/ui/masked-input';
+import { Switch } from '@/components/ui/switch';
 import { useErrors } from '@/hooks/useErrors';
 import { amount, positiveAmount } from '@/lib/formTypes';
 import { toMojos } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { t } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
+import { TriangleAlertIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -37,10 +41,14 @@ export default function IssueToken() {
     ticker: z.string().min(1, t`Ticker is required`),
     amount: positiveAmount(3),
     fee: amount(walletState.sync.unit.precision).optional(),
+    revocable: z.boolean(),
   });
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      revocable: false,
+    },
   });
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
@@ -49,6 +57,7 @@ export default function IssueToken() {
         name: values.name,
         ticker: values.ticker,
         amount: toMojos(values.amount.toString(), 3),
+        revocable: values.revocable,
         fee: toMojos(
           values.fee?.toString() || '0',
           walletState.sync.unit.precision,
@@ -147,6 +156,49 @@ export default function IssueToken() {
               />
             </div>
 
+            <FormField
+              control={form.control}
+              name='revocable'
+              render={({ field }) => (
+                <FormItem className='flex items-center justify-between gap-4 rounded-lg border p-4'>
+                  <div className='space-y-1'>
+                    <Label htmlFor='revocable'>
+                      <Trans>Revocable CAT</Trans>
+                    </Label>
+                    <p className='text-sm text-muted-foreground'>
+                      <Trans>
+                        Use this wallet&apos;s change address as the
+                        token&apos;s revocation address.
+                      </Trans>
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      id='revocable'
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            {form.watch('revocable') && (
+              <Alert variant='warning'>
+                <TriangleAlertIcon className='h-4 w-4' aria-hidden='true' />
+                <AlertTitle>
+                  <Trans>Revocable CAT Warning</Trans>
+                </AlertTitle>
+                <AlertDescription>
+                  <Trans>
+                    Only issue a revocable CAT if you understand the risks. Sage
+                    cannot revoke it; revocation currently requires external
+                    tools.
+                  </Trans>
+                </AlertDescription>
+              </Alert>
+            )}
+
             <Button type='submit'>
               <Trans>Issue Token</Trans>
             </Button>
@@ -171,6 +223,7 @@ export default function IssueToken() {
                     name={form.getValues().name}
                     ticker={form.getValues().ticker}
                     amount={form.getValues().amount.toString()}
+                    revocable={form.getValues().revocable}
                   />
                 ),
               }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes on-chain CAT issuance semantics and stores revocation metadata; incorrect hidden-puzzle handling could mint non-revocable or wrongly revocable tokens, though covered by a new wallet test.
> 
> **Overview**
> Adds **optional revocable CAT issuance** end-to-end: `IssueCat` gains a `revocable` flag (default false), the wallet issues via `issue_cat_with_hidden_puzzle_hash` using the wallet change address when enabled, and persisted asset metadata stores `hidden_puzzle_hash`. The Issue Token UI adds a revocable switch, inline warnings, and confirmation copy showing revocation address and Yes/No.
> 
> Also refactors **TypeScript binding export** so release builds do not write `src/bindings.ts`: Specta setup is shared via `specta_builder()`, `export_bindings()` is exposed for a new `generate-bindings` binary (debug-only), and `pnpm generate:bindings` runs it without launching the Sage GUI. New Cursor rules document validation steps and how to treat generated bindings and `.po` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94541114af912aef39bae5019366c865a940a847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->