### PR TITLE
Scan qr from image

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "cmdk": "^1.1.1",
     "emoji-mart": "^5.6.0",
     "framer-motion": "^12.33.0",
+    "jsqr": "^1.4.0",
     "lucide-react": "^0.445.0",
     "pretty-bytes": "^7.1.0",
     "qr-code-styling": "^1.9.2",
@@ -108,6 +109,8 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.24",
+    "chokidar": "^3.6.0",
+    "concurrently": "^9.0.1",
     "eslint": "^8.57.1",
     "eslint-plugin-lingui": "^0.9.0",
     "eslint-plugin-react": "^7.37.5",
@@ -120,8 +123,6 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^7.3.1",
-    "chokidar": "^3.6.0",
-    "ws": "^8.18.0",
-    "concurrently": "^9.0.1"
+    "ws": "^8.18.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       framer-motion:
         specifier: ^12.33.0
         version: 12.33.0(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      jsqr:
+        specifier: ^1.4.0
+        version: 1.4.0
       lucide-react:
         specifier: ^0.445.0
         version: 0.445.0(react@18.3.1)
@@ -2020,6 +2023,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
@@ -3056,6 +3060,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsqr@1.4.0:
+    resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -7122,6 +7129,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsqr@1.4.0: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:

--- a/src/components/PasteInput.tsx
+++ b/src/components/PasteInput.tsx
@@ -1,7 +1,8 @@
 import { cn } from '@/lib/utils';
+import { t } from '@lingui/core/macro';
 import { platform } from '@tauri-apps/plugin-os';
-import { ClipboardPasteIcon, ScanIcon } from 'lucide-react';
-import { forwardRef } from 'react';
+import { ClipboardPasteIcon, ImageIcon, ScanIcon } from 'lucide-react';
+import { forwardRef, useRef } from 'react';
 import { Input, InputProps } from './ui/input';
 
 export interface PasteInputProps extends InputProps {
@@ -9,6 +10,7 @@ export interface PasteInputProps extends InputProps {
   truncate?: boolean;
   value?: string;
   onEndIconClick?: () => void;
+  onScanImage?: (file: File) => void;
 }
 
 export const PasteInput = forwardRef<HTMLInputElement, PasteInputProps>(
@@ -20,11 +22,23 @@ export const PasteInput = forwardRef<HTMLInputElement, PasteInputProps>(
       onChange,
       value = '',
       onEndIconClick,
+      onScanImage,
       ...props
     },
     ref,
   ) => {
     const isMobile = platform() === 'ios' || platform() === 'android';
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      // Clear first so picking the same file twice still fires a change event.
+      event.target.value = '';
+      if (file) {
+        onScanImage?.(file);
+      }
+    };
 
     return (
       <div
@@ -38,22 +52,47 @@ export const PasteInput = forwardRef<HTMLInputElement, PasteInputProps>(
           type='text'
           placeholder={placeholder}
           className={cn(
-            'pr-10 w-full focus:outline-none select-none',
+            onScanImage ? 'pr-16' : 'pr-10',
+            'w-full focus:outline-none select-none',
             truncate && 'truncate',
           )}
           onChange={onChange}
           value={value}
           {...props}
         />
-        <div
-          className='absolute right-0 flex items-center pr-3 pointer-events-auto'
-          onClick={onEndIconClick}
-        >
-          {isMobile ? (
-            <ScanIcon className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0' />
-          ) : (
-            <ClipboardPasteIcon className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0' />
+        <div className='absolute right-0 flex items-center gap-2 pr-3 pointer-events-auto'>
+          {onScanImage && (
+            <>
+              <input
+                ref={fileInputRef}
+                type='file'
+                accept='image/*'
+                className='hidden'
+                onChange={handleFileChange}
+              />
+              <ImageIcon
+                aria-label={t`Scan QR code from an image`}
+                role='button'
+                className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
+                onClick={() => fileInputRef.current?.click()}
+              />
+            </>
           )}
+          <div onClick={onEndIconClick}>
+            {isMobile ? (
+              <ScanIcon
+                aria-label={t`Scan QR code with the camera`}
+                role='button'
+                className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
+              />
+            ) : (
+              <ClipboardPasteIcon
+                aria-label={t`Paste from clipboard`}
+                role='button'
+                className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
+              />
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/components/PasteInput.tsx
+++ b/src/components/PasteInput.tsx
@@ -70,29 +70,32 @@ export const PasteInput = forwardRef<HTMLInputElement, PasteInputProps>(
                 className='hidden'
                 onChange={handleFileChange}
               />
-              <ImageIcon
+              <button
+                type='button'
                 aria-label={t`Scan QR code from an image`}
-                role='button'
-                className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
+                className='h-4 w-4 p-0 border-0 bg-transparent text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
                 onClick={() => fileInputRef.current?.click()}
-              />
+              >
+                <ImageIcon aria-hidden='true' className='h-4 w-4' />
+              </button>
             </>
           )}
-          <div onClick={onEndIconClick}>
+          <button
+            type='button'
+            aria-label={
+              isMobile
+                ? t`Scan QR code with the camera`
+                : t`Paste from clipboard`
+            }
+            className='h-4 w-4 p-0 border-0 bg-transparent text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
+            onClick={onEndIconClick}
+          >
             {isMobile ? (
-              <ScanIcon
-                aria-label={t`Scan QR code with the camera`}
-                role='button'
-                className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
-              />
+              <ScanIcon aria-hidden='true' className='h-4 w-4' />
             ) : (
-              <ClipboardPasteIcon
-                aria-label={t`Paste from clipboard`}
-                role='button'
-                className='h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer shrink-0'
-              />
+              <ClipboardPasteIcon aria-hidden='true' className='h-4 w-4' />
             )}
-          </div>
+          </button>
         </div>
       </div>
     );

--- a/src/components/TransferDialog.tsx
+++ b/src/components/TransferDialog.tsx
@@ -60,9 +60,11 @@ export function TransferDialog({
     },
   });
 
-  const { handleScanOrPaste } = useScannerOrClipboard((scanResValue) => {
-    form.setValue('address', scanResValue);
-  });
+  const { handleScanOrPaste, handleScanImage } = useScannerOrClipboard(
+    (scanResValue) => {
+      form.setValue('address', scanResValue);
+    },
+  );
 
   const handler = (values: z.infer<typeof schema>) => {
     onSubmit(values.address, values.fee);
@@ -90,6 +92,7 @@ export function TransferDialog({
                       {...field}
                       placeholder={t`Enter address`}
                       onEndIconClick={handleScanOrPaste}
+                      onScanImage={handleScanImage}
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/hooks/useScannerOrClipboard.ts
+++ b/src/hooks/useScannerOrClipboard.ts
@@ -34,7 +34,8 @@ export function useScannerOrClipboard(onScanResult: (text: string) => void) {
         const content = await scanQrFromImage(file);
         onScanResult(content);
       } catch (error) {
-        const code = error instanceof ScanImageError ? error.code : 'unreadable';
+        const code =
+          error instanceof ScanImageError ? error.code : 'unreadable';
 
         const reason =
           code === 'no-qr-found'

--- a/src/hooks/useScannerOrClipboard.ts
+++ b/src/hooks/useScannerOrClipboard.ts
@@ -6,12 +6,16 @@ import {
 import { readText } from '@tauri-apps/plugin-clipboard-manager';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useNavigationStore } from '@/state';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
+import { t } from '@lingui/core/macro';
+import { useErrors } from '@/hooks/useErrors';
+import { ScanImageError, scanQrFromImage } from '@/lib/scanImage';
 
 export function useScannerOrClipboard(onScanResult: (text: string) => void) {
   const navigate = useNavigate();
   const location = useLocation();
   const { returnValues, setReturnValue } = useNavigationStore();
+  const { addError } = useErrors();
   const isMobile = platform() === 'ios' || platform() === 'android';
 
   useEffect(() => {
@@ -23,6 +27,27 @@ export function useScannerOrClipboard(onScanResult: (text: string) => void) {
       setReturnValue(location.pathname, { status: 'completed' });
     }
   }, [returnValues, onScanResult, location.pathname, setReturnValue]);
+
+  const handleScanImage = useCallback(
+    async (file: File) => {
+      try {
+        const content = await scanQrFromImage(file);
+        onScanResult(content);
+      } catch (error) {
+        const code = error instanceof ScanImageError ? error.code : 'unreadable';
+
+        const reason =
+          code === 'no-qr-found'
+            ? t`No QR code found in that image.`
+            : code === 'file-too-big'
+              ? t`That image is too large to scan.`
+              : t`That file could not be read as an image.`;
+
+        addError({ kind: 'invalid', reason });
+      }
+    },
+    [addError, onScanResult],
+  );
 
   const handleScanOrPaste = async () => {
     if (isMobile) {
@@ -48,5 +73,5 @@ export function useScannerOrClipboard(onScanResult: (text: string) => void) {
     }
   };
 
-  return { handleScanOrPaste, isMobile };
+  return { handleScanOrPaste, handleScanImage, isMobile };
 }

--- a/src/lib/scanImage.ts
+++ b/src/lib/scanImage.ts
@@ -30,16 +30,18 @@ export async function scanQrFromImage(file: File): Promise<string> {
   }
 
   try {
-    // Must run before any canvas is allocated: a small PNG can declare
-    // enormous dimensions, and the backing ImageData is 4 bytes per pixel.
+    // Bounds the canvas and ImageData we allocate below (4 bytes per pixel
+    // each): a small PNG can declare enormous dimensions. Note this does not
+    // bound the largest allocation on this path — createImageBitmap() above
+    // has already decoded the image at full native resolution, and the
+    // resulting ImageBitmap is itself roughly 4 bytes per pixel. The
+    // practical ceiling there is MAX_FILE_BYTES plus the webview's own
+    // decoder limits.
     if (bitmap.width * bitmap.height > MAX_PIXELS) {
       throw new ScanImageError('file-too-big');
     }
 
-    const scale = Math.min(
-      1,
-      MAX_EDGE / Math.max(bitmap.width, bitmap.height),
-    );
+    const scale = Math.min(1, MAX_EDGE / Math.max(bitmap.width, bitmap.height));
     const width = Math.max(1, Math.round(bitmap.width * scale));
     const height = Math.max(1, Math.round(bitmap.height * scale));
 

--- a/src/lib/scanImage.ts
+++ b/src/lib/scanImage.ts
@@ -1,0 +1,72 @@
+import jsQR from 'jsqr';
+
+export type ScanImageErrorCode = 'no-qr-found' | 'file-too-big' | 'unreadable';
+
+/**
+ * Carries a reason code only. Never put file content, decoded content, or the
+ * filename in the message — this error is logged and displayed.
+ */
+export class ScanImageError extends Error {
+  constructor(public readonly code: ScanImageErrorCode) {
+    super(code);
+    this.name = 'ScanImageError';
+  }
+}
+
+const MAX_FILE_BYTES = 20 * 1024 * 1024;
+const MAX_PIXELS = 40_000_000;
+const MAX_EDGE = 1600;
+
+export async function scanQrFromImage(file: File): Promise<string> {
+  if (file.size > MAX_FILE_BYTES) {
+    throw new ScanImageError('file-too-big');
+  }
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    throw new ScanImageError('unreadable');
+  }
+
+  try {
+    // Must run before any canvas is allocated: a small PNG can declare
+    // enormous dimensions, and the backing ImageData is 4 bytes per pixel.
+    if (bitmap.width * bitmap.height > MAX_PIXELS) {
+      throw new ScanImageError('file-too-big');
+    }
+
+    const scale = Math.min(
+      1,
+      MAX_EDGE / Math.max(bitmap.width, bitmap.height),
+    );
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new ScanImageError('unreadable');
+    }
+
+    context.drawImage(bitmap, 0, 0, width, height);
+    const imageData = context.getImageData(0, 0, width, height);
+
+    // attemptBoth reads light-on-dark codes. It is jsQR's current default,
+    // passed explicitly so a future default change cannot silently drop it.
+    const result = jsQR(imageData.data, width, height, {
+      inversionAttempts: 'attemptBoth',
+    });
+
+    if (!result) {
+      throw new ScanImageError('no-qr-found');
+    }
+
+    return result.data;
+  } finally {
+    bitmap.close();
+  }
+}

--- a/src/pages/Addresses.tsx
+++ b/src/pages/Addresses.tsx
@@ -42,10 +42,12 @@ export default function Addresses() {
     setCurrentPage,
   } = useDerivationState(hardened);
 
-  const { handleScanOrPaste } = useScannerOrClipboard((text: string) => {
-    setAddressToCheck(text);
-    setCheckStatus('idle');
-  });
+  const { handleScanOrPaste, handleScanImage } = useScannerOrClipboard(
+    (text: string) => {
+      setAddressToCheck(text);
+      setCheckStatus('idle');
+    },
+  );
 
   const pageCount = Math.ceil(totalDerivations / pageSize);
 
@@ -106,6 +108,7 @@ export default function Addresses() {
                 setCheckStatus('idle');
               }}
               onEndIconClick={handleScanOrPaste}
+              onScanImage={handleScanImage}
             />
             <Button
               variant='secondary'

--- a/src/pages/MintNft.tsx
+++ b/src/pages/MintNft.tsx
@@ -68,29 +68,33 @@ export default function MintNft() {
     },
   });
 
-  const { handleScanOrPaste: handleRoyaltyPaste } = useScannerOrClipboard(
-    (scanResValue) => {
-      form.setValue('royaltyAddress', scanResValue);
-    },
-  );
+  const {
+    handleScanOrPaste: handleRoyaltyPaste,
+    handleScanImage: handleRoyaltyScanImage,
+  } = useScannerOrClipboard((scanResValue) => {
+    form.setValue('royaltyAddress', scanResValue);
+  });
 
-  const { handleScanOrPaste: handleDataUrisPaste } = useScannerOrClipboard(
-    (scanResValue) => {
-      form.setValue('dataUris', scanResValue);
-    },
-  );
+  const {
+    handleScanOrPaste: handleDataUrisPaste,
+    handleScanImage: handleDataUrisScanImage,
+  } = useScannerOrClipboard((scanResValue) => {
+    form.setValue('dataUris', scanResValue);
+  });
 
-  const { handleScanOrPaste: handleMetadataUrisPaste } = useScannerOrClipboard(
-    (scanResValue) => {
-      form.setValue('metadataUris', scanResValue);
-    },
-  );
+  const {
+    handleScanOrPaste: handleMetadataUrisPaste,
+    handleScanImage: handleMetadataUrisScanImage,
+  } = useScannerOrClipboard((scanResValue) => {
+    form.setValue('metadataUris', scanResValue);
+  });
 
-  const { handleScanOrPaste: handleLicenseUrisPaste } = useScannerOrClipboard(
-    (scanResValue) => {
-      form.setValue('licenseUris', scanResValue);
-    },
-  );
+  const {
+    handleScanOrPaste: handleLicenseUrisPaste,
+    handleScanImage: handleLicenseUrisScanImage,
+  } = useScannerOrClipboard((scanResValue) => {
+    form.setValue('licenseUris', scanResValue);
+  });
 
   const onSubmit = (values: z.infer<typeof formSchema>) => {
     setPending(true);
@@ -207,6 +211,7 @@ export default function MintNft() {
                       placeholder={t`Enter comma separated URLs`}
                       {...field}
                       onEndIconClick={handleDataUrisPaste}
+                      onScanImage={handleDataUrisScanImage}
                     />
                   </FormControl>
                   <FormMessage />
@@ -228,6 +233,7 @@ export default function MintNft() {
                       placeholder={t`Enter comma separated URLs`}
                       {...field}
                       onEndIconClick={handleMetadataUrisPaste}
+                      onScanImage={handleMetadataUrisScanImage}
                     />
                   </FormControl>
                   <FormMessage />
@@ -249,6 +255,7 @@ export default function MintNft() {
                       placeholder={t`Enter comma separated URLs`}
                       {...field}
                       onEndIconClick={handleLicenseUrisPaste}
+                      onScanImage={handleLicenseUrisScanImage}
                     />
                   </FormControl>
                   <FormMessage />
@@ -270,6 +277,7 @@ export default function MintNft() {
                       placeholder={t`Enter address`}
                       {...field}
                       onEndIconClick={handleRoyaltyPaste}
+                      onScanImage={handleRoyaltyScanImage}
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/pages/Offers.tsx
+++ b/src/pages/Offers.tsx
@@ -38,11 +38,12 @@ import {
   CircleOff,
   FilterIcon,
   HandCoins,
+  ImageIcon,
   NfcIcon,
   ScanIcon,
   TrashIcon,
 } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import { getNdefPayloads, isNdefAvailable } from 'tauri-plugin-sage';
@@ -91,9 +92,23 @@ export function Offers() {
     [navigate],
   );
 
-  const { handleScanOrPaste } = useScannerOrClipboard((scanResValue) => {
-    viewOffer(scanResValue);
-  });
+  const { handleScanOrPaste, handleScanImage } = useScannerOrClipboard(
+    (scanResValue) => {
+      viewOffer(scanResValue);
+    },
+  );
+
+  const offerImageInputRef = useRef<HTMLInputElement>(null);
+
+  const handleOfferImageChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (file) {
+      handleScanImage(file);
+    }
+  };
 
   const updateOffers = useCallback(
     () =>
@@ -216,6 +231,21 @@ export function Offers() {
           <div className='flex items-center gap-2'>
             <Button size='icon' variant='ghost' onClick={handleScanOrPaste}>
               <ScanIcon className='h-5 w-5' aria-hidden='true' />
+            </Button>
+            <input
+              ref={offerImageInputRef}
+              type='file'
+              accept='image/*'
+              className='hidden'
+              onChange={handleOfferImageChange}
+            />
+            <Button
+              size='icon'
+              variant='ghost'
+              aria-label={t`Scan an offer QR code from an image`}
+              onClick={() => offerImageInputRef.current?.click()}
+            >
+              <ImageIcon className='h-5 w-5' aria-hidden='true' />
             </Button>
             <Button
               size='icon'

--- a/src/pages/Offers.tsx
+++ b/src/pages/Offers.tsx
@@ -98,6 +98,8 @@ export function Offers() {
     },
   );
 
+  const isMobile = platform() === 'ios' || platform() === 'android';
+
   const offerImageInputRef = useRef<HTMLInputElement>(null);
 
   const handleOfferImageChange = (
@@ -223,33 +225,44 @@ export function Offers() {
       });
   };
 
+  const scanImageButton = (
+    <Button
+      size='icon'
+      variant='ghost'
+      aria-label={t`Scan an offer QR code from an image`}
+      onClick={() => offerImageInputRef.current?.click()}
+    >
+      <ImageIcon className='h-5 w-5' aria-hidden='true' />
+    </Button>
+  );
+
   return (
     <>
+      <input
+        ref={offerImageInputRef}
+        type='file'
+        accept='image/*'
+        className='hidden'
+        onChange={handleOfferImageChange}
+      />
       <Header
         title={<Trans>Offers</Trans>}
+        alwaysShowChildren
         mobileActionItems={
           <div className='flex items-center gap-2'>
-            <Button size='icon' variant='ghost' onClick={handleScanOrPaste}>
+            <Button
+              size='icon'
+              variant='ghost'
+              aria-label={t`Scan an offer QR code with the camera`}
+              onClick={handleScanOrPaste}
+            >
               <ScanIcon className='h-5 w-5' aria-hidden='true' />
             </Button>
-            <input
-              ref={offerImageInputRef}
-              type='file'
-              accept='image/*'
-              className='hidden'
-              onChange={handleOfferImageChange}
-            />
+            {scanImageButton}
             <Button
               size='icon'
               variant='ghost'
-              aria-label={t`Scan an offer QR code from an image`}
-              onClick={() => offerImageInputRef.current?.click()}
-            >
-              <ImageIcon className='h-5 w-5' aria-hidden='true' />
-            </Button>
-            <Button
-              size='icon'
-              variant='ghost'
+              aria-label={t`Scan an offer from an NFC tag`}
               disabled={!isNfcAvailable}
               onClick={handleNfcScan}
             >
@@ -257,7 +270,9 @@ export function Offers() {
             </Button>
           </div>
         }
-      />
+      >
+        {!isMobile && scanImageButton}
+      </Header>
       <Container>
         <Card className='p-6'>
           <div className='flex flex-col gap-10'>

--- a/src/pages/Send.tsx
+++ b/src/pages/Send.tsx
@@ -169,9 +169,11 @@ export default function Send() {
   });
   const memoMode = form.watch('memoMode') || MemoMode.Text;
 
-  const { handleScanOrPaste } = useScannerOrClipboard((scanResValue) => {
-    form.setValue('address', scanResValue);
-  });
+  const { handleScanOrPaste, handleScanImage } = useScannerOrClipboard(
+    (scanResValue) => {
+      form.setValue('address', scanResValue);
+    },
+  );
 
   const onSubmit = () => {
     const values = form.getValues();
@@ -307,6 +309,7 @@ export default function Send() {
                         autoComplete='off'
                         placeholder={t`Enter address`}
                         onEndIconClick={handleScanOrPaste}
+                        onScanImage={handleScanImage}
                         {...field}
                       />
                     )}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -467,9 +467,11 @@ function WalletConnectSettings() {
   const { pair, sessions, disconnect, connecting } = useWalletConnect();
   const [uri, setUri] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
-  const { handleScanOrPaste } = useScannerOrClipboard((scanResValue) => {
-    setUri(scanResValue);
-  });
+  const { handleScanOrPaste, handleScanImage } = useScannerOrClipboard(
+    (scanResValue) => {
+      setUri(scanResValue);
+    },
+  );
 
   const handlePair = async () => {
     try {
@@ -522,6 +524,7 @@ function WalletConnectSettings() {
               placeholder={t`WalletConnect URI`}
               onChange={(e) => setUri(e.target.value)}
               onEndIconClick={handleScanOrPaste}
+              onScanImage={handleScanImage}
               disabled={connecting}
             />
 
@@ -1048,11 +1051,13 @@ function WalletSettings({ fingerprint }: { fingerprint: number }) {
     }
   };
 
-  const { handleScanOrPaste: handleScanOrPasteChangeAddress } =
-    useScannerOrClipboard((scanResValue) => {
-      setLocalChangeAddress(scanResValue);
-      saveChangeAddress(scanResValue);
-    });
+  const {
+    handleScanOrPaste: handleScanOrPasteChangeAddress,
+    handleScanImage: handleScanImageChangeAddress,
+  } = useScannerOrClipboard((scanResValue) => {
+    setLocalChangeAddress(scanResValue);
+    saveChangeAddress(scanResValue);
+  });
 
   const fetchDatabaseStats = useCallback(async () => {
     setLoadingStats(true);
@@ -1293,6 +1298,7 @@ function WalletSettings({ fingerprint }: { fingerprint: number }) {
                 saveChangeAddress(localChangeAddress);
               }}
               onEndIconClick={handleScanOrPasteChangeAddress}
+              onScanImage={handleScanImageChangeAddress}
             />
           </div>
         </SettingItem>


### PR DESCRIPTION
Fix #813 

Allows using a static image for QR code scans of address and offers/offer links. Works on mobile and desktop, though a little differently.
- mobile can choos photo library or files
- desktop just files

https://github.com/user-attachments/assets/ffd22f58-94a3-4709-84cc-1218ac937450

