### PR TITLE
Fix wry arrow key input on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9833,8 +9833,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "wry"
 version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed1a195b0375491dd15a7066a10251be217ce743cf4bbbbdcf5391d6473bee0"
+source = "git+https://github.com/Rigidity/wry.git?branch=sage%2Fwry-v0.54.1-patched#76ac9922bc72342567c7d2fc0d2fd985621b1bdf"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,6 @@ clap = "4.5.21"
 # Testing
 tempfile = "3.25.0"
 tower = "0.5.3"
+
+[patch.crates-io]
+wry = { git = "https://github.com/Rigidity/wry.git", branch = "sage/wry-v0.54.1-patched" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scope is limited to swapping the `wry` dependency source for a targeted keyboard fix; main caveat is relying on a git fork until upstream merges the patch.
> 
> **Overview**
> **Fixes arrow key input on macOS** by overriding the `wry` crate (Tauri’s WebView layer) with a patched fork instead of the crates.io `0.54.1` release.
> 
> A workspace-level `[patch.crates-io]` entry points `wry` at `Rigidity/wry` on branch `sage/wry-v0.54.1-patched`; `Cargo.lock` is updated to resolve `wry` from that git revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0b110960f8598d1bc394c1bec1c4506f610e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->