### PR TITLE
Fix single NFT mint edition

### DIFF
--- a/src/pages/MintNft.tsx
+++ b/src/pages/MintNft.tsx
@@ -113,28 +113,15 @@ export default function MintNft() {
         .filter(Boolean),
     };
 
-    const mints =
-      values.editionCount > 1
-        ? Array.from({ length: values.editionCount }, (_, i) => ({
-            edition_number: i + values.editionStart,
-            edition_total: values.editionTotal ?? values.editionCount,
-            royalty_address: values.royaltyAddress || null,
-            royalty_ten_thousandths: Number(values.royaltyPercent) * 100,
-            data_uris: mintDetails.data_uris,
-            metadata_uris: mintDetails.metadata_uris,
-            license_uris: mintDetails.license_uris,
-          }))
-        : [
-            {
-              edition_number: null,
-              edition_total: null,
-              royalty_address: values.royaltyAddress || null,
-              royalty_ten_thousandths: Number(values.royaltyPercent) * 100,
-              data_uris: mintDetails.data_uris,
-              metadata_uris: mintDetails.metadata_uris,
-              license_uris: mintDetails.license_uris,
-            },
-          ];
+    const mints = Array.from({ length: values.editionCount }, (_, i) => ({
+      edition_number: i + values.editionStart,
+      edition_total: values.editionTotal ?? values.editionCount,
+      royalty_address: values.royaltyAddress || null,
+      royalty_ten_thousandths: Number(values.royaltyPercent) * 100,
+      data_uris: mintDetails.data_uris,
+      metadata_uris: mintDetails.metadata_uris,
+      license_uris: mintDetails.license_uris,
+    }));
 
     commands
       .bulkMintNfts({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes on-chain mint metadata for single-edition NFTs (null vs numbered editions), which can affect how mints are interpreted by wallets and indexers.
> 
> **Overview**
> **Fixes single NFT minting** by always building `mints` through the same `Array.from` path used for multi-edition mints, instead of a special case when `editionCount === 1`.
> 
> Previously, minting one NFT sent `edition_number` and `edition_total` as `null`, which could break or mislabel the mint on-chain. A single mint now sends `edition_number: editionStart` and `edition_total: editionTotal ?? editionCount` (e.g. 1 of 1 when defaults are used), matching the bulk mint payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359146879b346d9c9ab9167415615b8c277fd2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->