### PR TITLE
Fix clippy issues

### DIFF
--- a/crates/sage-apps/src/bridge/methods/system/runtime_manager/get_active_taskbar_runtime.rs
+++ b/crates/sage-apps/src/bridge/methods/system/runtime_manager/get_active_taskbar_runtime.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use crate::{
     BridgeApprovalRequestResult, BridgeContext, BridgeHandleResult, BridgeMethod,
     BridgeMethodCapability, BridgeMethodHandleError, BridgeTools, RustBridgeRequest,
-    SageAppRuntimeRecordView, SystemBridgeCapability, find_active_taskbar_runtime,
-    find_runtime_by_runtime_id_optional, resolve_running_app,
+    SageAppRuntimeRecord, SageAppRuntimeRecordView, SystemBridgeCapability,
+    find_active_taskbar_runtime, find_runtime_by_runtime_id_optional, resolve_running_app,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -45,7 +45,7 @@ impl BridgeMethod for RuntimeManagerGetActiveTaskbarRuntime {
             })?;
         let host_window_label = app
             .runtime()
-            .with_runtime(|runtime| runtime.host_window_label().to_string());
+            .with_runtime(SageAppRuntimeRecord::host_window_label);
 
         let active_taskbar_runtime =
             find_active_taskbar_runtime(tools.host_state, &host_window_label).await;

--- a/crates/sage-apps/src/bridge/methods/user/app/lifecycle.rs
+++ b/crates/sage-apps/src/bridge/methods/user/app/lifecycle.rs
@@ -46,7 +46,7 @@ impl BridgeMethod for AppLifecycleSetBeforeStopListener {
             .await;
 
         if params.active() {
-            listeners.insert(ctx.app.id().to_string());
+            listeners.insert(ctx.app.id().clone());
         } else {
             listeners.remove(&ctx.app.id());
         }

--- a/crates/sage-apps/src/bridge/state.rs
+++ b/crates/sage-apps/src/bridge/state.rs
@@ -32,7 +32,7 @@ pub(crate) async fn write_pending_approval(
     let now = unix_timestamp_ms() as u64;
     let mut pending = apps_state.bridge.pending_approvals.lock().await;
     pending.insert(
-        approval_id.to_string(),
+        approval_id.clone(),
         PendingBridgeApproval {
             approval_id: approval_id.clone(),
             app_id,

--- a/crates/sage-apps/src/lifecycle/update/background.rs
+++ b/crates/sage-apps/src/lifecycle/update/background.rs
@@ -10,10 +10,10 @@ use crate::{
 
 pub fn start_background_app_update_checker(app_handle: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(5000)).await;
+        tokio::time::sleep(Duration::from_secs(5)).await;
         tracing::info!("starting background app update checker");
 
-        let mut interval = tokio::time::interval(Duration::from_secs(60 * 10));
+        let mut interval = tokio::time::interval(Duration::from_mins(10));
 
         loop {
             if let Err(err) = run_background_app_update_check(&app_handle).await {

--- a/crates/sage-apps/src/runtime/commands.rs
+++ b/crates/sage-apps/src/runtime/commands.rs
@@ -5,11 +5,11 @@ use specta::Type;
 use tauri::{AppHandle, State};
 
 use crate::{
-    AppsHostState, RuntimeTargetParams, SageAppRuntimeRecordView, SystemKillRuntimeResult,
-    clear_active_taskbar_runtime, enter_apps_workspace, focus_taskbar_runtime,
-    get_runtime_by_app_id, get_webview_in_sage_window, kill_taskbar_runtime, leave_apps_workspace,
-    list_runtimes, start_app_install_runtime, start_app_update_runtime, start_donation_runtime,
-    start_sandbox_tests_runtime, start_user_app,
+    AppsHostState, RuntimeTargetParams, SageAppRuntimeRecord, SageAppRuntimeRecordView,
+    SystemKillRuntimeResult, clear_active_taskbar_runtime, enter_apps_workspace,
+    focus_taskbar_runtime, get_runtime_by_app_id, get_webview_in_sage_window, kill_taskbar_runtime,
+    leave_apps_workspace, list_runtimes, start_app_install_runtime, start_app_update_runtime,
+    start_donation_runtime, start_sandbox_tests_runtime, start_user_app,
 };
 
 #[derive(Debug, Deserialize, Type)]
@@ -213,7 +213,7 @@ pub async fn apps_dev_reload_runtime(
         .await
         .map_err(|_| "Runtime not found".to_string())?;
 
-    let webview_label = runtime.with_runtime(|runtime| runtime.webview_label().to_string());
+    let webview_label = runtime.with_runtime(SageAppRuntimeRecord::webview_label);
 
     let webview = get_webview_in_sage_window(&app, &webview_label)?;
 

--- a/crates/sage-apps/src/runtime/manager.rs
+++ b/crates/sage-apps/src/runtime/manager.rs
@@ -228,7 +228,7 @@ pub(crate) async fn reload_app_runtime(
 
     let webview_label = resolved_running_app
         .runtime()
-        .with_runtime(|runtime| runtime.webview_label().to_string());
+        .with_runtime(SageAppRuntimeRecord::webview_label);
 
     get_webview_in_sage_window(app_handle, &webview_label)?
         .reload()
@@ -242,7 +242,7 @@ async fn reload_all_user_runtimes(
     for runtime in list_runtimes(apps_state).await? {
         let (webview_label, should_reload) = runtime.with_runtime(|runtime| {
             (
-                runtime.webview_label().to_string(),
+                runtime.webview_label(),
                 runtime.app().is_user_app() && !runtime.internal(),
             )
         });
@@ -352,7 +352,7 @@ fn runtime_window_identity(resolved_running_app: &ResolvedRunningApp) -> Runtime
         .runtime()
         .with_runtime(|record| RuntimeWindowIdentity {
             runtime_id: record.runtime_id(),
-            host_window_label: record.host_window_label().to_string(),
+            host_window_label: record.host_window_label(),
         })
 }
 

--- a/crates/sage-apps/src/runtime/start.rs
+++ b/crates/sage-apps/src/runtime/start.rs
@@ -191,7 +191,7 @@ async fn create_runtime_for_app(
 
     let runtime_for_nav = shared_runtime.clone();
     let builder = WebviewBuilder::new(
-        webview_label.to_string(),
+        webview_label.clone(),
         WebviewUrl::CustomProtocol(build_entry_src(&app, args.query.clone())),
     )
     .transparent(true)
@@ -420,8 +420,5 @@ async fn mark_origin_may_contain_secrets_if_needed(
 }
 
 fn debug_test_apps_enabled() -> bool {
-    cfg!(debug_assertions)
-        && std::env::var("SAGE_DEBUG_TEST_APPS")
-            .map(|v| v == "1")
-            .unwrap_or(false)
+    cfg!(debug_assertions) && std::env::var("SAGE_DEBUG_TEST_APPS").is_ok_and(|v| v == "1")
 }

--- a/crates/sage-apps/src/runtime/state/types.rs
+++ b/crates/sage-apps/src/runtime/state/types.rs
@@ -50,21 +50,6 @@ pub struct AppRuntimeState {
     pub pending_stop_ready: Mutex<BTreeMap<String, oneshot::Sender<()>>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct SageLifecycleBeforeStopDetail {
-    pub request_id: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub runtime_id: Option<String>,
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SetBeforeStopListenerParams {
@@ -160,7 +145,7 @@ impl SageAppRuntimeRecord {
     }
 
     pub(crate) fn runtime_id(&self) -> String {
-        self.runtime_id.to_string()
+        self.runtime_id.clone()
     }
 
     pub(crate) fn app(&self) -> SharedSageApp {
@@ -172,11 +157,11 @@ impl SageAppRuntimeRecord {
     }
 
     pub(crate) fn webview_label(&self) -> String {
-        self.webview_label.to_string()
+        self.webview_label.clone()
     }
 
     pub(crate) fn host_window_label(&self) -> String {
-        self.host_window_label.to_string()
+        self.host_window_label.clone()
     }
 
     pub(crate) fn presentation(&self) -> AppPresentation {
@@ -259,7 +244,7 @@ impl SharedRuntime {
     }
 
     pub fn runtime_id(&self) -> String {
-        self.with_runtime(|runtime| runtime.runtime_id().to_string())
+        self.with_runtime(SageAppRuntimeRecord::runtime_id)
     }
 
     pub fn app_id(&self) -> String {

--- a/crates/sage-apps/src/runtime/state/view.rs
+++ b/crates/sage-apps/src/runtime/state/view.rs
@@ -23,10 +23,10 @@ pub struct SageAppRuntimeRecordView {
 impl From<&SharedRuntime> for SageAppRuntimeRecordView {
     fn from(value: &SharedRuntime) -> Self {
         value.with_runtime(|runtime| Self {
-            runtime_id: runtime.runtime_id().clone(),
+            runtime_id: runtime.runtime_id(),
             app: runtime.app().into(),
-            host_window_label: runtime.host_window_label().to_string(),
-            webview_label: runtime.webview_label().to_string(),
+            host_window_label: runtime.host_window_label(),
+            webview_label: runtime.webview_label(),
             presentation: runtime.presentation(),
             mode: runtime.mode(),
             visibility: runtime.visibility(),

--- a/crates/sage-apps/src/runtime/state/write.rs
+++ b/crates/sage-apps/src/runtime/state/write.rs
@@ -7,8 +7,8 @@ pub(crate) async fn write_runtime(
     apps_state: &State<'_, AppsHostState>,
     runtime: SageAppRuntimeRecord,
 ) -> SharedRuntime {
-    let runtime_id = runtime.runtime_id().to_string();
-    let app_id = runtime.app().id().to_string();
+    let runtime_id = runtime.runtime_id();
+    let app_id = runtime.app().id().clone();
 
     let runtime = SharedRuntime::new(runtime);
 

--- a/crates/sage-database/src/tables/mempool_items.rs
+++ b/crates/sage-database/src/tables/mempool_items.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::Entry;
+
 use chia_wallet_sdk::prelude::*;
 use sqlx::{Row, SqliteConnection, SqliteExecutor, query};
 
@@ -398,22 +400,20 @@ async fn mempool_items_with_coins(
 
         let transaction_coin = create_transaction_coin(row)?;
 
-        if !items.contains_key(&item_hash) {
-            let fee: u64 = row.get::<Vec<u8>, _>("item_fee").convert()?;
-            let submitted_timestamp: Option<i64> = row.get("submitted_timestamp");
-            order.push(item_hash);
-            items.insert(
-                item_hash,
-                (
+        let entry = match items.entry(item_hash) {
+            Entry::Vacant(entry) => {
+                let fee: u64 = row.get::<Vec<u8>, _>("item_fee").convert()?;
+                let submitted_timestamp: Option<i64> = row.get("submitted_timestamp");
+                order.push(item_hash);
+                entry.insert((
                     fee,
                     submitted_timestamp.map(|ts| ts as u64),
                     Vec::new(),
                     Vec::new(),
-                ),
-            );
-        }
-
-        let entry = items.get_mut(&item_hash).unwrap();
+                ))
+            }
+            Entry::Occupied(entry) => entry.into_mut(),
+        };
         if is_input {
             entry.2.push(transaction_coin.clone());
         }

--- a/crates/sage-wallet/src/queues/cat_queue.rs
+++ b/crates/sage-wallet/src/queues/cat_queue.rs
@@ -34,7 +34,7 @@ impl CatQueue {
     }
 
     async fn process_batch(&self) -> Result<(), WalletError> {
-        let cats = timeout(Duration::from_secs(120), DexieCat::fetch_all(self.testnet)).await??;
+        let cats = timeout(Duration::from_mins(2), DexieCat::fetch_all(self.testnet)).await??;
 
         if cats.is_empty() {
             return Ok(());

--- a/crates/sage-wallet/src/queues/offer_queue.rs
+++ b/crates/sage-wallet/src/queues/offer_queue.rs
@@ -99,7 +99,7 @@ impl OfferQueue {
                 warn!("Coin lookup failed for {}: {}", peer.socket_addr(), err);
                 self.state.lock().await.ban(
                     peer.socket_addr().ip(),
-                    Duration::from_secs(300),
+                    Duration::from_mins(5),
                     "coin lookup failed",
                 );
                 return Ok(());

--- a/crates/sage-wallet/src/queues/puzzle_queue.rs
+++ b/crates/sage-wallet/src/queues/puzzle_queue.rs
@@ -227,7 +227,7 @@ impl PuzzleQueue {
                     ) {
                         self.state.lock().await.ban(
                             addr.ip(),
-                            Duration::from_secs(300),
+                            Duration::from_mins(5),
                             "failed puzzle lookup",
                         );
                     }

--- a/crates/sage-wallet/src/sync_manager.rs
+++ b/crates/sage-wallet/src/sync_manager.rs
@@ -176,7 +176,7 @@ impl SyncManager {
                         debug!("Failed to handle message from {ip}: {error}");
                         self.state.lock().await.ban(
                             ip,
-                            Duration::from_secs(300),
+                            Duration::from_mins(5),
                             "failed to handle message",
                         );
                     }
@@ -250,7 +250,7 @@ impl SyncManager {
             warn!("Failed to add new subscriptions: {error}");
             self.state.lock().await.ban(
                 ip,
-                Duration::from_secs(300),
+                Duration::from_mins(5),
                 "failed to add new subscriptions",
             );
         } else {
@@ -505,11 +505,10 @@ impl SyncManager {
                 }
                 Ok(Err(error)) => {
                     warn!("Initial wallet sync failed: {error}");
-                    self.state.lock().await.ban(
-                        *ip,
-                        Duration::from_secs(300),
-                        "wallet sync failed",
-                    );
+                    self.state
+                        .lock()
+                        .await
+                        .ban(*ip, Duration::from_mins(5), "wallet sync failed");
                     self.initial_wallet_sync = InitialWalletSync::Idle;
                     self.event_sender.send(SyncEvent::Stop).await.ok();
                 }
@@ -517,7 +516,7 @@ impl SyncManager {
                     warn!("Initial wallet sync timed out");
                     self.state.lock().await.ban(
                         *ip,
-                        Duration::from_secs(300),
+                        Duration::from_mins(5),
                         "wallet sync timed out",
                     );
                     self.initial_wallet_sync = InitialWalletSync::Idle;

--- a/crates/sage-wallet/src/sync_manager/options.rs
+++ b/crates/sage-wallet/src/sync_manager/options.rs
@@ -32,7 +32,7 @@ impl Default for Timeouts {
     fn default() -> Self {
         Self {
             sync_delay: Duration::from_secs(1),
-            cat_delay: Duration::from_secs(3600),
+            cat_delay: Duration::from_hours(1),
             nft_uri_delay: Duration::from_millis(500),
             puzzle_delay: Duration::from_secs(1),
             transaction_delay: Duration::from_secs(1),

--- a/crates/sage-wallet/src/sync_manager/peer_discovery.rs
+++ b/crates/sage-wallet/src/sync_manager/peer_discovery.rs
@@ -131,7 +131,7 @@ impl SyncManager {
                     };
 
                     if message.msg_type != ProtocolMessageTypes::Handshake {
-                        return Err(ClientError::InvalidResponse(
+                        Err(ClientError::InvalidResponse(
                             vec![ProtocolMessageTypes::Handshake],
                             message.msg_type,
                         ))?;
@@ -141,15 +141,15 @@ impl SyncManager {
                         Handshake::from_bytes(&message.data).map_err(ClientError::from)?;
 
                     if handshake.node_type != NodeType::Introducer {
-                        return Err(ClientError::WrongNodeType(
+                        Err(ClientError::WrongNodeType(
                             NodeType::Introducer,
                             handshake.node_type,
                         ))?;
                     }
 
                     if handshake.network_id != network_id {
-                        return Err(ClientError::WrongNetwork(
-                            network_id.to_string(),
+                        Err(ClientError::WrongNetwork(
+                            network_id.clone(),
                             handshake.network_id,
                         ))?;
                     }
@@ -220,7 +220,7 @@ impl SyncManager {
                     debug!("Failed to request peers from {}: {}", ip, error);
                     self.state.lock().await.ban(
                         ip,
-                        Duration::from_secs(300),
+                        Duration::from_mins(5),
                         "failed to request peers",
                     );
                 }
@@ -259,7 +259,7 @@ impl SyncManager {
                 if ban {
                     self.state.lock().await.ban(
                         ip,
-                        Duration::from_secs(300),
+                        Duration::from_mins(5),
                         "invalid ip in peer list",
                     );
                 }
@@ -317,7 +317,7 @@ impl SyncManager {
                     } else if !force {
                         self.state.lock().await.ban(
                             socket_addr.ip(),
-                            Duration::from_secs(60 * 10),
+                            Duration::from_mins(10),
                             "could not add peer",
                         );
                     }
@@ -327,7 +327,7 @@ impl SyncManager {
                     if !force {
                         self.state.lock().await.ban(
                             socket_addr.ip(),
-                            Duration::from_secs(60 * 10),
+                            Duration::from_mins(10),
                             "failed to connect",
                         );
                     }
@@ -337,7 +337,7 @@ impl SyncManager {
                     if !force {
                         self.state.lock().await.ban(
                             socket_addr.ip(),
-                            Duration::from_secs(60 * 10),
+                            Duration::from_mins(10),
                             "connection timed out",
                         );
                     }
@@ -434,7 +434,7 @@ impl SyncManager {
             } else if message.height > height.saturating_add(3) {
                 state.ban(
                     existing_peer.socket_addr().ip(),
-                    Duration::from_secs(900),
+                    Duration::from_mins(15),
                     "peer is behind",
                 );
             }

--- a/crates/sage-wallet/src/utils/offchain_metadata.rs
+++ b/crates/sage-wallet/src/utils/offchain_metadata.rs
@@ -40,9 +40,9 @@ pub fn compute_nft_info(did_id: Option<Bytes32>, blob: &[u8]) -> ComputedNftInfo
         let attributes = attributes.unwrap_or_default();
         Some(CollectionRow {
             description: None,
-            hash: calculate_collection_id(did_id, &metadata_collection_id.to_string()),
+            hash: calculate_collection_id(did_id, &metadata_collection_id),
             minter_hash: did_id,
-            uuid: metadata_collection_id.to_string(),
+            uuid: metadata_collection_id,
             name: Some(name),
             icon_url: attributes.iter().find_map(|item| {
                 match (item.kind.as_str(), item.value.as_str()) {

--- a/crates/sage/src/endpoints/keys.rs
+++ b/crates/sage/src/endpoints/keys.rs
@@ -400,12 +400,12 @@ impl Sage {
             .iter()
             .find(|w| w.fingerprint == req.fingerprint);
 
-        if let Some(cfg) = wallet_cfg {
-            if let Some(change_address) = &cfg.change_address {
-                return Ok(GetWalletAddressResponse {
-                    address: change_address.clone(),
-                });
-            }
+        if let Some(cfg) = wallet_cfg
+            && let Some(change_address) = &cfg.change_address
+        {
+            return Ok(GetWalletAddressResponse {
+                address: change_address.clone(),
+            });
         }
 
         let network = self

--- a/crates/sage/src/endpoints/settings.rs
+++ b/crates/sage/src/endpoints/settings.rs
@@ -42,7 +42,7 @@ impl Sage {
         let ip = req.ip.parse()?;
 
         if req.ban {
-            peer_state.ban(ip, Duration::from_secs(60 * 60), "manually banned");
+            peer_state.ban(ip, Duration::from_hours(1), "manually banned");
         } else {
             peer_state.remove_peer(ip);
         }

--- a/crates/sage/src/error.rs
+++ b/crates/sage/src/error.rs
@@ -237,9 +237,8 @@ pub enum Error {
 impl Error {
     pub fn kind(&self) -> ErrorKind {
         match self {
-            Self::Wallet(..) => ErrorKind::Wallet,
+            Self::Wallet(..) | Self::NoSigningKey => ErrorKind::Wallet,
             Self::NotLoggedIn => ErrorKind::Unauthorized,
-            Self::NoSigningKey => ErrorKind::Wallet,
             Self::Keychain(error) => match error {
                 KeychainError::Decrypt => ErrorKind::Unauthorized,
                 KeychainError::KeyExists

--- a/crates/sage/src/sage.rs
+++ b/crates/sage/src/sage.rs
@@ -446,7 +446,7 @@ impl Sage {
                     .journal_mode(SqliteJournalMode::Wal)
                     .log_statements(log::LevelFilter::Trace)
                     .synchronous(SqliteSynchronous::Normal)
-                    .busy_timeout(Duration::from_secs(60)),
+                    .busy_timeout(Duration::from_mins(1)),
             )
             .await?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -308,7 +308,7 @@ pub fn run() {
                 let cleanup_base_path = path.clone();
 
                 tauri::async_runtime::spawn(async move {
-                    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     tracing::info!("starting pending storage cleanup task");
 
                     if let Err(err) =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical lint fixes and equivalent duration literals; no new features or security-sensitive logic changes.
> 
> **Overview**
> This PR applies **Clippy-driven cleanups** across the Rust workspace with no intended behavior changes.
> 
> In **sage-apps**, runtime access now passes **method references** (e.g. `SageAppRuntimeRecord::webview_label`) into `with_runtime` instead of redundant closures and `.to_string()` calls; string handling favors **`clone()`** where Clippy flags extra allocations. The unused **`SageLifecycleBeforeStopDetail`** type is removed. Background update and Tauri startup delays use **`Duration::from_secs(5)`** instead of `from_millis(5000)`, and the update checker interval uses **`from_mins(10)`**. Debug env checks use **`is_ok_and`**.
> 
> In **sage-database**, mempool row grouping uses **`HashMap::entry`** instead of `contains_key` plus `unwrap`.
> 
> In **sage-wallet** and **sage**, peer ban durations and queue timeouts are expressed with **`Duration::from_mins` / `from_hours`** where applicable; introducer handshake validation uses **`Err(...)?`** instead of early `return Err`; NFT metadata drops redundant **`.to_string()`** on values already owned as `String`. **`get_wallet_address`** uses a **`let`-chain** for the change-address override, **`Error::kind`** merges **`NoSigningKey`** with wallet errors, and SQLite **`busy_timeout`** uses **`from_mins(1)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4087501d9a6e2ad097997e0b186b4b106901ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->