### PR TITLE
Fix Windows build failures

### DIFF
--- a/builtin-apps/src/system/build.mjs
+++ b/builtin-apps/src/system/build.mjs
@@ -32,7 +32,7 @@ function run(command, args) {
     const child = spawn(command, args, {
       cwd: packageRoot,
       stdio: 'inherit',
-      shell: false,
+      shell: process.platform === 'win32',
     });
 
     child.on('error', rejectPromise);

--- a/crates/sage-apps/build.rs
+++ b/crates/sage-apps/build.rs
@@ -1,0 +1,17 @@
+use std::{env, path::Path};
+
+fn main() {
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set");
+    let manifest_path = Path::new(&manifest_dir).join("windows-app-manifest.xml");
+
+    println!("cargo:rerun-if-changed={}", manifest_path.display());
+    println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
+    println!(
+        "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
+        manifest_path.display()
+    );
+}

--- a/crates/sage-apps/src/runtime/start.rs
+++ b/crates/sage-apps/src/runtime/start.rs
@@ -357,7 +357,7 @@ fn build_persistent_storage_target(
     match storage {
         #[cfg(target_os = "windows")]
         SageAppStorage::WindowsProfile { directory_name } => {
-            builder.data_directory(data_directory_for(directory_name))
+            builder.data_directory(data_directory_for(&directory_name))
         }
 
         #[cfg(not(target_os = "windows"))]

--- a/crates/sage-apps/windows-app-manifest.xml
+++ b/crates/sage-apps/windows-app-manifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/scripts/build-builtin-static.mjs
+++ b/scripts/build-builtin-static.mjs
@@ -44,7 +44,11 @@ function finalizeManifest(source, dist) {
       '--dist',
       dist,
     ],
-    { stdio: 'inherit', cwd: repoRoot },
+    {
+      stdio: 'inherit',
+      cwd: repoRoot,
+      shell: process.platform === 'win32',
+    },
   );
 }
 


### PR DESCRIPTION
## Summary
- borrow the owned Windows profile directory name when passing it to `data_directory_for`
- embed a Common Controls v6 manifest so the Rust generators start on Windows
- execute pnpm command shims through the Windows shell in both builtin-app build scripts
- restore the Windows x64 and ARM build pipeline

## Test plan
- [x] `cargo fmt --all -- --files-with-diff --check`
- [x] `cargo clippy --workspace --all-features --all-targets`
- [x] `pnpm prettier:check`
- [x] ESLint on both changed `.mjs` files
- [x] `pnpm --dir builtin-apps/src/system build`
- [x] `pnpm run build:builtin-static`
- [ ] Confirm Windows x64 and ARM jobs pass in GitHub Actions

Full `pnpm lint` currently fails on the pre-existing non-null assertion in `src/components/WalletAddressPicker.tsx:52`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Windows build and packaging fixes with a small Rust API usage correction; no auth, data, or cross-platform runtime behavior changes beyond Windows manifest embedding.
> 
> **Overview**
> **Unblocks Windows CI and local builds** by fixing a Rust borrow error, embedding the Common Controls v6 manifest, and running Node build shims through the shell on Windows.
> 
> The webview startup path now passes `&directory_name` into `data_directory_for` so Windows profile storage compiles. A new `build.rs` (Windows-only) links an embedded `windows-app-manifest.xml` so generated binaries load **Microsoft.Windows.Common-Controls** v6, which avoids startup failures tied to legacy control styling.
> 
> Node build scripts (`builtin-apps/src/system/build.mjs` and `scripts/build-builtin-static.mjs`) set `shell: true` on `win32` when spawning `pnpm` / `pnpm.cmd`, matching how those entrypoints are resolved elsewhere in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8281098a4bddd277acd38e9e7f7b86055dc3623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->