### PR TITLE
ci: reduce full-matrix build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,10 @@ jobs:
         with:
           cache-targets: false
 
+      - name: Install GTK
+        timeout-minutes: 20
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev
+
       - name: Build desktop assets
         run: pnpm build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ github.event_name == 'pull_request' && '64' || '16' }}
+  CARGO_PROFILE_RELEASE_OPT_LEVEL: ${{ github.event_name == 'pull_request' && '1' || '3' }}
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: 'true'
+
 jobs:
   tests:
     name: Tests
@@ -40,10 +46,16 @@ jobs:
           pnpm prettier:check
 
       - name: Install GTK
+        timeout-minutes: 20
         run: sudo apt-get update && sudo apt-get install libgtk-3-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
 
       - name: Clippy
         run: cargo clippy --workspace --all-features --all-targets
@@ -59,8 +71,56 @@ jobs:
       - name: Fmt
         run: cargo fmt --all -- --files-with-diff --check
 
-  build:
+      - name: Show sccache statistics
+        run: sccache --show-stats
+
+  prepare-desktop-assets:
+    name: Prepare desktop assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Cache PNPM dependencies
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
+      - name: Build desktop assets
+        run: pnpm build
+        env:
+          CI: true
+
+      - name: Upload desktop assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-assets
+          path: |
+            dist
+            builtin-apps/build/dist
+          retention-days: 1
+
+      - name: Show sccache statistics
+        run: sccache --show-stats
+
+  build-desktop:
     name: ${{ matrix.platform_name }}
+    needs: prepare-desktop-assets
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write
@@ -71,45 +131,28 @@ jobs:
           - platform: 'macos-15'
             platform_name: MacOS
             cache_key: macos
-            build: 'pnpm tauri build --target universal-apple-darwin'
+            build: 'pnpm tauri build --target universal-apple-darwin --config src-tauri/tauri.ci.conf.json'
+            pr_build: 'pnpm tauri build --target universal-apple-darwin --bundles dmg --config src-tauri/tauri.ci.conf.json'
           - platform: 'ubuntu-22.04'
             platform_name: Linux (x64)
             cache_key: linux-x64
-            build: 'pnpm tauri build'
+            build: 'pnpm tauri build --config src-tauri/tauri.ci.conf.json'
+            pr_build: 'pnpm tauri build --bundles deb --config src-tauri/tauri.ci.conf.json'
           - platform: 'linux-arm64'
             platform_name: Linux (ARM)
             cache_key: linux-arm64
-            build: 'pnpm tauri build --target aarch64-unknown-linux-gnu'
+            build: 'pnpm tauri build --target aarch64-unknown-linux-gnu --config src-tauri/tauri.ci.conf.json'
+            pr_build: 'pnpm tauri build --target aarch64-unknown-linux-gnu --bundles deb --config src-tauri/tauri.ci.conf.json'
           - platform: 'windows-2022'
             platform_name: Windows (x64)
             cache_key: windows-x64
-            build: 'pnpm tauri build'
+            build: 'pnpm tauri build --config src-tauri/tauri.ci.conf.json'
+            pr_build: 'pnpm tauri build --bundles msi --config src-tauri/tauri.ci.conf.json'
           - platform: 'windows-2022'
             platform_name: Windows (ARM)
             cache_key: windows-arm64
-            build: 'pnpm tauri build --target aarch64-pc-windows-msvc'
-          - platform: 'macos-26'
-            platform_name: iOS (TestFlight)
-            platform_type: iOS
-            cache_key: ios-testflight
-            build: 'pnpm tauri ios build --export-method app-store-connect --build-number 1'
-            disable_offers: 'false'
-            disable_options: 'false'
-            disable_swap: 'false'
-            ipa_name: Sage_TestFlight
-          - platform: 'macos-26'
-            platform_name: iOS (App Store)
-            platform_type: iOS
-            cache_key: ios-app-store
-            build: 'pnpm tauri ios build --export-method app-store-connect --build-number 2'
-            disable_offers: 'true'
-            disable_options: 'true'
-            disable_swap: 'true'
-            ipa_name: Sage_AppStore
-          - platform: 'macos-15'
-            platform_name: Android
-            cache_key: android
-            build: 'pnpm tauri android build'
+            build: 'pnpm tauri build --target aarch64-pc-windows-msvc --config src-tauri/tauri.ci.conf.json'
+            pr_build: 'pnpm tauri build --target aarch64-pc-windows-msvc --bundles msi --config src-tauri/tauri.ci.conf.json'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,10 +160,6 @@ jobs:
       - name: Add x86_64-apple-darwin
         if: matrix.platform_name == 'MacOS'
         run: rustup target add x86_64-apple-darwin
-
-      - name: Add aarch64-apple-ios
-        if: matrix.platform_type == 'iOS'
-        run: rustup target add aarch64-apple-ios
 
       - name: Add aarch64-pc-windows-msvc
         if: matrix.platform_name == 'Windows (ARM)'
@@ -130,17 +169,18 @@ jobs:
         if: matrix.platform_name == 'Linux (ARM)'
         run: rustup target add aarch64-unknown-linux-gnu
 
-      - name: Add Android targets
-        if: matrix.platform_name == 'Android'
-        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
+          cache-targets: false
           key: ${{ matrix.cache_key }}
 
       - name: Ubuntu dependencies
         if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'linux-arm64'
+        timeout-minutes: 20
         run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev
 
       - name: Ubuntu ARM dependencies
@@ -152,30 +192,6 @@ jobs:
         run: |
           choco install nasm
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install Android NDK
-        uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        if: matrix.platform_name == 'Android'
-        with:
-          ndk-version: r26d
-          link-to-sdk: true
-          add-to-path: true
-
-      - name: Add NDK toolchain to path
-        if: matrix.platform_name == 'Android'
-        run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin" >> $GITHUB_PATH
-        env:
-          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
-
-      - name: Setup Android signing
-        if: matrix.platform_name == 'Android'
-        run: |
-          cd src-tauri/gen/android
-          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties
-          echo "password=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
-          base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
-          echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -189,31 +205,21 @@ jobs:
       - name: Frontend dependencies
         run: pnpm install
 
+      - name: Download desktop assets
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-assets
+          path: .
+
       - name: Save API key to file
-        if: matrix.platform_name == 'MacOS' || matrix.platform_type == 'iOS'
+        if: matrix.platform_name == 'MacOS'
         run: |
           mkdir -p ~/private_keys
           echo -n '${{ secrets.APPLE_API_SECRET_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
 
-      - name: Setup Xcode
-        if: matrix.platform_type == 'iOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26.5'
-
-      - name: Verify Xcode SDK
-        if: matrix.platform_type == 'iOS'
-        run: |
-          xcodebuild -version
-          xcrun --sdk iphoneos --show-sdk-version
-
-      - name: Bindgen CLI
-        run: cargo install bindgen-cli --locked
-
       # On MacOS we only notarize on tagged releases
-      # On iOS we need these secrets as well to do code signing
       - name: Build with secrets
-        if: ${{ (matrix.platform_name == 'MacOS' && startsWith(github.event.ref, 'refs/tags/v')) || matrix.platform_type == 'iOS' }}
+        if: matrix.platform_name == 'MacOS' && startsWith(github.event.ref, 'refs/tags/v')
         run: ${{ matrix.build }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -221,38 +227,22 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_KEY_PATH: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
-          VITE_DISABLE_OFFERS: ${{ matrix.disable_offers }}
-          VITE_DISABLE_OPTIONS: ${{ matrix.disable_options }}
-          VITE_DISABLE_SWAP: ${{ matrix.disable_swap }}
-          CI: true
-
-      - name: Preserve iOS IPA
-        if: matrix.platform_type == 'iOS'
-        run: |
-          mkdir -p artifacts/ios
-          cp src-tauri/gen/apple/build/arm64/Sage.ipa "artifacts/ios/${{ matrix.ipa_name }}.ipa"
-
-      # On Android we need to use the NDK environment variables.
-      - name: Build with NDK
-        if: matrix.platform_name == 'Android'
-        run: ${{ matrix.build }}
-        env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
-          NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           CI: true
 
       # We don't currently do signing on other platforms
       - name: Build without secrets
-        if: ${{ !((matrix.platform_name == 'MacOS' && startsWith(github.event.ref, 'refs/tags/v')) || matrix.platform_type == 'iOS' || matrix.platform_name == 'Android') }}
-        run: ${{ matrix.build }}
+        if: ${{ !(matrix.platform_name == 'MacOS' && startsWith(github.event.ref, 'refs/tags/v')) }}
+        run: ${{ github.event_name == 'pull_request' && matrix.pr_build || matrix.build }}
         env:
           CI: true
+
+      - name: Show sccache statistics
+        run: sccache --show-stats
 
       # MacOS
       - name: Upload APP (MacOS)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'MacOS'
+        if: matrix.platform_name == 'MacOS' && github.event_name != 'pull_request'
         with:
           name: Sage.app
           path: target/universal-apple-darwin/release/bundle/macos/*.app
@@ -282,14 +272,14 @@ jobs:
 
       - name: Upload DMG (Linux x64)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Linux (x64)'
+        if: matrix.platform_name == 'Linux (x64)' && github.event_name != 'pull_request'
         with:
           name: Sage_x64.rpm
           path: target/release/bundle/rpm/*.rpm
 
       - name: Upload AppImage (Linux x64)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Linux (x64)'
+        if: matrix.platform_name == 'Linux (x64)' && github.event_name != 'pull_request'
         with:
           name: Sage_x64.AppImage
           path: target/release/bundle/appimage/*.AppImage
@@ -313,14 +303,14 @@ jobs:
 
       - name: Upload DMG (Linux ARM)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Linux (ARM)'
+        if: matrix.platform_name == 'Linux (ARM)' && github.event_name != 'pull_request'
         with:
           name: Sage_ARM64.rpm
           path: target/aarch64-unknown-linux-gnu/release/bundle/rpm/*.rpm
 
       - name: Upload AppImage (Linux ARM)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Linux (ARM)'
+        if: matrix.platform_name == 'Linux (ARM)' && github.event_name != 'pull_request'
         with:
           name: Sage_ARM64.AppImage
           path: target/aarch64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
@@ -344,7 +334,7 @@ jobs:
 
       - name: Upload EXE (Windows x64)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Windows (x64)'
+        if: matrix.platform_name == 'Windows (x64)' && github.event_name != 'pull_request'
         with:
           name: Sage_x64.exe
           path: target/release/bundle/nsis/*.exe
@@ -367,7 +357,7 @@ jobs:
 
       - name: Upload EXE (Windows ARM)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Windows (ARM)'
+        if: matrix.platform_name == 'Windows (ARM)' && github.event_name != 'pull_request'
         with:
           name: Sage_ARM64.exe
           path: target/aarch64-pc-windows-msvc/release/bundle/nsis/*.exe
@@ -380,7 +370,146 @@ jobs:
             target/aarch64-pc-windows-msvc/release/bundle/msi/*.msi
             target/aarch64-pc-windows-msvc/release/bundle/nsis/*.exe
 
-      # iOS
+  build-mobile:
+    name: ${{ matrix.platform_name }}
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: 'macos-26'
+            platform_name: iOS (TestFlight)
+            platform_type: iOS
+            cache_key: ios-testflight
+            build: 'pnpm tauri ios build --export-method app-store-connect --build-number 1'
+            disable_offers: 'false'
+            disable_options: 'false'
+            disable_swap: 'false'
+            ipa_name: Sage_TestFlight
+          - platform: 'macos-26'
+            platform_name: iOS (App Store)
+            platform_type: iOS
+            cache_key: ios-app-store
+            build: 'pnpm tauri ios build --export-method app-store-connect --build-number 2'
+            disable_offers: 'true'
+            disable_options: 'true'
+            disable_swap: 'true'
+            ipa_name: Sage_AppStore
+          - platform: 'macos-15'
+            platform_name: Android
+            platform_type: Android
+            cache_key: android
+            build: 'pnpm tauri android build'
+            pr_build: 'pnpm tauri android build --aab'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add aarch64-apple-ios
+        if: matrix.platform_type == 'iOS'
+        run: rustup target add aarch64-apple-ios
+
+      - name: Add Android targets
+        if: matrix.platform_type == 'Android'
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          key: ${{ matrix.cache_key }}
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        if: matrix.platform_type == 'Android'
+        with:
+          ndk-version: r26d
+          link-to-sdk: true
+          add-to-path: true
+
+      - name: Add NDK toolchain to path
+        if: matrix.platform_type == 'Android'
+        run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/darwin-x86_64/bin" >> $GITHUB_PATH
+        env:
+          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+
+      - name: Setup Android signing
+        if: matrix.platform_type == 'Android'
+        run: |
+          cd src-tauri/gen/android
+          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties
+          echo "password=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
+          base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
+          echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Cache PNPM dependencies
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Frontend dependencies
+        run: pnpm install
+
+      - name: Save API key to file
+        if: matrix.platform_type == 'iOS'
+        run: |
+          mkdir -p ~/private_keys
+          echo -n '${{ secrets.APPLE_API_SECRET_KEY }}' > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+
+      - name: Setup Xcode
+        if: matrix.platform_type == 'iOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.5'
+
+      - name: Verify Xcode SDK
+        if: matrix.platform_type == 'iOS'
+        run: |
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-version
+
+      - name: Build iOS
+        if: matrix.platform_type == 'iOS'
+        run: ${{ matrix.build }}
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_PATH: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+          VITE_DISABLE_OFFERS: ${{ matrix.disable_offers }}
+          VITE_DISABLE_OPTIONS: ${{ matrix.disable_options }}
+          VITE_DISABLE_SWAP: ${{ matrix.disable_swap }}
+          CI: true
+
+      - name: Preserve iOS IPA
+        if: matrix.platform_type == 'iOS'
+        run: |
+          mkdir -p artifacts/ios
+          cp src-tauri/gen/apple/build/arm64/Sage.ipa "artifacts/ios/${{ matrix.ipa_name }}.ipa"
+
+      - name: Build Android
+        if: matrix.platform_type == 'Android'
+        run: ${{ github.event_name == 'pull_request' && matrix.pr_build || matrix.build }}
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+          NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          CI: true
+
+      - name: Show sccache statistics
+        run: sccache --show-stats
+
       - name: Upload IPA (iOS)
         uses: actions/upload-artifact@v4
         if: matrix.platform_type == 'iOS'
@@ -402,24 +531,23 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
 
-      # Android
       - name: Upload AAB (Android)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Android'
+        if: matrix.platform_type == 'Android'
         with:
           name: Sage_Android.aab
           path: src-tauri/gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab
 
       - name: Upload APK (Android)
         uses: actions/upload-artifact@v4
-        if: matrix.platform_name == 'Android'
+        if: matrix.platform_type == 'Android' && github.event_name != 'pull_request'
         with:
           name: Sage_Android.apk
           path: src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk
 
       - name: Release (Android)
         uses: softprops/action-gh-release@v2
-        if: matrix.platform_name == 'Android' && startsWith(github.event.ref, 'refs/tags/v')
+        if: matrix.platform_type == 'Android' && startsWith(github.event.ref, 'refs/tags/v')
         with:
           files: |
             src-tauri/gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab

--- a/src-tauri/tauri.ci.conf.json
+++ b/src-tauri/tauri.ci.conf.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "beforeBuildCommand": ""
+  }
+}


### PR DESCRIPTION
## Summary
- use sccache for source-aware Rust compilation while retaining dependency-only Cargo caching
- build desktop assets once and reuse them across desktop targets
- use faster PR-only Rust optimization and one package format per platform while preserving every architecture
- retain full optimization and all package formats for non-PR builds

## Test plan
- [x] `pnpm prettier:check`
- [x] `pnpm lint`
- [x] `cargo fmt --all -- --files-with-diff --check`
- [x] `cargo clippy --workspace --all-features --all-targets`
- [x] `cargo test --workspace --all-features`
- [x] `pnpm build`
- [x] local Tauri debug build with prebuilt asset config
- [x] actionlint (excluding the repository's custom `linux-arm64` runner label)
- [ ] compare first and warm CI timings with the baseline run

## Dependency
Stacked on #827, which introduces the initial dependency caching and macOS bundle fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release packaging and optimization paths for PR vs tag builds; misconfigured conditionals could ship fewer artifacts on non-PR runs or skip signing/notarization expectations.
> 
> **Overview**
> Speeds up CI by **caching compiled Rust with sccache** (alongside dependency-only `rust-cache` with `cache-targets: false`) and by **building desktop frontend assets once** in `prepare-desktop-assets`, then reusing them in the desktop matrix via artifacts.
> 
> Desktop Tauri builds use **`src-tauri/tauri.ci.conf.json`** so `beforeBuildCommand` is empty and matrix jobs skip redundant `pnpm build`. **Pull requests** use looser release settings (`opt-level` 1, more codegen units), **one bundle per platform** (`pr_build`), and skip uploading extra installer formats; **tags/main-style runs** keep full optimization and all bundle types.
> 
> The monolithic build matrix is split into **`build-desktop`** and **`build-mobile`**; Android PR builds can target **AAB only** (`--aab`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee4cd351c8184e682cd4de354322d28c27cc481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->