### PR TITLE
Fix Windows incognito sandbox isolation and improve failure recovery

### DIFF
--- a/crates/sage-apps/src/runtime/start.rs
+++ b/crates/sage-apps/src/runtime/start.rs
@@ -322,7 +322,7 @@ fn build_storage(
     build_persistent_storage_target(builder, app)
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(target_os = "windows")]
 fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBuilder<Wry> {
     let builder = if app.with(|app| app.common().has_persistent_webview_storage()) {
         builder
@@ -332,7 +332,16 @@ fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBu
 
     // Incognito webviews still need their app-specific storage target. On Windows this scopes the
     // WebView2 InPrivate session so another incognito app cannot keep its in-memory data alive.
-    build_persistent_storage_target(builder, app)
+    build_windows_storage_target(builder, app)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
+fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBuilder<Wry> {
+    if app.with(|app| app.common().has_persistent_webview_storage()) {
+        builder
+    } else {
+        builder.incognito(true)
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -352,21 +361,17 @@ fn build_persistent_storage_target(
     }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-fn build_persistent_storage_target(
+#[cfg(target_os = "windows")]
+fn build_windows_storage_target(
     builder: WebviewBuilder<Wry>,
     app: &SharedSageApp,
 ) -> WebviewBuilder<Wry> {
     let storage = app.with(|app| app.storage().clone());
 
     match storage {
-        #[cfg(target_os = "windows")]
         SageAppStorage::WindowsProfile { directory_name } => {
             builder.data_directory(data_directory_for(&directory_name))
         }
-
-        #[cfg(not(target_os = "windows"))]
-        SageAppStorage::WindowsProfile { .. } => builder,
 
         SageAppStorage::AppleDataStore { .. } | SageAppStorage::Unmanaged => builder,
     }

--- a/crates/sage-apps/src/runtime/start.rs
+++ b/crates/sage-apps/src/runtime/start.rs
@@ -324,10 +324,14 @@ fn build_storage(
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBuilder<Wry> {
-    if !app.with(|app| app.common().has_persistent_webview_storage()) {
-        return builder.incognito(true);
-    }
+    let builder = if app.with(|app| app.common().has_persistent_webview_storage()) {
+        builder
+    } else {
+        builder.incognito(true)
+    };
 
+    // Incognito webviews still need their app-specific storage target. On Windows this scopes the
+    // WebView2 InPrivate session so another incognito app cannot keep its in-memory data alive.
     build_persistent_storage_target(builder, app)
 }
 

--- a/crates/sage-apps/src/sandbox/probes/isolation.rs
+++ b/crates/sage-apps/src/sandbox/probes/isolation.rs
@@ -189,27 +189,33 @@ pub(in crate::sandbox) async fn run_isolation_test(
         BUILTIN_STORAGE_ISOLATION_INCOGNITO_ID,
     ];
 
-    stop_test_apps(app, apps_state, &app_ids).await;
+    stop_test_apps(app, apps_state, &app_ids).await?;
 
     seed_host_isolation_probe(app, &run_id).await?;
 
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_STORAGE_ISOLATION_PERSISTENT_ID,
-        &[("runId", run_id.clone())],
-    )
-    .await?;
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_STORAGE_ISOLATION_INCOGNITO_ID,
-        &[("runId", run_id.clone())],
-    )
-    .await?;
+    let probe_result = async {
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_STORAGE_ISOLATION_PERSISTENT_ID,
+            &[("runId", run_id.clone())],
+        )
+        .await?;
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_STORAGE_ISOLATION_INCOGNITO_ID,
+            &[("runId", run_id.clone())],
+        )
+        .await?;
 
-    let results = poll_isolation(apps_state, &run_id, 2, 2_000).await?;
-    stop_test_apps(app, apps_state, &app_ids).await;
+        poll_isolation(apps_state, &run_id, 2, 2_000).await
+    }
+    .await;
+
+    let stop_result = stop_test_apps(app, apps_state, &app_ids).await;
+    let results = probe_result?;
+    stop_result?;
 
     let persistent = results
         .iter()

--- a/crates/sage-apps/src/sandbox/probes/network.rs
+++ b/crates/sage-apps/src/sandbox/probes/network.rs
@@ -11,25 +11,31 @@ pub(in crate::sandbox) async fn run_network_test(
     let run_id = unique_run_id("sandbox-network");
     let app_ids = [BUILTIN_NETWORK_ALLOW_A_ID, BUILTIN_NETWORK_ALLOW_B_ID];
 
-    stop_test_apps(app, apps_state, &app_ids).await;
+    stop_test_apps(app, apps_state, &app_ids).await?;
 
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_NETWORK_ALLOW_A_ID,
-        &[("runId", run_id.clone())],
-    )
-    .await?;
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_NETWORK_ALLOW_B_ID,
-        &[("runId", run_id.clone())],
-    )
-    .await?;
+    let probe_result = async {
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_NETWORK_ALLOW_A_ID,
+            &[("runId", run_id.clone())],
+        )
+        .await?;
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_NETWORK_ALLOW_B_ID,
+            &[("runId", run_id.clone())],
+        )
+        .await?;
 
-    let results = poll_network(apps_state, &run_id, 2, 4_000).await?;
-    stop_test_apps(app, apps_state, &app_ids).await;
+        poll_network(apps_state, &run_id, 2, 4_000).await
+    }
+    .await;
+
+    let stop_result = stop_test_apps(app, apps_state, &app_ids).await;
+    let results = probe_result?;
+    stop_result?;
 
     for result in &results {
         if result.data.error.is_some() {

--- a/crates/sage-apps/src/sandbox/probes/persistence.rs
+++ b/crates/sage-apps/src/sandbox/probes/persistence.rs
@@ -178,7 +178,13 @@ pub(in crate::sandbox) async fn run_persistence_test(
                     .data
                     .error
                     .clone()
-                    .unwrap_or_else(|| "Incognito read probe mismatch.".into())
+                    .unwrap_or_else(|| {
+                        format!(
+                            "Incognito read probe mismatch: localStorage present={}, IndexedDB present={}.",
+                            incognito_read.data.local_storage_present,
+                            incognito_read.data.indexed_db_present,
+                        )
+                    })
             }),
         ),
     ))

--- a/crates/sage-apps/src/sandbox/probes/persistence.rs
+++ b/crates/sage-apps/src/sandbox/probes/persistence.rs
@@ -14,25 +14,31 @@ pub(in crate::sandbox) async fn run_persistence_test(
         BUILTIN_PERSISTENCE_INCOGNITO_ID,
     ];
 
-    stop_test_apps(app, apps_state, &app_ids).await;
+    stop_test_apps(app, apps_state, &app_ids).await?;
 
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_PERSISTENCE_PERSISTENT_ID,
-        &[("runId", run_id.clone()), ("phase", "write".into())],
-    )
-    .await?;
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_PERSISTENCE_INCOGNITO_ID,
-        &[("runId", run_id.clone()), ("phase", "write".into())],
-    )
-    .await?;
+    let write_probe_result = async {
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_PERSISTENCE_PERSISTENT_ID,
+            &[("runId", run_id.clone()), ("phase", "write".into())],
+        )
+        .await?;
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_PERSISTENCE_INCOGNITO_ID,
+            &[("runId", run_id.clone()), ("phase", "write".into())],
+        )
+        .await?;
 
-    let write_results = poll_persistence_write(apps_state, &run_id, 2, 2_000).await?;
-    stop_test_apps(app, apps_state, &app_ids).await;
+        poll_persistence_write(apps_state, &run_id, 2, 2_000).await
+    }
+    .await;
+
+    let stop_result = stop_test_apps(app, apps_state, &app_ids).await;
+    let write_results = write_probe_result?;
+    stop_result?;
 
     let persistent_write = write_results
         .iter()
@@ -110,23 +116,29 @@ pub(in crate::sandbox) async fn run_persistence_test(
         ));
     }
 
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_PERSISTENCE_PERSISTENT_ID,
-        &[("runId", run_id.clone()), ("phase", "read".into())],
-    )
-    .await?;
-    start_test_app(
-        app,
-        apps_state,
-        BUILTIN_PERSISTENCE_INCOGNITO_ID,
-        &[("runId", run_id.clone()), ("phase", "read".into())],
-    )
-    .await?;
+    let read_probe_result = async {
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_PERSISTENCE_PERSISTENT_ID,
+            &[("runId", run_id.clone()), ("phase", "read".into())],
+        )
+        .await?;
+        start_test_app(
+            app,
+            apps_state,
+            BUILTIN_PERSISTENCE_INCOGNITO_ID,
+            &[("runId", run_id.clone()), ("phase", "read".into())],
+        )
+        .await?;
 
-    let read_results = poll_persistence_read(apps_state, &run_id, 2, 2_000).await?;
-    stop_test_apps(app, apps_state, &app_ids).await;
+        poll_persistence_read(apps_state, &run_id, 2, 2_000).await
+    }
+    .await;
+
+    let stop_result = stop_test_apps(app, apps_state, &app_ids).await;
+    let read_results = read_probe_result?;
+    stop_result?;
 
     let persistent_read = read_results
         .iter()

--- a/crates/sage-apps/src/sandbox/runner.rs
+++ b/crates/sage-apps/src/sandbox/runner.rs
@@ -212,12 +212,7 @@ pub async fn sandbox_runner(app: AppHandle) {
         build_effective_state(&baseline, Some(&temp_run))
     };
 
-    current_state.overall_critical_status =
-        if effective.storage_isolation_from_sage.status == SandboxCapabilityStatus::Failed {
-            SandboxCapabilityStatus::Failed
-        } else {
-            SandboxCapabilityStatus::Passed
-        };
+    current_state.overall_critical_status = overall_status(&effective);
     current_state.finished_at = Some(unix_timestamp_ms());
 
     *apps_state.sandbox.baseline.lock().await = current_state.clone();
@@ -227,9 +222,64 @@ pub async fn sandbox_runner(app: AppHandle) {
     emit_sandbox_state_changed(&app, &apps_state).await;
 }
 
+fn overall_status(state: &SandboxState) -> SandboxCapabilityStatus {
+    let statuses = [
+        state.storage_isolation_from_sage.status,
+        state.storage_persistence_normal.status,
+        state.storage_non_persistence_incognito.status,
+        state.network_allowlist_enforced.status,
+    ];
+
+    if statuses.contains(&SandboxCapabilityStatus::Failed) {
+        SandboxCapabilityStatus::Failed
+    } else if statuses.contains(&SandboxCapabilityStatus::Running) {
+        SandboxCapabilityStatus::Running
+    } else if statuses.contains(&SandboxCapabilityStatus::Pending) {
+        SandboxCapabilityStatus::Pending
+    } else {
+        SandboxCapabilityStatus::Passed
+    }
+}
+
 fn sandbox_state_is_all_pending(state: &SandboxState) -> bool {
     state.storage_isolation_from_sage.status == SandboxCapabilityStatus::Pending
         && state.storage_persistence_normal.status == SandboxCapabilityStatus::Pending
         && state.storage_non_persistence_incognito.status == SandboxCapabilityStatus::Pending
         && state.network_allowlist_enforced.status == SandboxCapabilityStatus::Pending
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::types::{build_initial_sandbox_state, mark_cap};
+
+    #[test]
+    fn overall_status_fails_when_any_capability_fails() {
+        let mut state = build_initial_sandbox_state();
+
+        for capability in [
+            SandboxCapability::StorageIsolationFromSage,
+            SandboxCapability::StoragePersistenceNormal,
+            SandboxCapability::StorageNonPersistenceIncognito,
+            SandboxCapability::NetworkAllowlistEnforced,
+        ] {
+            mark_cap(
+                &mut state,
+                capability,
+                SandboxCapabilityStatus::Passed,
+                None,
+                1,
+            );
+        }
+
+        mark_cap(
+            &mut state,
+            SandboxCapability::StorageNonPersistenceIncognito,
+            SandboxCapabilityStatus::Failed,
+            None,
+            2,
+        );
+
+        assert_eq!(overall_status(&state), SandboxCapabilityStatus::Failed);
+    }
 }

--- a/crates/sage-apps/src/sandbox/runner.rs
+++ b/crates/sage-apps/src/sandbox/runner.rs
@@ -90,118 +90,45 @@ pub async fn sandbox_runner(app: AppHandle) {
         )
     };
 
-    let isolation_fut = run_isolation_test(&app, &apps_state);
-    let persistence_fut = run_persistence_test(&app, &apps_state);
-    let network_fut = run_network_test(&app, &apps_state);
+    mark_running(
+        &mut current_state,
+        &[SandboxCapability::NetworkAllowlistEnforced],
+    );
+    update_current_run_state(&app, &apps_state, current_state.clone()).await;
 
-    tokio::pin!(isolation_fut);
-    tokio::pin!(persistence_fut);
-    tokio::pin!(network_fut);
+    // Storage probes share WebView lifecycle concerns and must not overlap each
+    // other. The network probe is independent, so keep it in a parallel lane.
+    let ((), network_result) = tokio::join!(
+        async {
+            record_single_probe_result(
+                &mut current_state,
+                SandboxCapability::StorageIsolationFromSage,
+                run_isolation_test(&app, &apps_state).await,
+            );
+            mark_running(
+                &mut current_state,
+                &[
+                    SandboxCapability::StoragePersistenceNormal,
+                    SandboxCapability::StorageNonPersistenceIncognito,
+                ],
+            );
+            update_current_run_state(&app, &apps_state, current_state.clone()).await;
 
-    let mut isolation_done = false;
-    let mut persistence_done = false;
-    let mut network_done = false;
+            record_persistence_probe_result(
+                &mut current_state,
+                run_persistence_test(&app, &apps_state).await,
+            );
+            update_current_run_state(&app, &apps_state, current_state.clone()).await;
+        },
+        run_network_test(&app, &apps_state),
+    );
 
-    while !(isolation_done && persistence_done && network_done) {
-        tokio::select! {
-            res = &mut isolation_fut, if !isolation_done => {
-                isolation_done = true;
-
-                match res {
-                    Ok((passed, details)) => {
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::StorageIsolationFromSage,
-                            if passed { SandboxCapabilityStatus::Passed } else { SandboxCapabilityStatus::Failed },
-                            details,
-                            unix_timestamp_ms(),
-                        );
-                    }
-                    Err(err) => {
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::StorageIsolationFromSage,
-                            SandboxCapabilityStatus::Failed,
-                            Some(err),
-                            unix_timestamp_ms(),
-                        );
-                    }
-                }
-
-                update_current_run_state(&app, &apps_state, current_state.clone()).await;
-            }
-
-            res = &mut persistence_fut, if !persistence_done => {
-                persistence_done = true;
-
-                match res {
-                    Ok((normal, incog)) => {
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::StoragePersistenceNormal,
-                            if normal.0 { SandboxCapabilityStatus::Passed } else { SandboxCapabilityStatus::Failed },
-                            normal.1,
-                            unix_timestamp_ms(),
-                        );
-
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::StorageNonPersistenceIncognito,
-                            if incog.0 { SandboxCapabilityStatus::Passed } else { SandboxCapabilityStatus::Failed },
-                            incog.1,
-                            unix_timestamp_ms(),
-                        );
-                    }
-                    Err(err) => {
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::StoragePersistenceNormal,
-                            SandboxCapabilityStatus::Failed,
-                            Some(err.clone()),
-                            unix_timestamp_ms(),
-                        );
-
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::StorageNonPersistenceIncognito,
-                            SandboxCapabilityStatus::Failed,
-                            Some(err),
-                            unix_timestamp_ms(),
-                        );
-                    }
-                }
-
-                update_current_run_state(&app, &apps_state, current_state.clone()).await;
-            }
-
-            res = &mut network_fut, if !network_done => {
-                network_done = true;
-
-                match res {
-                    Ok((passed, details)) => {
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::NetworkAllowlistEnforced,
-                            if passed { SandboxCapabilityStatus::Passed } else { SandboxCapabilityStatus::Failed },
-                            details,
-                            unix_timestamp_ms(),
-                        );
-                    }
-                    Err(err) => {
-                        mark_cap(
-                            &mut current_state,
-                            SandboxCapability::NetworkAllowlistEnforced,
-                            SandboxCapabilityStatus::Failed,
-                            Some(err),
-                            unix_timestamp_ms(),
-                        );
-                    }
-                }
-
-                update_current_run_state(&app, &apps_state, current_state.clone()).await;
-            }
-        }
-    }
+    record_single_probe_result(
+        &mut current_state,
+        SandboxCapability::NetworkAllowlistEnforced,
+        network_result,
+    );
+    update_current_run_state(&app, &apps_state, current_state.clone()).await;
 
     let effective = {
         let baseline = apps_state.sandbox.baseline.lock().await.clone();
@@ -220,6 +147,69 @@ pub async fn sandbox_runner(app: AppHandle) {
     *apps_state.sandbox.running.lock().await = false;
 
     emit_sandbox_state_changed(&app, &apps_state).await;
+}
+
+fn mark_running(state: &mut SandboxState, capabilities: &[SandboxCapability]) {
+    for capability in capabilities {
+        mark_cap(
+            state,
+            *capability,
+            SandboxCapabilityStatus::Running,
+            None,
+            unix_timestamp_ms(),
+        );
+    }
+}
+
+fn record_single_probe_result(
+    state: &mut SandboxState,
+    capability: SandboxCapability,
+    result: Result<(bool, Option<String>), String>,
+) {
+    let (status, details) = match result {
+        Ok((passed, details)) => (
+            if passed {
+                SandboxCapabilityStatus::Passed
+            } else {
+                SandboxCapabilityStatus::Failed
+            },
+            details,
+        ),
+        Err(err) => (SandboxCapabilityStatus::Failed, Some(err)),
+    };
+
+    mark_cap(state, capability, status, details, unix_timestamp_ms());
+}
+
+type PersistenceProbeResult = Result<((bool, Option<String>), (bool, Option<String>)), String>;
+
+fn record_persistence_probe_result(state: &mut SandboxState, result: PersistenceProbeResult) {
+    match result {
+        Ok((normal, incognito)) => {
+            record_single_probe_result(
+                state,
+                SandboxCapability::StoragePersistenceNormal,
+                Ok(normal),
+            );
+            record_single_probe_result(
+                state,
+                SandboxCapability::StorageNonPersistenceIncognito,
+                Ok(incognito),
+            );
+        }
+        Err(err) => {
+            record_single_probe_result(
+                state,
+                SandboxCapability::StoragePersistenceNormal,
+                Err(err.clone()),
+            );
+            record_single_probe_result(
+                state,
+                SandboxCapability::StorageNonPersistenceIncognito,
+                Err(err),
+            );
+        }
+    }
 }
 
 fn overall_status(state: &SandboxState) -> SandboxCapabilityStatus {

--- a/crates/sage-apps/src/sandbox/runtime.rs
+++ b/crates/sage-apps/src/sandbox/runtime.rs
@@ -1,17 +1,45 @@
 use std::collections::{BTreeMap, HashMap};
 
 use tauri::{AppHandle, State};
+use tokio::time::{Duration, sleep, timeout};
 use uuid::Uuid;
 
-use crate::{AppsHostState, close_runtime_internal, start_sandbox_test};
+use crate::{
+    AppsHostState, close_runtime_internal, find_webview_in_sage_window, start_sandbox_test,
+};
+
+const TEST_WEBVIEW_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
+const TEST_WEBVIEW_CLOSE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 pub(crate) async fn stop_test_apps(
     app: &AppHandle,
     apps_state: &State<'_, AppsHostState>,
     app_ids: &[&str],
-) {
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+
     for app_id in app_ids {
+        let webview_label = format!("app-{app_id}");
         close_runtime_internal(app, apps_state, app_id).await;
+
+        if timeout(TEST_WEBVIEW_CLOSE_TIMEOUT, async {
+            while find_webview_in_sage_window(app, &webview_label).is_some() {
+                sleep(TEST_WEBVIEW_CLOSE_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .is_err()
+        {
+            errors.push(format!(
+                "timed out waiting for sandbox test webview '{app_id}' to close"
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
     }
 }
 

--- a/crates/sage-apps/src/sandbox/types.rs
+++ b/crates/sage-apps/src/sandbox/types.rs
@@ -157,9 +157,9 @@ pub fn build_running_sandbox_state(started_at: i64) -> SandboxState {
     SandboxState {
         overall_critical_status: SandboxCapabilityStatus::Running,
         storage_isolation_from_sage: make_cap(SandboxCapabilityStatus::Running, None),
-        storage_persistence_normal: make_cap(SandboxCapabilityStatus::Running, None),
-        storage_non_persistence_incognito: make_cap(SandboxCapabilityStatus::Running, None),
-        network_allowlist_enforced: make_cap(SandboxCapabilityStatus::Running, None),
+        storage_persistence_normal: make_cap(SandboxCapabilityStatus::Pending, None),
+        storage_non_persistence_incognito: make_cap(SandboxCapabilityStatus::Pending, None),
+        network_allowlist_enforced: make_cap(SandboxCapabilityStatus::Pending, None),
         started_at: Some(started_at),
         finished_at: None,
     }

--- a/crates/sage-apps/src/security/csp.rs
+++ b/crates/sage-apps/src/security/csp.rs
@@ -8,6 +8,11 @@ fn csp_source_list(items: &[String]) -> String {
 
 pub fn build_app_csp(app: &SharedSageApp, network_id: &str) -> String {
     let mut connect_sources = BTreeSet::from(["'self'".to_string()]);
+    let mut image_sources = BTreeSet::from([
+        "'self'".to_string(),
+        "blob:".to_string(),
+        "data:".to_string(),
+    ]);
 
     app.with(|app| {
         for entry in app
@@ -15,7 +20,12 @@ pub fn build_app_csp(app: &SharedSageApp, network_id: &str) -> String {
             .network()
             .effective_whitelist_for_network(network_id)
         {
-            connect_sources.insert(entry.as_permission_string());
+            let source = entry.as_permission_string();
+            connect_sources.insert(source.clone());
+
+            if entry.scheme() == "https" {
+                image_sources.insert(source);
+            }
         }
     });
 
@@ -24,11 +34,7 @@ pub fn build_app_csp(app: &SharedSageApp, network_id: &str) -> String {
     let default_src = csp_source_list(&["'self'".to_string()]);
     let font_src = csp_source_list(&["'self'".to_string(), "data:".to_string()]);
     let frame_src = csp_source_list(&["'none'".to_string()]);
-    let img_src = csp_source_list(&[
-        "'self'".to_string(),
-        "data:".to_string(),
-        "blob:".to_string(),
-    ]);
+    let img_src = csp_source_list(&image_sources.into_iter().collect::<Vec<_>>());
     let manifest_src = csp_source_list(&["'none'".to_string()]);
     let media_src = csp_source_list(&[
         "'self'".to_string(),
@@ -105,13 +111,14 @@ mod tests {
 
     fn app_with_network_grants() -> (SharedSageApp, TempDir) {
         let shared = entry("https", "shared.example.com");
+        let shared_websocket = entry("wss", "events.example.com");
         let mainnet = entry("https", "mainnet.example.com");
         let testnet = entry("https", "testnet.example.com");
 
         let requested = SageRequestedPermissions::new(
             SageRequestedNetworkPermissions::new(
                 [],
-                [shared.clone()],
+                [shared.clone(), shared_websocket.clone()],
                 [
                     (
                         "mainnet".to_string(),
@@ -131,7 +138,7 @@ mod tests {
         let granted = SageGrantedPermissions::new(
             &requested,
             [],
-            [shared],
+            [shared, shared_websocket],
             BTreeMap::from([
                 ("mainnet".to_string(), BTreeSet::from([mainnet])),
                 ("testnet11".to_string(), BTreeSet::from([testnet])),
@@ -175,5 +182,26 @@ mod tests {
         assert!(testnet_csp.contains("https://shared.example.com"));
         assert!(testnet_csp.contains("https://testnet.example.com"));
         assert!(!testnet_csp.contains("https://mainnet.example.com"));
+    }
+
+    #[test]
+    fn csp_img_src_allows_https_sources_for_the_active_network() {
+        let (app, _dir) = app_with_network_grants();
+
+        let mainnet_csp = build_app_csp(&app, "mainnet");
+        let img_src = mainnet_csp
+            .split(';')
+            .map(str::trim)
+            .find_map(|directive| directive.strip_prefix("img-src "))
+            .expect("CSP should contain img-src");
+        let sources = img_src.split_ascii_whitespace().collect::<BTreeSet<_>>();
+
+        assert!(sources.contains("'self'"));
+        assert!(sources.contains("blob:"));
+        assert!(sources.contains("data:"));
+        assert!(sources.contains("https://shared.example.com"));
+        assert!(sources.contains("https://mainnet.example.com"));
+        assert!(!sources.contains("https://testnet.example.com"));
+        assert!(!sources.contains("wss://events.example.com"));
     }
 }

--- a/src/components/apps/AppsLaunchpad.tsx
+++ b/src/components/apps/AppsLaunchpad.tsx
@@ -2,6 +2,10 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { CorruptedAppCard } from '@/components/apps/CorruptedAppCard';
 import { AppsLaunchpadContextMenu } from '@/components/apps/AppsLaunchpadContextMenu';
 import { Button } from '@/components/ui/button';
+import {
+  getEffectiveSandboxState,
+  listSandboxCapabilities,
+} from '@/lib/apps/sandbox';
 import { formatSandboxLaunchDecision } from '@/lib/apps/sandboxPolicy';
 import {
   commands,
@@ -10,7 +14,7 @@ import {
   UserSageAppView,
 } from '@/bindings.ts';
 import { useApps } from '@/contexts/AppsContext.tsx';
-import { Plus } from 'lucide-react';
+import { Plus, TriangleAlert } from 'lucide-react';
 import { AppsPageActionsMenu } from '@/components/apps/AppsPageActionsMenu';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppTile } from '@/components/apps/AppTile';
@@ -88,6 +92,10 @@ async function openApp(appId: string) {
 
 export function AppsLaunchpad() {
   const [contextMenu, setContextMenu] = useState<AppContextMenuState>(null);
+  const [sandboxRerunPending, setSandboxRerunPending] = useState(false);
+  const [sandboxRerunError, setSandboxRerunError] = useState<string | null>(
+    null,
+  );
   const pageRef = useRef<HTMLDivElement | null>(null);
 
   const [updateCheckStateByAppId, setUpdateCheckStateByAppId] = useState<
@@ -112,8 +120,17 @@ export function AppsLaunchpad() {
     clearAppStorage,
     pendingUpdates,
     busyAppIds,
+    sandboxState,
     getLaunchGate,
   } = useApps();
+
+  const effectiveSandboxState = getEffectiveSandboxState(sandboxState);
+  const failedSandboxTestCount = effectiveSandboxState
+    ? listSandboxCapabilities(effectiveSandboxState).filter(
+        ([, result]) => result.status === 'failed',
+      ).length
+    : 0;
+  const sandboxTestsRunning = Boolean(sandboxState?.currentRun);
 
   const runningAppIds = useMemo(() => {
     return new Set(runtimes.map((runtime) => runtime.app.common.identity.id));
@@ -225,6 +242,19 @@ export function AppsLaunchpad() {
         ...prev,
         [appId]: `Update failed: ${message}`,
       }));
+    }
+  }
+
+  async function handleRerunSandboxTests() {
+    setSandboxRerunPending(true);
+    setSandboxRerunError(null);
+
+    try {
+      await commands.appsRerunSandboxTests();
+    } catch (err) {
+      setSandboxRerunError(formatErrorMessage(err));
+    } finally {
+      setSandboxRerunPending(false);
     }
   }
 
@@ -372,6 +402,41 @@ export function AppsLaunchpad() {
       </div>
 
       <div className='mx-auto w-full max-w-7xl flex-1 min-h-0 overflow-auto px-4 pb-4 md:px-6 md:pb-6'>
+        {failedSandboxTestCount > 0 ? (
+          <Alert variant='warning' className='mb-6'>
+            <TriangleAlert className='h-4 w-4' aria-hidden='true' />
+            <AlertTitle>
+              {failedSandboxTestCount} sandbox{' '}
+              {failedSandboxTestCount === 1 ? 'test' : 'tests'} failed
+            </AlertTitle>
+            <AlertDescription className='flex flex-wrap items-center justify-between gap-3'>
+              <div>
+                <p>
+                  Some apps may be blocked for your protection. Try running the
+                  sandbox tests again.
+                </p>
+                {sandboxRerunError ? (
+                  <p className='mt-1 text-destructive'>
+                    Could not re-run tests: {sandboxRerunError}
+                  </p>
+                ) : null}
+              </div>
+              <Button
+                variant='outline'
+                size='sm'
+                disabled={sandboxTestsRunning || sandboxRerunPending}
+                onClick={() => {
+                  void handleRerunSandboxTests();
+                }}
+              >
+                {sandboxTestsRunning || sandboxRerunPending
+                  ? 'Running tests…'
+                  : 'Re-run tests'}
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
         {error ? (
           <Alert className='mb-6'>
             <AlertTitle>Apps error</AlertTitle>


### PR DESCRIPTION
Fixes a WebView2 lifecycle issue that could cause the incognito storage sandbox check to fail and block affected apps.

- Isolates incognito apps with per-app WebView2 profiles
- Includes every sandbox check in the overall status
- Runs independent probes in parallel while serializing storage-related probes
- Shows a warning with a re-run action when sandbox tests fail

<img width="1102" height="98" alt="image" src="https://github.com/user-attachments/assets/6156b3be-c1cf-421f-b5e1-000bb554b1f0" />
