### PR TITLE
fix(dev): serve live system app builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use rustls::crypto::aws_lc_rs::default_provider;
 use sage::Sage;
 use sage_api::SyncEvent;
 use tauri::Manager;
-#[cfg(not(mobile))]
+#[cfg(all(not(mobile), not(debug_assertions)))]
 use tauri::path::BaseDirectory;
 use tauri_specta::{Builder, ErrorHandlingMode, collect_commands, collect_events};
 use tokio::sync::Mutex;
@@ -284,17 +284,20 @@ pub fn run() {
 
             #[cfg(not(mobile))]
             {
-                let bundled_builtin_apps = app
-                    .path()
-                    .resolve("builtin-apps", BaseDirectory::Resource)?;
+                #[cfg(not(debug_assertions))]
+                {
+                    let bundled_builtin_apps = app
+                        .path()
+                        .resolve("builtin-apps", BaseDirectory::Resource)?;
 
-                if bundled_builtin_apps.is_dir() {
-                    apps::set_builtin_apps_root(bundled_builtin_apps);
-                } else {
-                    tracing::warn!(
-                        "bundled builtin apps directory not found at {}; using development path",
-                        bundled_builtin_apps.display()
-                    );
+                    if bundled_builtin_apps.is_dir() {
+                        apps::set_builtin_apps_root(bundled_builtin_apps);
+                    } else {
+                        tracing::warn!(
+                            "bundled builtin apps directory not found at {}; using development path",
+                            bundled_builtin_apps.display()
+                        );
+                    }
                 }
 
                 let apps_db = tauri::async_runtime::block_on(apps::AppsDb::initialize(&path))


### PR DESCRIPTION
Before this change, Sage prefered built system apps even in dev mode skipping live reload path so on change it re-built then but then served stale sources