### PR TITLE
feat: allow HTTP networking for localhost apps

### DIFF
--- a/crates/sage-apps/src/lifecycle/install.rs
+++ b/crates/sage-apps/src/lifecycle/install.rs
@@ -199,6 +199,8 @@ where
     S: AppInstallSource + Send + Sync,
 {
     let manifest = source.manifest(&prepared_artifact);
+    let app_source = source.source(&prepared_artifact);
+    crate::validate_network_permissions_for_source(manifest.permissions(), &app_source)?;
 
     let snapshot_dir = fresh_snapshot_dir(&target.app_dir);
     fs::create_dir_all(&snapshot_dir)?;
@@ -223,10 +225,7 @@ where
         wallet_scope,
     )?;
 
-    Ok(UserSageApp::new_installed(
-        common,
-        source.source(&prepared_artifact),
-    ))
+    Ok(UserSageApp::new_installed(common, app_source))
 }
 
 #[cfg(test)]

--- a/crates/sage-apps/src/lifecycle/manifest.rs
+++ b/crates/sage-apps/src/lifecycle/manifest.rs
@@ -2,7 +2,8 @@ use anyhow::{Context, Result as AnyResult};
 
 use crate::{
     MANIFEST_FILE_NAME, SageAppManifestUrl, SageAppPackageManifest, SageAppPackageManifestPreview,
-    bytes_sha256_hex, download_bytes_with_limit, parse_manifest_header_v0_from_value,
+    UserSageAppSource, bytes_sha256_hex, download_bytes_with_limit,
+    parse_manifest_header_v0_from_value, validate_network_permissions_for_source,
 };
 
 const MAX_URL_MANIFEST_BYTES: u64 = 1024 * 1024;
@@ -85,6 +86,7 @@ pub fn read_manifest(package_root: &std::path::Path) -> AnyResult<SageAppPackage
                 err.inner()
             )
         })?;
+    validate_network_permissions_for_source(manifest.permissions(), &UserSageAppSource::Zip)?;
     manifest.validate_package_files(package_root)?;
 
     Ok(manifest)

--- a/crates/sage-apps/src/security/csp.rs
+++ b/crates/sage-apps/src/security/csp.rs
@@ -15,11 +15,19 @@ pub fn build_app_csp(app: &SharedSageApp, network_id: &str) -> String {
     ]);
 
     app.with(|app| {
+        let allows_http = app
+            .as_user()
+            .is_some_and(|app| app.source().allows_http_network_permissions());
+
         for entry in app
             .granted_permissions()
             .network()
             .effective_whitelist_for_network(network_id)
         {
+            if entry.scheme() == "http" && !allows_http {
+                continue;
+            }
+
             let source = entry.as_permission_string();
             connect_sources.insert(source.clone());
 
@@ -109,16 +117,27 @@ mod tests {
         .unwrap()
     }
 
-    fn app_with_network_grants() -> (SharedSageApp, TempDir) {
+    fn app_with_network_grants_for_source(
+        app_url: &str,
+        include_http: bool,
+    ) -> (SharedSageApp, TempDir) {
         let shared = entry("https", "shared.example.com");
         let shared_websocket = entry("wss", "events.example.com");
+        let local_http = entry("http", "localhost:3000");
         let mainnet = entry("https", "mainnet.example.com");
         let testnet = entry("https", "testnet.example.com");
+        let mut shared_requested = vec![shared.clone(), shared_websocket.clone()];
+        let mut shared_granted = vec![shared, shared_websocket];
+
+        if include_http {
+            shared_requested.push(local_http.clone());
+            shared_granted.push(local_http);
+        }
 
         let requested = SageRequestedPermissions::new(
             SageRequestedNetworkPermissions::new(
                 [],
-                [shared.clone(), shared_websocket.clone()],
+                shared_requested,
                 [
                     (
                         "mainnet".to_string(),
@@ -138,7 +157,7 @@ mod tests {
         let granted = SageGrantedPermissions::new(
             &requested,
             [],
-            [shared, shared_websocket],
+            shared_granted,
             BTreeMap::from([
                 ("mainnet".to_string(), BTreeSet::from([mainnet])),
                 ("testnet11".to_string(), BTreeSet::from([testnet])),
@@ -162,11 +181,15 @@ mod tests {
         let app = UserSageApp::new_installed(
             common,
             UserSageAppSource::Url {
-                app_url: SageAppUrl::parse("https://example.com/app/").unwrap(),
+                app_url: SageAppUrl::parse(app_url).unwrap(),
             },
         );
 
         (SharedSageApp::new(app.into_sage_app()), dir)
+    }
+
+    fn app_with_network_grants() -> (SharedSageApp, TempDir) {
+        app_with_network_grants_for_source("https://example.com/app/", false)
     }
 
     #[test]
@@ -203,5 +226,23 @@ mod tests {
         assert!(sources.contains("https://mainnet.example.com"));
         assert!(!sources.contains("https://testnet.example.com"));
         assert!(!sources.contains("wss://events.example.com"));
+    }
+
+    #[test]
+    fn csp_connect_src_allows_http_for_loopback_installed_apps() {
+        let (app, _dir) = app_with_network_grants_for_source("http://localhost:4173/", true);
+
+        let csp = build_app_csp(&app, "mainnet");
+
+        assert!(csp.contains("http://localhost:3000"));
+    }
+
+    #[test]
+    fn csp_connect_src_ignores_http_for_publicly_installed_apps() {
+        let (app, _dir) = app_with_network_grants_for_source("https://example.com/app/", true);
+
+        let csp = build_app_csp(&app, "mainnet");
+
+        assert!(!csp.contains("http://localhost:3000"));
     }
 }

--- a/crates/sage-apps/src/types/app/preview.rs
+++ b/crates/sage-apps/src/types/app/preview.rs
@@ -3,7 +3,7 @@ use specta::Type;
 
 use crate::{
     SageAppIconView, SageAppPackageManifest, SageAppPackageManifestPreview, SageAppUrl,
-    normalized_non_empty_string,
+    UserSageAppSource, normalized_non_empty_string, validate_network_permissions_for_source,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -55,6 +55,15 @@ impl SageAppUrlPreview {
         manifest: SageAppPackageManifestPreview,
         manifest_hash: String,
     ) -> anyhow::Result<Self> {
+        if let Some(full_manifest) = manifest.full_manifest() {
+            validate_network_permissions_for_source(
+                full_manifest.permissions(),
+                &UserSageAppSource::Url {
+                    app_url: app_url.clone(),
+                },
+            )?;
+        }
+
         let icon = SageAppIconView::from_url_preview(app_url, &manifest).await;
 
         Ok(Self {

--- a/crates/sage-apps/src/types/app/user_apps.rs
+++ b/crates/sage-apps/src/types/app/user_apps.rs
@@ -276,8 +276,19 @@ impl UserSageApp {
         }
     }
 
-    pub(crate) fn set_pending_update(&mut self, pending_update: Option<UserSageAppPendingUpdate>) {
+    pub(crate) fn set_pending_update(
+        &mut self,
+        pending_update: Option<UserSageAppPendingUpdate>,
+    ) -> anyhow::Result<()> {
+        if let Some(pending_update) = &pending_update {
+            crate::validate_network_permissions_for_source(
+                pending_update.manifest().permissions(),
+                &self.source,
+            )?;
+        }
+
         self.pending_update = pending_update;
+        Ok(())
     }
 
     pub(crate) fn common(&self) -> &SageAppCommon {
@@ -343,7 +354,7 @@ impl SageApp {
             .apply_update(pending, granted_permissions, snapshot)
             .map_err(|err| anyhow::anyhow!("failed to apply app update: {err}"))?;
 
-        app.set_pending_update(None);
+        app.set_pending_update(None)?;
 
         Ok(())
     }
@@ -400,10 +411,7 @@ impl SageApp {
         pending_update: Option<UserSageAppPendingUpdate>,
     ) -> anyhow::Result<()> {
         match self {
-            Self::User(app) => {
-                app.set_pending_update(pending_update);
-                Ok(())
-            }
+            Self::User(app) => app.set_pending_update(pending_update),
             Self::System(_) => anyhow::bail!("system app cannot have pending user update"),
         }
     }
@@ -477,13 +485,30 @@ impl<'de> Deserialize<'de> for UserSageApp {
     {
         let raw = UserSageAppRaw::deserialize(deserializer)?;
 
-        let common = raw.common.try_into().map_err(serde::de::Error::custom)?;
+        let common: SageAppCommon = raw.common.try_into().map_err(serde::de::Error::custom)?;
+
+        crate::validate_network_permissions_for_source(common.requested_permissions(), &raw.source)
+            .map_err(serde::de::Error::custom)?;
+
+        if let Some(pending_update) = &raw.pending_update {
+            crate::validate_network_permissions_for_source(
+                pending_update.manifest().permissions(),
+                &raw.source,
+            )
+            .map_err(serde::de::Error::custom)?;
+        }
 
         Ok(UserSageApp::load_persisted(
             common,
             raw.source,
             raw.pending_update,
         ))
+    }
+}
+
+impl UserSageAppSource {
+    pub(crate) fn allows_http_network_permissions(&self) -> bool {
+        matches!(self, Self::Url { app_url } if app_url.is_loopback())
     }
 }
 

--- a/crates/sage-apps/src/types/invariants/permission.rs
+++ b/crates/sage-apps/src/types/invariants/permission.rs
@@ -1,9 +1,32 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    CapabilityFlags, SageNetworkWhitelistEntry, SageRequestedCapabilities, UserBridgeCapability,
+    CapabilityFlags, SageNetworkWhitelistEntry, SageRequestedCapabilities,
+    SageRequestedPermissions, UserBridgeCapability, UserSageAppSource,
     get_user_capability_definition,
 };
+
+pub fn validate_network_permissions_for_source(
+    permissions: &SageRequestedPermissions,
+    source: &UserSageAppSource,
+) -> anyhow::Result<()> {
+    if source.allows_http_network_permissions() {
+        return Ok(());
+    }
+
+    if let Some(entry) = permissions
+        .network()
+        .all_whitelist_entries()
+        .find(|entry| entry.scheme() == "http")
+    {
+        anyhow::bail!(
+            "HTTP network permission {} is only allowed for apps installed from localhost",
+            entry.as_permission_string()
+        );
+    }
+
+    Ok(())
+}
 
 pub fn validate_permissions_policy(
     capabilities: impl IntoIterator<Item = UserBridgeCapability>,
@@ -129,4 +152,45 @@ pub fn split_required_optional_set<T: Ord>(
         .collect::<BTreeSet<_>>();
 
     (required, optional)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SageAppUrl, SageRequestedCapabilities, SageRequestedNetworkPermissions};
+
+    fn http_permissions() -> SageRequestedPermissions {
+        SageRequestedPermissions::new(
+            SageRequestedNetworkPermissions::new(
+                [SageNetworkWhitelistEntry::new("http", "localhost:3000").unwrap()],
+                [],
+                [],
+            )
+            .unwrap(),
+            SageRequestedCapabilities::empty(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn http_network_permissions_require_loopback_installed_source() {
+        let permissions = http_permissions();
+        let local_source = UserSageAppSource::Url {
+            app_url: SageAppUrl::parse("http://localhost:4173").unwrap(),
+        };
+        let public_source = UserSageAppSource::Url {
+            app_url: SageAppUrl::parse("https://example.com/app").unwrap(),
+        };
+
+        validate_network_permissions_for_source(&permissions, &local_source).unwrap();
+
+        for source in [public_source, UserSageAppSource::Zip] {
+            let err = validate_network_permissions_for_source(&permissions, &source).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("only allowed for apps installed from localhost"),
+                "unexpected error: {err}"
+            );
+        }
+    }
 }

--- a/crates/sage-apps/src/types/invariants/url.rs
+++ b/crates/sage-apps/src/types/invariants/url.rs
@@ -1,5 +1,5 @@
 use anyhow::Result as AnyResult;
-use url::Url;
+use url::{Host, Url};
 
 pub fn normalize_app_url(mut url: Url) -> AnyResult<Url> {
     validate_app_url(&url)?;
@@ -18,7 +18,7 @@ pub fn normalize_app_url(mut url: Url) -> AnyResult<Url> {
 pub fn validate_app_url(url: &Url) -> AnyResult<()> {
     match url.scheme() {
         "https" => {}
-        "http" if is_localhost(url) => {}
+        "http" if is_loopback_url(url) => {}
         scheme => {
             anyhow::bail!(
                 "unsupported app URL scheme '{scheme}', only https is allowed except http://localhost"
@@ -33,6 +33,11 @@ pub fn validate_app_url(url: &Url) -> AnyResult<()> {
     Ok(())
 }
 
-fn is_localhost(url: &Url) -> bool {
-    matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"))
+pub fn is_loopback_url(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(ip)) => ip == std::net::Ipv4Addr::LOCALHOST,
+        Some(Host::Ipv6(ip)) => ip == std::net::Ipv6Addr::LOCALHOST,
+        None => false,
+    }
 }

--- a/crates/sage-apps/src/types/network.rs
+++ b/crates/sage-apps/src/types/network.rs
@@ -46,7 +46,7 @@ impl SageNetworkWhitelistEntry {
         let host = host.into().trim().to_ascii_lowercase();
 
         if !Self::is_allowed_scheme(&scheme) {
-            anyhow::bail!("invalid scheme '{scheme}', only https and wss allowed");
+            anyhow::bail!("invalid scheme '{scheme}', only http, https, and wss allowed");
         }
 
         if !Self::is_csp_safe_host(&host) {
@@ -69,7 +69,7 @@ impl SageNetworkWhitelistEntry {
     }
 
     fn is_allowed_scheme(s: &str) -> bool {
-        matches!(s, "https" | "wss")
+        matches!(s, "http" | "https" | "wss")
     }
 
     fn is_csp_safe_host(host: &str) -> bool {
@@ -168,6 +168,16 @@ mod tests {
         ] {
             SageNetworkWhitelistEntry::new("https", host)
                 .unwrap_or_else(|err| panic!("expected {host} to be accepted: {err}"));
+        }
+
+        SageNetworkWhitelistEntry::new("http", "localhost:3000")
+            .expect("HTTP entries are validated against the app source later");
+    }
+
+    #[test]
+    fn network_entry_rejects_unsupported_schemes() {
+        for scheme in ["ftp", "file", "ws"] {
+            assert!(SageNetworkWhitelistEntry::new(scheme, "localhost:3000").is_err());
         }
     }
 

--- a/crates/sage-apps/src/types/permissions/requested.rs
+++ b/crates/sage-apps/src/types/permissions/requested.rs
@@ -258,4 +258,15 @@ impl SageRequestedNetworkPermissions {
     pub fn whitelist_by_network(&self) -> &BTreeMap<String, SageRequestedNetworkWhitelist> {
         &self.whitelist_by_network
     }
+
+    pub fn all_whitelist_entries(&self) -> impl Iterator<Item = &SageNetworkWhitelistEntry> {
+        self.whitelist
+            .required()
+            .chain(self.whitelist.optional())
+            .chain(
+                self.whitelist_by_network
+                    .values()
+                    .flat_map(|whitelist| whitelist.required().chain(whitelist.optional())),
+            )
+    }
 }

--- a/crates/sage-apps/src/types/url.rs
+++ b/crates/sage-apps/src/types/url.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use specta::Type;
 use url::Url;
 
-use crate::{normalize_app_url, slugify_app_name};
+use crate::{is_loopback_url, normalize_app_url, slugify_app_name};
 
 pub const MANIFEST_FILE_NAME: &str = "sage-manifest.json";
 
@@ -42,6 +42,10 @@ impl SageAppUrl {
 
     pub fn as_bytes(&self) -> &[u8] {
         self.as_str().as_bytes()
+    }
+
+    pub fn is_loopback(&self) -> bool {
+        is_loopback_url(&self.0)
     }
 
     pub fn into_string(self) -> String {
@@ -124,6 +128,19 @@ mod tests {
     fn app_url_allows_loopback_http() {
         let out = SageAppUrl::parse("http://127.0.0.1:4173").unwrap();
         assert_eq!(out.as_str(), "http://127.0.0.1:4173/");
+        assert!(out.is_loopback());
+    }
+
+    #[test]
+    fn app_url_identifies_localhost_over_https_as_loopback() {
+        let out = SageAppUrl::parse("https://localhost:4173").unwrap();
+        assert!(out.is_loopback());
+    }
+
+    #[test]
+    fn app_url_identifies_public_https_as_non_loopback() {
+        let out = SageAppUrl::parse("https://example.com/app").unwrap();
+        assert!(!out.is_loopback());
     }
 
     #[test]
@@ -133,6 +150,7 @@ mod tests {
             .to_string();
 
         assert!(err.contains("requires HTTPS") || err.contains("only https"));
+        assert!(SageAppUrl::parse("http://127.0.0.2/app").is_err());
     }
 
     #[test]

--- a/packages/sage-app-ui/src/components/PermissionsEditor/PermissionRow.tsx
+++ b/packages/sage-app-ui/src/components/PermissionsEditor/PermissionRow.tsx
@@ -47,11 +47,15 @@ export function PermissionRow({
   ) => void;
 }) {
   if (entry.kind === 'network') {
-    const visibleSchemes = (['https', 'wss'] as const).filter(
+    const visibleSchemes = (['http', 'https', 'wss'] as const).filter(
       (scheme) => entry.schemes[scheme].visible,
     );
 
-    const primaryScheme = visibleSchemes.includes('wss') ? 'wss' : 'https';
+    const primaryScheme = visibleSchemes.includes('wss')
+      ? 'wss'
+      : visibleSchemes.includes('https')
+        ? 'https'
+        : 'http';
     const primaryState = entry.schemes[primaryScheme];
     const checkboxDisabled = !editable || primaryState.disabled;
 

--- a/packages/sage-app-ui/src/components/PermissionsEditor/PermissionsEditor.tsx
+++ b/packages/sage-app-ui/src/components/PermissionsEditor/PermissionsEditor.tsx
@@ -370,8 +370,17 @@ export function PermissionEditor({
       nextKeys.add(networkKey(requiredEntry));
     }
 
+    const httpKey = `http://${entry.host}`;
     const httpsKey = `https://${entry.host}`;
     const wssKey = `wss://${entry.host}`;
+
+    if (scheme === 'http') {
+      if (nextGranted) {
+        nextKeys.add(httpKey);
+      } else {
+        nextKeys.delete(httpKey);
+      }
+    }
 
     if (scheme === 'https') {
       if (nextGranted) {

--- a/packages/sage-app-ui/src/components/PermissionsEditor/permissionEntries.ts
+++ b/packages/sage-app-ui/src/components/PermissionsEditor/permissionEntries.ts
@@ -107,16 +107,23 @@ export function buildNetworkEntries(
   const entries: PermissionEntry[] = [];
 
   for (const host of hosts) {
+    const httpKey = schemeKey('http', host);
     const httpsKey = schemeKey('https', host);
     const wssKey = schemeKey('wss', host);
+    const httpRequested =
+      requiredKeys.has(httpKey) || optionalKeys.has(httpKey);
     const httpsRequested =
       requiredKeys.has(httpsKey) || optionalKeys.has(httpsKey);
     const wssRequested = requiredKeys.has(wssKey) || optionalKeys.has(wssKey);
     const hostHasRequired =
-      requiredKeys.has(httpsKey) || requiredKeys.has(wssKey);
+      requiredKeys.has(httpKey) ||
+      requiredKeys.has(httpsKey) ||
+      requiredKeys.has(wssKey);
 
     if (section === 'required' && !hostHasRequired) continue;
     if (section === 'optional' && hostHasRequired) continue;
+    const httpRequired = requiredKeys.has(httpKey);
+    const httpGranted = httpRequired || grantedKeys.has(httpKey);
     const wssRequired = requiredKeys.has(wssKey);
     const wssGranted = wssRequired || grantedKeys.has(wssKey);
     const httpsRequired = requiredKeys.has(httpsKey);
@@ -128,6 +135,14 @@ export function buildNetworkEntries(
       NetworkPermissionScheme,
       NetworkPermissionSchemeState
     > = {
+      http: {
+        scheme: 'http',
+        key: httpKey,
+        required: httpRequired,
+        granted: httpGranted,
+        disabled: httpRequired,
+        visible: httpRequested,
+      },
       https: {
         scheme: 'https',
         key: httpsKey,
@@ -156,7 +171,7 @@ export function buildNetworkEntries(
       label: host,
       description: null,
       required: hostHasRequired,
-      granted: httpsGranted || wssGranted,
+      granted: httpGranted || httpsGranted || wssGranted,
       sensitivityRank: 1,
       schemes,
     });
@@ -184,7 +199,7 @@ export function sortPermissionEntries(
 function isSupportedNetworkScheme(
   scheme: string,
 ): scheme is NetworkPermissionScheme {
-  return scheme === 'https' || scheme === 'wss';
+  return scheme === 'http' || scheme === 'https' || scheme === 'wss';
 }
 
 function makeNetworkEntry(

--- a/packages/sage-app-ui/src/components/PermissionsEditor/types.ts
+++ b/packages/sage-app-ui/src/components/PermissionsEditor/types.ts
@@ -1,6 +1,6 @@
 import type { UserBridgeCapability } from 'sage-system-app-sdk';
 
-export type NetworkPermissionScheme = 'https' | 'wss';
+export type NetworkPermissionScheme = 'http' | 'https' | 'wss';
 
 export interface NetworkPermissionSchemeState {
   scheme: NetworkPermissionScheme;


### PR DESCRIPTION
This lets apps use HTTP for network calls, but only when the app itself is installed from localhost or another loopback address. This makes local development possible without requiring HTTPS certificates for both the app and its backend. Apps installed from public addresses cannot request HTTP network access.