### PR TITLE
transaction management and maintenance optimizations

### DIFF
--- a/crates/sage-database/src/lib.rs
+++ b/crates/sage-database/src/lib.rs
@@ -25,7 +25,15 @@ impl Database {
         Self { pool }
     }
 
+    /// Begins a transaction that may write.
     pub async fn tx(&self) -> Result<DatabaseTx<'_>> {
+        let tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        Ok(DatabaseTx::new(tx))
+    }
+
+    /// Begins a read-only transaction, for callers that need several reads to see
+    /// a consistent snapshot but never write.
+    pub async fn read_tx(&self) -> Result<DatabaseTx<'_>> {
         let tx = self.pool.begin().await?;
         Ok(DatabaseTx::new(tx))
     }

--- a/crates/sage-database/src/maintenance.rs
+++ b/crates/sage-database/src/maintenance.rs
@@ -65,6 +65,20 @@ impl Database {
         })
     }
 
+    /// Recomputes query planner statistics for every table.
+    pub async fn analyze(&self) -> Result<()> {
+        // `analysis_limit` is per-connection, so it has to be set on the same
+        // connection as the `ANALYZE` it bounds.
+        let mut conn = self.pool.acquire().await?;
+
+        sqlx::query("PRAGMA analysis_limit = 400")
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query("ANALYZE").execute(&mut *conn).await?;
+
+        Ok(())
+    }
+
     pub async fn perform_sqlite_maintenance(&self, force_vacuum: bool) -> Result<MaintenanceStats> {
         let vacuum = if force_vacuum {
             Vacuum::Always

--- a/crates/sage-database/src/maintenance.rs
+++ b/crates/sage-database/src/maintenance.rs
@@ -66,6 +66,16 @@ impl Database {
     }
 
     pub async fn perform_sqlite_maintenance(&self, force_vacuum: bool) -> Result<MaintenanceStats> {
+        let vacuum = if force_vacuum {
+            Vacuum::Always
+        } else {
+            Vacuum::IfNeeded
+        };
+
+        self.maintenance(vacuum).await
+    }
+
+    async fn maintenance(&self, vacuum: Vacuum) -> Result<MaintenanceStats> {
         let total_start = Instant::now();
         let mut stats = MaintenanceStats {
             vacuum_duration_ms: 0,
@@ -108,14 +118,16 @@ impl Database {
             }
         }
 
-        // 3. Check if VACUUM is needed (unless forced)
-        let should_vacuum = if force_vacuum {
-            true
-        } else {
-            let db_stats = self.get_database_stats().await?;
+        // 3. Check if VACUUM is needed (unless forced or skipped entirely)
+        let should_vacuum = match vacuum {
+            Vacuum::Never => false,
+            Vacuum::Always => true,
+            Vacuum::IfNeeded => {
+                let db_stats = self.get_database_stats().await?;
 
-            // VACUUM if more than 10% free space or more than 1000 free pages
-            db_stats.free_percentage > 10.0 || db_stats.free_pages > 1000
+                // VACUUM if more than 10% free space or more than 1000 free pages
+                db_stats.free_percentage > 10.0 || db_stats.free_pages > 1000
+            }
         };
 
         // 4. Perform VACUUM if needed
@@ -158,18 +170,24 @@ impl Database {
         Ok(stats)
     }
 
-    /// Performs a quick maintenance routine suitable for regular automated runs
-    ///
-    /// This is a lighter version that only runs ANALYZE and WAL checkpoint,
-    /// skipping VACUUM unless specifically needed.
+    /// Runs `ANALYZE` and a WAL checkpoint, never `VACUUM`.
     pub async fn perform_quick_maintenance(&self) -> Result<MaintenanceStats> {
-        self.perform_sqlite_maintenance(false).await
+        self.maintenance(Vacuum::Never).await
     }
 
     /// Performs a full maintenance routine including forced VACUUM
-    ///
-    /// This is suitable for periodic deep maintenance (e.g., weekly or monthly)
     pub async fn perform_full_maintenance(&self) -> Result<MaintenanceStats> {
-        self.perform_sqlite_maintenance(true).await
+        self.maintenance(Vacuum::Always).await
     }
+}
+
+/// Whether a maintenance run is allowed to `VACUUM`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Vacuum {
+    /// Skip `VACUUM` entirely, whatever the free page count.
+    Never,
+    /// `VACUUM` only when enough free space has accumulated to be worth reclaiming.
+    IfNeeded,
+    /// Always `VACUUM`.
+    Always,
 }

--- a/crates/sage-wallet/src/sync_manager.rs
+++ b/crates/sage-wallet/src/sync_manager.rs
@@ -506,6 +506,10 @@ impl SyncManager {
     }
 
     async fn poll_tasks(&mut self) {
+        // Set when initial sync just finished, so the analyze below happens after
+        // the borrow of `initial_wallet_sync` has been released.
+        let mut initial_sync_completed = false;
+
         if let InitialWalletSync::Syncing { ip, task } = &mut self.initial_wallet_sync
             && let Ok(Some(result)) = timeout(Duration::from_secs(1), poll_once(task)).await
         {
@@ -513,6 +517,7 @@ impl SyncManager {
                 Ok(Ok(())) => {
                     self.initial_wallet_sync = InitialWalletSync::Subscribed(*ip);
                     self.event_sender.send(SyncEvent::Subscribed).await.ok();
+                    initial_sync_completed = true;
                 }
                 Ok(Err(error)) => {
                     warn!("Initial wallet sync failed: {error}");
@@ -635,6 +640,16 @@ impl SyncManager {
                     self.blocktime_queue_task = None;
                 }
                 None => {}
+            }
+        }
+
+        // The startup analyze writes nothing for a wallet whose tables were still
+        // empty, so a first sync would otherwise run with no statistics at all.
+        if initial_sync_completed && let Some(wallet) = self.wallet.clone() {
+            if let Err(error) = wallet.db.analyze().await {
+                warn!("Failed to refresh query planner statistics: {error}");
+            } else {
+                info!("Refreshed query planner statistics after initial sync");
             }
         }
     }

--- a/crates/sage-wallet/src/wallet/derivations.rs
+++ b/crates/sage-wallet/src/wallet/derivations.rs
@@ -52,7 +52,7 @@ impl Wallet {
         hardened: bool,
         reuse: bool,
     ) -> Result<Vec<Bytes32>, WalletError> {
-        let mut tx = self.db.tx().await?;
+        let mut tx = self.db.read_tx().await?;
 
         let unused_index = tx.unused_derivation_index(hardened).await?;
         let next_index = tx.derivation_index(hardened).await?;

--- a/crates/sage/src/endpoints/keys.rs
+++ b/crates/sage/src/endpoints/keys.rs
@@ -452,7 +452,7 @@ impl Sage {
 
         let pool = self.connect_to_pool(db_path).await?;
         let db = Database::new(pool);
-        let mut tx = db.tx().await?;
+        let mut tx = db.read_tx().await?;
         let index = tx.unused_derivation_index(hardened).await?;
         Ok(tx.custody_p2_puzzle_hash(index, hardened).await.ok())
     }

--- a/crates/sage/src/sage.rs
+++ b/crates/sage/src/sage.rs
@@ -542,20 +542,9 @@ impl Sage {
 
 /// Refreshes the query planner's table statistics.
 async fn update_query_planner_stats(pool: &SqlitePool) {
-    let mut conn = match pool.acquire().await {
-        Ok(conn) => conn,
-        Err(error) => {
-            warn!("Could not acquire a connection to update query planner stats: {error}");
-            return;
-        }
-    };
-
-    for statement in ["PRAGMA analysis_limit = 400", "PRAGMA optimize"] {
-        if let Err(error) = sqlx::query(statement).execute(&mut *conn).await {
-            warn!("Failed to update query planner stats via `{statement}`: {error}");
-            return;
-        }
+    if let Err(error) = Database::new(pool.clone()).analyze().await {
+        warn!("Failed to update query planner stats: {error}");
+    } else {
+        info!("Updated database query planner statistics");
     }
-
-    info!("Updated database query planner statistics");
 }

--- a/crates/sage/src/sage.rs
+++ b/crates/sage/src/sage.rs
@@ -25,7 +25,7 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
 };
 use tokio::sync::{Mutex, mpsc};
-use tracing::{Level, error, info};
+use tracing::{Level, error, info, warn};
 use tracing_appender::rolling::{Builder, Rotation};
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, filter::filter_fn, fmt, layer::SubscriberExt,
@@ -454,6 +454,8 @@ impl Sage {
             return Err(Error::DatabaseVersionTooOld);
         }
 
+        update_query_planner_stats(&pool).await;
+
         Ok(pool)
     }
 
@@ -536,4 +538,24 @@ impl Sage {
         fs::write(self.path.join("keys.bin"), self.keychain.to_bytes()?)?;
         Ok(())
     }
+}
+
+/// Refreshes the query planner's table statistics.
+async fn update_query_planner_stats(pool: &SqlitePool) {
+    let mut conn = match pool.acquire().await {
+        Ok(conn) => conn,
+        Err(error) => {
+            warn!("Could not acquire a connection to update query planner stats: {error}");
+            return;
+        }
+    };
+
+    for statement in ["PRAGMA analysis_limit = 400", "PRAGMA optimize"] {
+        if let Err(error) = sqlx::query(statement).execute(&mut *conn).await {
+            warn!("Failed to update query planner stats via `{statement}`: {error}");
+            return;
+        }
+    }
+
+    info!("Updated database query planner statistics");
 }

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashSet, future, sync::Arc, time::Duration};
 
 use sage::{Result, Sage};
 use sage_api::SyncEvent as ApiEvent;
@@ -8,7 +8,55 @@ use sage_wallet::SyncEvent;
 #[cfg(not(mobile))]
 use tauri::Manager;
 use tauri::{AppHandle, Emitter};
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::Mutex,
+    task::JoinHandle,
+    time::{Instant, sleep_until},
+};
+
+/// How long a burst of refresh events is collected before being emitted.
+const REFRESH_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// Refresh events, which tell the frontend "this kind of data changed, refetch".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RefreshEvent {
+    Derivation,
+    CoinState,
+    PuzzleBatchSynced,
+    CatInfo,
+    DidInfo,
+    NftData,
+}
+
+impl RefreshEvent {
+    /// Returns `None` for events that must be delivered as they happen, either
+    /// because they carry a payload or because they are one-off state changes.
+    fn from_api_event(event: &ApiEvent) -> Option<Self> {
+        match event {
+            ApiEvent::Derivation => Some(Self::Derivation),
+            ApiEvent::CoinState => Some(Self::CoinState),
+            ApiEvent::PuzzleBatchSynced => Some(Self::PuzzleBatchSynced),
+            ApiEvent::CatInfo => Some(Self::CatInfo),
+            ApiEvent::DidInfo => Some(Self::DidInfo),
+            ApiEvent::NftData => Some(Self::NftData),
+            ApiEvent::Start { .. }
+            | ApiEvent::Stop
+            | ApiEvent::Subscribed
+            | ApiEvent::TransactionFailed { .. } => None,
+        }
+    }
+
+    fn into_api_event(self) -> ApiEvent {
+        match self {
+            Self::Derivation => ApiEvent::Derivation,
+            Self::CoinState => ApiEvent::CoinState,
+            Self::PuzzleBatchSynced => ApiEvent::PuzzleBatchSynced,
+            Self::CatInfo => ApiEvent::CatInfo,
+            Self::DidInfo => ApiEvent::DidInfo,
+            Self::NftData => ApiEvent::NftData,
+        }
+    }
+}
 
 pub struct Initialized(pub Mutex<bool>);
 
@@ -20,37 +68,69 @@ pub async fn initialize(app_handle: AppHandle, sage: &mut Sage) -> Result<()> {
     let mut receiver = sage.initialize().await?;
 
     tokio::spawn(async move {
-        while let Some(event) = receiver.recv().await {
-            #[cfg(not(mobile))]
-            if let SyncEvent::NetworkChanged { .. } = &event {
-                let apps_state = app_handle.state::<AppsHostState>();
+        let mut pending = HashSet::new();
+        let mut flush_at: Option<Instant> = None;
 
-                process_sage_network_change(&app_handle, &apps_state).await;
-            }
-            let event = match event {
-                SyncEvent::Start(ip) => ApiEvent::Start { ip: ip.to_string() },
-                SyncEvent::Stop => ApiEvent::Stop,
-                SyncEvent::Subscribed => ApiEvent::Subscribed,
-                SyncEvent::DerivationIndex { .. } => ApiEvent::Derivation,
-                SyncEvent::TransactionFailed {
-                    transaction_id,
-                    error,
-                } => ApiEvent::TransactionFailed {
-                    transaction_id: transaction_id.to_string(),
-                    error,
-                },
-                // TODO: New event?
-                SyncEvent::CoinsUpdated
-                | SyncEvent::TransactionUpdated { .. }
-                | SyncEvent::OfferUpdated { .. } => ApiEvent::CoinState,
-                SyncEvent::PuzzleBatchSynced => ApiEvent::PuzzleBatchSynced,
-                SyncEvent::CatInfo => ApiEvent::CatInfo,
-                SyncEvent::DidInfo => ApiEvent::DidInfo,
-                SyncEvent::NftData => ApiEvent::NftData,
-                SyncEvent::NetworkChanged { .. } => continue,
+        loop {
+            // Only wait on a deadline when a burst is actually in flight.
+            let flush = async {
+                match flush_at {
+                    Some(deadline) => sleep_until(deadline).await,
+                    None => future::pending().await,
+                }
             };
-            if app_handle.emit("sync-event", event).is_err() {
-                break;
+
+            tokio::select! {
+                received = receiver.recv() => {
+                    let Some(event) = received else {
+                        break;
+                    };
+
+                    #[cfg(not(mobile))]
+                    if let SyncEvent::NetworkChanged { .. } = &event {
+                        let apps_state = app_handle.state::<AppsHostState>();
+
+                        process_sage_network_change(&app_handle, &apps_state).await;
+                    }
+                    let event = match event {
+                        SyncEvent::Start(ip) => ApiEvent::Start { ip: ip.to_string() },
+                        SyncEvent::Stop => ApiEvent::Stop,
+                        SyncEvent::Subscribed => ApiEvent::Subscribed,
+                        SyncEvent::DerivationIndex { .. } => ApiEvent::Derivation,
+                        SyncEvent::TransactionFailed {
+                            transaction_id,
+                            error,
+                        } => ApiEvent::TransactionFailed {
+                            transaction_id: transaction_id.to_string(),
+                            error,
+                        },
+                        // TODO: New event?
+                        SyncEvent::CoinsUpdated
+                        | SyncEvent::TransactionUpdated { .. }
+                        | SyncEvent::OfferUpdated { .. } => ApiEvent::CoinState,
+                        SyncEvent::PuzzleBatchSynced => ApiEvent::PuzzleBatchSynced,
+                        SyncEvent::CatInfo => ApiEvent::CatInfo,
+                        SyncEvent::DidInfo => ApiEvent::DidInfo,
+                        SyncEvent::NftData => ApiEvent::NftData,
+                        SyncEvent::NetworkChanged { .. } => continue,
+                    };
+
+                    if let Some(refresh) = RefreshEvent::from_api_event(&event) {
+                        pending.insert(refresh);
+                        flush_at.get_or_insert_with(|| Instant::now() + REFRESH_DEBOUNCE);
+                    } else if app_handle.emit("sync-event", event).is_err() {
+                        break;
+                    }
+                }
+                () = flush => {
+                    flush_at = None;
+
+                    for refresh in pending.drain() {
+                        if app_handle.emit("sync-event", refresh.into_api_event()).is_err() {
+                            return Result::Ok(());
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This PR includes a handful of optimizations to database transaction handling and sync events

- For database calls that will write, open with `BEGIN IMMEDIATE` to take a RESERVED lock immediately avoiding a lock upgrade. We currently use a SAHRED lock for all read and write transactions, which introduces and contention mediation when they need to be upgrade by a write operation.
  - the upshot is that database operations should differentiate between `db.tx()` and `db.read_tx()` to benefit from this optimization 
- added debounce to app_state eventing to reduce `event -> ui -> refetch` loops. This reduces the amount of traffic in the database and the amount of lock contention during the sync
- update table stats at wallet login. This trades about 10-100ms at startup for automatically tuning the database instead of expecting the user to know what the Optimize button does and when to use it.
- recalculate stats after sync completes

an additional possible optimization for initial sync:
- An empty database has no stats and as it fills during a long sync, queries will not be optimized, since stats only happens after the sync finishes or the app restarts. For a large wallet this makes the sync progressively slower. We could add a background stats job or trigger on number of writes or something. It might not be worth the added complexity.