### PR TITLE
Support isolated Sage data roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,12 +6596,12 @@ version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs 5.0.1",
  "rustls",
  "sage",
  "sage-api",
  "sage-api-macro",
  "sage-client",
+ "sage-config",
  "sage-rpc",
  "serde",
  "serde_json",
@@ -6612,7 +6612,6 @@ dependencies = [
 name = "sage-client"
 version = "0.13.0"
 dependencies = [
- "dirs 5.0.1",
  "reqwest 0.12.24",
  "sage-api",
  "sage-api-macro",
@@ -6628,6 +6627,7 @@ name = "sage-config"
 version = "0.13.0"
 dependencies = [
  "chia-wallet-sdk",
+ "dirs 5.0.1",
  "expect-test",
  "hex",
  "indexmap 2.12.1",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ pnpm tauri:dev
 pnpm tauri:dev --release
 ```
 
+Set `SAGE_ROOT` to keep an instance's configuration, certificates, wallets, and
+installed apps in a custom directory:
+
+```bash
+SAGE_ROOT=/tmp/sage-profile-a pnpm tauri:dev
+SAGE_ROOT=/tmp/sage-profile-b pnpm tauri:dev
+```
+
+The installed desktop binary and the `sage rpc` commands use the same variable.
+When running multiple RPC servers, configure a different RPC port in each
+root's `config.toml`.
+
 And build the application with:
 
 ```bash

--- a/crates/sage-apps/src/bridge/methods/user/app.rs
+++ b/crates/sage-apps/src/bridge/methods/user/app.rs
@@ -16,14 +16,8 @@ pub(crate) use request_permission_grants::*;
 
 use std::path::PathBuf;
 
-use tauri::Manager;
+use crate::BridgeTools;
 
-use crate::{BridgeMethodHandleError, BridgeTools};
-
-pub(crate) fn resolve_app_base_path(
-    tools: &BridgeTools<'_>,
-) -> Result<PathBuf, BridgeMethodHandleError> {
-    tools.app_handle.path().app_data_dir().map_err(|err| {
-        BridgeMethodHandleError::internal_error(format!("failed to resolve app data dir: {err}"))
-    })
+pub(crate) fn resolve_app_base_path(tools: &BridgeTools<'_>) -> PathBuf {
+    tools.host_state.root.clone()
 }

--- a/crates/sage-apps/src/bridge/methods/user/app/request_capability_grant.rs
+++ b/crates/sage-apps/src/bridge/methods/user/app/request_capability_grant.rs
@@ -90,7 +90,7 @@ impl BridgeMethod for AppRequestCapabilityGrant {
 
         ensure_capability_requestable_by_app(params.capability)?;
 
-        let base_path = resolve_app_base_path(&tools)?;
+        let base_path = resolve_app_base_path(&tools);
 
         let result = match grant_capability(
             tools.app_handle,

--- a/crates/sage-apps/src/bridge/methods/user/app/request_network_whitelist_grant.rs
+++ b/crates/sage-apps/src/bridge/methods/user/app/request_network_whitelist_grant.rs
@@ -91,7 +91,7 @@ impl BridgeMethod for AppRequestNetworkWhitelistGrant {
     ) -> BridgeHandleResult {
         let params: RequestNetworkWhitelistGrantParams = parse_required_params(self, request)?;
 
-        let base_path = resolve_app_base_path(&tools)?;
+        let base_path = resolve_app_base_path(&tools);
 
         let grant_result = grant_network_whitelist_entry(
             tools.app_handle,

--- a/crates/sage-apps/src/host.rs
+++ b/crates/sage-apps/src/host.rs
@@ -1,6 +1,9 @@
-use std::collections::{HashMap, HashSet};
-use std::fmt;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    path::PathBuf,
+    sync::Arc,
+};
 
 use parking_lot::RwLock;
 use sage::Sage;
@@ -15,6 +18,7 @@ pub type AppState = Arc<Mutex<Sage>>;
 
 #[derive(Debug)]
 pub struct AppsHostState {
+    pub(crate) root: PathBuf,
     pub app_operation_locks: RwLock<HashMap<String, Arc<Mutex<()>>>>,
     pub app_update_locks: RwLock<HashSet<String>>,
     pub runtime: AppRuntimeState,
@@ -25,8 +29,9 @@ pub struct AppsHostState {
 }
 
 impl AppsHostState {
-    pub fn new(db: AppsDb) -> Self {
+    pub fn new(root: PathBuf, db: AppsDb) -> Self {
         Self {
+            root,
             app_operation_locks: RwLock::default(),
             app_update_locks: RwLock::default(),
             runtime: AppRuntimeState::default(),

--- a/crates/sage-apps/src/lifecycle/storage.rs
+++ b/crates/sage-apps/src/lifecycle/storage.rs
@@ -165,7 +165,8 @@ pub async fn process_pending_storage_cleanup(app: &AppHandle, _base_path: &Path)
                     .map_err(anyhow::Error::msg)?;
 
                 #[cfg(target_os = "windows")]
-                clear_app_storage_by_target(app, &target.storage).map_err(anyhow::Error::msg)?;
+                clear_app_storage_by_target(app, _base_path, &target.storage)
+                    .map_err(anyhow::Error::msg)?;
 
                 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
                 clear_app_storage_by_target(app, &target.storage);
@@ -216,17 +217,13 @@ pub async fn clear_app_storage_by_target(
 #[cfg(target_os = "windows")]
 pub fn clear_app_storage_by_target(
     _app: &AppHandle,
+    base_path: &Path,
     target: &SageAppStorage,
 ) -> Result<(), String> {
     match target {
         #[cfg(target_os = "windows")]
         SageAppStorage::WindowsProfile { directory_name } => {
-            let app_data_dir = _app
-                .path()
-                .app_data_dir()
-                .map_err(|e| format!("failed to resolve app data dir: {e}"))?;
-
-            let profile_dir = app_data_dir.join(data_directory_for(directory_name));
+            let profile_dir = base_path.join(data_directory_for(directory_name));
 
             match fs::remove_dir_all(&profile_dir) {
                 Ok(()) => {}
@@ -266,12 +263,7 @@ pub(crate) async fn rotate_app_storage_and_origin(
 ) -> Result<(), String> {
     let app_id = app.id();
 
-    let base_path = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|err| format!("failed to resolve app data dir: {err}"))?;
-
-    let next_storage = allocate_new_storage(app_handle, apps_state, &base_path)
+    let next_storage = allocate_new_storage(app_handle, apps_state, &apps_state.root)
         .await
         .map_err(|err| format!("failed to allocate rotated storage: {err}"))?;
 

--- a/crates/sage-apps/src/runtime/start.rs
+++ b/crates/sage-apps/src/runtime/start.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::Path};
 
 use specta::Type;
 use tauri::webview::NewWindowResponse;
@@ -205,10 +205,10 @@ async fn create_runtime_for_app(
     let builder = build_initialization_script(builder);
 
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    let builder = build_storage(builder, &app)?;
+    let builder = build_storage(builder, &app, &apps_state.root)?;
 
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    let builder = build_storage(builder, &app);
+    let builder = build_storage(builder, &app, &apps_state.root);
 
     let (x, y, width, height) = if args.debug_layout {
         debug_layout_for_app(&app.id())
@@ -315,6 +315,7 @@ async fn rotate_incognito_app_storage_and_origin_if_needed(
 fn build_storage(
     builder: WebviewBuilder<Wry>,
     app: &SharedSageApp,
+    _root: &Path,
 ) -> Result<WebviewBuilder<Wry>, String> {
     if !app.with(|app| app.common().has_persistent_webview_storage()) {
         return Ok(builder.incognito(true));
@@ -324,7 +325,11 @@ fn build_storage(
 }
 
 #[cfg(target_os = "windows")]
-fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBuilder<Wry> {
+fn build_storage(
+    builder: WebviewBuilder<Wry>,
+    app: &SharedSageApp,
+    root: &Path,
+) -> WebviewBuilder<Wry> {
     let builder = if app.with(|app| app.common().has_persistent_webview_storage()) {
         builder
     } else {
@@ -333,11 +338,15 @@ fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBu
 
     // Incognito webviews still need their app-specific storage target. On Windows this scopes the
     // WebView2 InPrivate session so another incognito app cannot keep its in-memory data alive.
-    build_windows_storage_target(builder, app)
+    build_windows_storage_target(builder, app, root)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
-fn build_storage(builder: WebviewBuilder<Wry>, app: &SharedSageApp) -> WebviewBuilder<Wry> {
+fn build_storage(
+    builder: WebviewBuilder<Wry>,
+    app: &SharedSageApp,
+    _root: &Path,
+) -> WebviewBuilder<Wry> {
     if app.with(|app| app.common().has_persistent_webview_storage()) {
         builder
     } else {
@@ -366,12 +375,13 @@ fn build_persistent_storage_target(
 fn build_windows_storage_target(
     builder: WebviewBuilder<Wry>,
     app: &SharedSageApp,
+    root: &Path,
 ) -> WebviewBuilder<Wry> {
     let storage = app.with(|app| app.storage().clone());
 
     match storage {
         SageAppStorage::WindowsProfile { directory_name } => {
-            builder.data_directory(data_directory_for(&directory_name))
+            builder.data_directory(root.join(data_directory_for(&directory_name)))
         }
 
         SageAppStorage::AppleDataStore { .. } | SageAppStorage::Unmanaged => builder,

--- a/crates/sage-cli/Cargo.toml
+++ b/crates/sage-cli/Cargo.toml
@@ -24,7 +24,7 @@ sage-api = { workspace = true }
 sage-api-macro = { workspace = true }
 sage-rpc = { workspace = true }
 sage-client = { workspace = true }
-dirs = { workspace = true }
+sage-config = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -27,9 +27,7 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    let path = dirs::data_dir()
-        .expect("could not get data directory")
-        .join("com.rigidnetwork.sage");
+    let path = sage_config::sage_root().expect("could not get Sage root directory");
 
     match args.command {
         Command::Rpc { command } => command.handle(path).await?,

--- a/crates/sage-cli/src/rpc.rs
+++ b/crates/sage-cli/src/rpc.rs
@@ -45,7 +45,7 @@ impl_endpoints! {
                     Ok(())
                 },
                 (repeat Self::Endpoint { body } => {
-                    let client = Client::new()?;
+                    let client = Client::from_dir(&path)?;
                     handle(client.endpoint(body).await);
                     Ok(())
                 } ,)

--- a/crates/sage-client/Cargo.toml
+++ b/crates/sage-client/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 sage-api = { workspace = true }
 sage-api-macro = { workspace = true }
 sage-config = { workspace = true }
-dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true, features = ["http2", "rustls-tls-webpki-roots", "json"] }

--- a/crates/sage-client/src/lib.rs
+++ b/crates/sage-client/src/lib.rs
@@ -23,9 +23,7 @@ pub struct Client {
 
 impl Client {
     pub fn new() -> Result<Self, SageRpcError> {
-        let path = dirs::data_dir()
-            .ok_or(SageRpcError::MissingDataDir)?
-            .join("com.rigidnetwork.sage");
+        let path = sage_config::sage_root().ok_or(SageRpcError::MissingDataDir)?;
         Self::from_dir(&path)
     }
 

--- a/crates/sage-config/Cargo.toml
+++ b/crates/sage-config/Cargo.toml
@@ -21,6 +21,7 @@ serde_with = { workspace = true, features = ["hex"] }
 indexmap = { workspace = true, features = ["serde"] }
 specta = { workspace = true, features = ["derive", "indexmap"] }
 hex = { workspace = true }
+dirs = { workspace = true }
 
 [dev-dependencies]
 expect-test = { workspace = true }

--- a/crates/sage-config/src/lib.rs
+++ b/crates/sage-config/src/lib.rs
@@ -3,9 +3,11 @@
 mod config;
 mod network;
 mod old;
+mod path;
 mod wallet;
 
 pub use config::*;
 pub use network::*;
 pub use old::*;
+pub use path::*;
 pub use wallet::*;

--- a/crates/sage-config/src/path.rs
+++ b/crates/sage-config/src/path.rs
@@ -1,0 +1,43 @@
+use std::{env, path::PathBuf};
+
+pub const SAGE_ROOT_ENV: &str = "SAGE_ROOT";
+
+const SAGE_DATA_DIRECTORY: &str = "com.rigidnetwork.sage";
+
+pub fn sage_root_override() -> Option<PathBuf> {
+    env::var_os(SAGE_ROOT_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+pub fn sage_root() -> Option<PathBuf> {
+    resolve_sage_root(sage_root_override(), dirs::data_dir())
+}
+
+fn resolve_sage_root(root: Option<PathBuf>, data_dir: Option<PathBuf>) -> Option<PathBuf> {
+    root.or_else(|| data_dir.map(|path| path.join(SAGE_DATA_DIRECTORY)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn environment_root_overrides_data_directory() {
+        let root = resolve_sage_root(
+            Some(Path::new("/custom/sage").to_path_buf()),
+            Some(Path::new("/data").to_path_buf()),
+        );
+
+        assert_eq!(root, Some(Path::new("/custom/sage").to_path_buf()));
+    }
+
+    #[test]
+    fn default_root_uses_application_identifier() {
+        let root = resolve_sage_root(None, Some(Path::new("/data").to_path_buf()));
+
+        assert_eq!(root, Some(Path::new("/data").join("com.rigidnetwork.sage")));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -276,7 +276,11 @@ pub fn run() {
         .setup(move |app| {
             builder.mount_events(app);
 
-            let path = app.path().app_data_dir()?;
+            let path = if let Some(path) = sage_config::sage_root_override() {
+                path
+            } else {
+                app.path().app_data_dir()?
+            };
             let app_state = AppState::new(Mutex::new(Sage::new(&path, false)));
 
             app.manage(Initialized(Mutex::new(false)));
@@ -304,7 +308,7 @@ pub fn run() {
                 let apps_db = tauri::async_runtime::block_on(apps::AppsDb::initialize(&path))
                     .expect("failed to initialize Sage apps database");
 
-                app.manage(AppsHostState::new(apps_db));
+                app.manage(AppsHostState::new(path.clone(), apps_db));
 
                 apps::start_background_app_update_checker(app.handle().clone());
 


### PR DESCRIPTION
## Summary
- add a shared `SAGE_ROOT` override for desktop, CLI, and RPC clients
- route wallet, app database, app storage, and Windows webview profile data through the selected root
- document multi-instance usage and the need for distinct RPC ports

## Test plan
- [x] `cargo fmt --all -- --files-with-diff --check`
- [x] `cargo clippy --workspace --all-features --all-targets`
- [x] `cargo test -p sage-config -p sage-apps -p sage-client -p sage-cli -p sage-tauri`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where wallets, TLS material, app DB, and webview storage live; misconfigured or shared roots could mix instances, though default behavior is unchanged when `SAGE_ROOT` is unset.
> 
> **Overview**
> Adds a shared **`SAGE_ROOT`** override so desktop, **`sage rpc`**, and the RPC client can use the same on-disk root instead of only the default OS data directory (`com.rigidnetwork.sage`).
> 
> **`sage-config`** centralizes resolution in `sage_root()` / `sage_root_override()`; CLI and client drop direct `dirs` usage and read config/certs from that root. The Tauri setup uses the override when set, otherwise keeps Tauri’s app data dir, and passes that path into **`Sage`** and the apps DB.
> 
> **`sage-apps`** stores the root on **`AppsHostState`** and routes bridge grants, storage rotation, Windows WebView2 profile dirs, and abandoned-profile cleanup under it (profiles live under `{root}/profiles/...`). README documents running multiple dev instances and using distinct RPC ports per root’s `config.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f7d11e71f17df635dcaf4497e69bbd766777b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->